### PR TITLE
fix(validateVine): Error detection

### DIFF
--- a/packages/compiler/src/validate.ts
+++ b/packages/compiler/src/validate.ts
@@ -766,7 +766,9 @@ export function validateVine(
   // without quiting this function too early
   let hasErrInVineCompFns = false
   for (const vineCompFnDecl of vineCompFnDecls) {
-    hasErrInVineCompFns = findValidateError(validatesFromVineFn, vineCompFnDecl)
+    const hasErr = findValidateError(validatesFromVineFn, vineCompFnDecl)
+    if (hasErr)
+      hasErrInVineCompFns = hasErr
   }
 
   return !hasErrInVineCompFns


### PR DESCRIPTION
In the loop of validating all the Vine component functions, if the first one has errors but the following one doesn't, the final validating result is incorrect.