### PR TITLE
refactor: remove duplicate options

### DIFF
--- a/packages/compiler/index.ts
+++ b/packages/compiler/index.ts
@@ -47,13 +47,7 @@ export function createVineFileCtx(
   fileId: string,
   fileCtxCache?: VineFileCtx,
 ) {
-  const root = babelParse(code, {
-    errorRecovery: true,
-    sourceType: 'module',
-    plugins: [
-      'typescript',
-    ],
-  })
+  const root = babelParse(code)
   const vineFileCtx: VineFileCtx = {
     root,
     fileId,


### PR DESCRIPTION
Re-defining the same options in [parse.ts#L5](https://github.com/sakanjo/vue-vine/blob/c874b3233bc3feca4fef91545fd9f7988a567562/packages/compiler/src/babel-helpers/parse.ts#L5).