### PR TITLE
fix: execute build before playground

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "Vue"
   ],
   "scripts": {
-    "play": "pnpm --filter @vue-vine/playground run dev",
+    "play": "nx build vue-vine && pnpm --filter @vue-vine/playground run dev",
     "dev": "nx build vue-vine && nx watch --projects=@vue-vine/vite-plugin,vue-vine -- nx run \\$NX_PROJECT_NAME:build",
     "ext:watch": "pnpm --filter vue-vine-extension run watch",
     "ext:build": "pnpm --filter vue-vine-extension run compile",


### PR DESCRIPTION
Executing play has an error：Cannot find module 'vue-vine/vite' or its corresponding type declarations.