### PR TITLE
feat(compiler): implement vineModel

### DIFF
--- a/packages/compiler/src/babel-helpers/ast.ts
+++ b/packages/compiler/src/babel-helpers/ast.ts
@@ -179,6 +179,13 @@ export function isVineMacroOf(
   }
 }
 
+export const isVineProp = isVineMacroOf('vineProp')
+export const isVineSlots = isVineMacroOf('vineSlots')
+export const isVineEmits = isVineMacroOf('vineEmits')
+export const isVineModel = isVineMacroOf('vineModel')
+export const isVineStyle = isVineMacroOf('vineStyle')
+export const isVineCustomElement = isVineMacroOf('vineCustomElement')
+
 export function isStatementContainsVineMacroCall(node: Node) {
   let result = false
   traverse(node, (descendant) => {

--- a/packages/compiler/src/constants.ts
+++ b/packages/compiler/src/constants.ts
@@ -3,9 +3,15 @@ import type { BindingTypes as VueBindingTypes } from '@vue/compiler-dom'
 export const DEFINE_COMPONENT_HELPER = 'defineComponent'
 export const USE_DEFAULTS_HELPER = 'useDefaults'
 export const TO_REFS_HELPER = 'toRefs'
+export const USE_MODEL_HELPER = 'useModel'
 export const CSS_VARS_HELPER = 'useCssVars'
 export const USE_SLOT_HELPER = 'useSlots'
 export const UN_REF_HELPER = 'unref'
+export const DEFAULT_MODEL_NAME = 'modelValue'
+export const DEFAULT_MODEL_MODIFIERS_NAME = 'modelModifiers'
+/**
+ * These macros can't be inside other expressions but just called directly.
+ */
 export const BARE_CALL_MACROS = [
   'vineExpose',
   'vineOptions',
@@ -19,6 +25,7 @@ export const VINE_MACROS = [
   'vineProp.withDefault',
   'vineEmits',
   'vineSlots',
+  'vineModel',
   ...BARE_CALL_MACROS,
 ] as const
 export const VINE_TAG_TEMPLATE_CALLER = [
@@ -30,6 +37,9 @@ export const VINE_TAG_TEMPLATE_CALLER = [
   'stylus',
   'postcss',
 ] as const
+export const CAN_BE_CALLED_MULTI_TIMES_MACROS = [
+  'vineModel',
+]
 export const SUPPORTED_CSS_LANGS = ['css', 'scss', 'sass', 'less', 'stylus', 'postcss'] as const
 export const VUE_REACTIVITY_APIS = [
   'ref',

--- a/packages/compiler/src/template/compose.ts
+++ b/packages/compiler/src/template/compose.ts
@@ -280,6 +280,7 @@ export function createSeparatedTemplateComposer(
           allBindings[key] = true
         }
       }
+
       let setupFnReturns = '{ '
       for (const key in allBindings) {
         if (

--- a/packages/compiler/src/transform.ts
+++ b/packages/compiler/src/transform.ts
@@ -15,12 +15,13 @@ import {
   TO_REFS_HELPER,
   UN_REF_HELPER,
   USE_DEFAULTS_HELPER,
+  USE_MODEL_HELPER,
   USE_SLOT_HELPER,
 } from './constants'
 import { sortStyleImport } from './style/order'
 import type { MergedImportsMap, NamedImportSpecifierMeta } from './template/compose'
 import { createInlineTemplateComposer, createSeparatedTemplateComposer } from './template/compose'
-import type { VineCompilerHooks, VineFileCtx } from './types'
+import type { VineCompFnCtx, VineCompilerHooks, VineFileCtx } from './types'
 import { filterJoin, showIf } from './utils'
 import { isStatementContainsVineMacroCall } from './babel-helpers/ast'
 import { compileCSSVars } from './style/transform-css-var'
@@ -87,6 +88,77 @@ function registerImport(
   }
 }
 
+function setupCodeGenerationForVineModel(
+  vineFnCompCtx: VineCompFnCtx,
+): string {
+  let modelCodeGen: string[] = []
+
+  for (const [modelName, modelDef] of Object.entries(vineFnCompCtx.vineModels)) {
+    const { varName } = modelDef
+    modelCodeGen.push(
+      `const ${varName} = _${USE_MODEL_HELPER}(__props, '${modelName}')`,
+    )
+  }
+
+  return `\n${modelCodeGen.join('\n')}\n`
+}
+
+function propsOptionsCodeGeneration(
+  vineFileCtx: VineFileCtx,
+  vineCompFnCtx: VineCompFnCtx,
+) {
+  const segementsFromProps = Object.entries(vineCompFnCtx.props).map(([propName, propMeta]) => {
+    const metaFields = []
+    if (propMeta.isRequired) {
+      metaFields.push('required: true')
+    }
+    if (propMeta.isBool) {
+      metaFields.push('type: Boolean')
+    }
+    if (propMeta.validator) {
+      metaFields.push(`validator: ${
+        vineFileCtx.originCode.slice(
+          propMeta.validator.start!,
+          propMeta.validator.end!,
+        )
+      }`)
+    }
+    return `${propName}: { ${
+      showIf(
+        metaFields.filter(Boolean).length > 0,
+        filterJoin(metaFields, ', '),
+        '/* Simple prop */',
+      )
+    } },`
+  })
+
+  const segementsFromVineModel = Object
+    .entries(vineCompFnCtx.vineModels)
+    .reduce<string[]>((segments, [modelName, modelDef]) => {
+      const { modelModifiersName, modelOptions } = modelDef
+      segments.push(
+        `${modelName}: ${
+          modelOptions
+            ? vineFileCtx.originCode.slice(
+                modelOptions.start!,
+                modelOptions.end!,
+              )
+            : '{}'
+        },`,
+      )
+      segments.push(
+        `${modelModifiersName}: {},`,
+      )
+
+      return segments
+    }, [])
+
+  return [
+    ...segementsFromProps,
+    ...segementsFromVineModel,
+  ]
+}
+
 /**
  * Processing `.vine.ts` file transforming.
  *
@@ -107,10 +179,15 @@ export function transformFile(
 ) {
   const isDev = compilerHooks.getCompilerCtx().options.mode !== 'production'
   const ms = vineFileCtx.fileMagicCode
+
   // Traverse file context's `styleDefine`, and generate import statements.
   // Ordered by their import releationship.
   const styleImportStmts = sortStyleImport(vineFileCtx)
   const mergedImportsMap: MergedImportsMap = new Map()
+
+  // Flag that is used for noticing prepend `useDefaults` helper function.
+  let isPrependedUseDefaults = false
+
   const {
     templateCompileResults,
     generatedPreambleStmts,
@@ -119,7 +196,7 @@ export function transformFile(
     ? createInlineTemplateComposer(compilerHooks)
     : createSeparatedTemplateComposer(compilerHooks)
 
-  let isPrependedUseDefaults = false
+  // Traverse all component functions and transform them into IIFE
   for (const vineCompFnCtx of vineFileCtx.vineCompFns) {
     const setupFnReturns = compileSetupFnReturns({
       vineFileCtx,
@@ -128,7 +205,9 @@ export function transformFile(
       mergedImportsMap,
       bindingMetadata: vineCompFnCtx.bindings,
     })
-    const isNeedUseDefaults = Object.values(vineCompFnCtx.props).some(meta => Boolean(meta.default))
+    const isNeedUseDefaults = Object
+      .values(vineCompFnCtx.props)
+      .some(meta => Boolean(meta.default))
 
     // Add `defineComponent` helper function import specifier
     let vueImportsMeta = mergedImportsMap.get('vue')
@@ -223,7 +302,48 @@ export function transformFile(
           } }`
           : ' /* No setup ctx destructuring */'
       }`
-      if (Object.values(vineCompFnCtx.props).some(meta => Boolean(meta.isFromMacroDefine))) {
+
+      // Code generation for vineSlots
+      if (Object.entries(vineCompFnCtx.slots).length > 0) {
+        ms.prependLeft(
+          firstStmt.start!,
+          `const ${vineCompFnCtx.slotsAlias} = _${USE_SLOT_HELPER}();\n`,
+        )
+      }
+
+      // Code generation for vineModel
+      if (Object.entries(vineCompFnCtx.vineModels).length > 0) {
+        registerImport(
+          mergedImportsMap,
+          'vue',
+          USE_MODEL_HELPER,
+          `_${USE_MODEL_HELPER}`,
+        )
+        ms.prependLeft(
+          firstStmt.start!,
+          setupCodeGenerationForVineModel(vineCompFnCtx),
+        )
+      }
+
+      // Insert `useCssVars` helper function call
+      if (
+        Array.from(
+          Object.entries(vineCompFnCtx.cssBindings),
+        ).length > 0
+      ) {
+        ms.prependLeft(
+          firstStmt.start!,
+          `\n${compileCSSVars(vineCompFnCtx, inline)}\n`,
+        )
+      }
+
+      // If there's any prop that is from macro define,
+      // we need to import `toRefs`
+      if (
+        Object
+          .values(vineCompFnCtx.props)
+          .some(meta => Boolean(meta.isFromMacroDefine))
+      ) {
         registerImport(
           mergedImportsMap,
           'vue',
@@ -236,24 +356,6 @@ export function transformFile(
         ms.prependLeft(
           firstStmt.start!,
           `const { ${propsFromMacro.join(', ')} } = _toRefs(${vineCompFnCtx.propsAlias});\n`,
-        )
-      }
-
-      // vineSlots
-      if (Object.entries(vineCompFnCtx.slots).length > 0) {
-        ms.prependLeft(
-          firstStmt.start!,
-          `const ${vineCompFnCtx.slotsAlias} = _${USE_SLOT_HELPER}();\n`,
-        )
-      }
-
-      // Insert `useCssVars` helper function call
-      if (Array.from(
-        Object.entries(vineCompFnCtx.cssBindings),
-      ).length > 0) {
-        ms.prependLeft(
-          firstStmt.start!,
-          `\n${compileCSSVars(vineCompFnCtx, inline)}\n`,
         )
       }
 
@@ -315,7 +417,18 @@ export function transformFile(
 
       ms.prependLeft(firstStmt.start!, `setup(${setupFormalParams}) {\n`)
       ms.appendRight(lastStmt.end!, '\n}')
+
+      const emitsKeys = [
+        ...vineCompFnCtx.emits.map(emit => `'${emit}'`),
+        ...Object.keys(vineCompFnCtx.vineModels).map(modelName => `'update:${modelName}'`),
+      ]
+      const propsOptionFields = propsOptionsCodeGeneration(
+        vineFileCtx,
+        vineCompFnCtx,
+      )
+
       ms.prependLeft(firstStmt.start!, `const __vine = _defineComponent({\n${
+        // Some basic component options
         vineCompFnCtx.options
           ? `...${ms.original.slice(
             vineCompFnCtx.options.start!,
@@ -323,40 +436,23 @@ export function transformFile(
           )},`
           : `name: '${vineCompFnCtx.fnName}',`
       }\n${
-        Object.keys(vineCompFnCtx.props).length > 0
+        propsOptionFields.length > 0
           ? `props: {\n${
-            Object.entries(vineCompFnCtx.props).map(([propName, propMeta]) => {
-              const metaFields = []
-              if (propMeta.isRequired) {
-                metaFields.push('required: true')
-              }
-              if (propMeta.isBool) {
-                metaFields.push('type: Boolean')
-              }
-              if (propMeta.validator) {
-                metaFields.push(`validator: ${
-                  ms.original.slice(
-                    propMeta.validator.start!,
-                    propMeta.validator.end!,
-                  )
-                }`)
-              }
-              return `${propName}: { ${
-                showIf(
-                  metaFields.filter(Boolean).length > 0,
-                  filterJoin(metaFields, ', '),
-                  '/* Simple prop */',
-                )
-              } },`
-            }).join('\n')
+            propsOptionsCodeGeneration(
+              vineFileCtx,
+              vineCompFnCtx,
+            ).join('\n')
           }\n},`
           : '/* No props */'
       }\n${
-        vineCompFnCtx.emits.length > 0
-          ? `emits: [${vineCompFnCtx.emits.map(emit => `'${emit}'`).join(', ')}],`
+        emitsKeys.length > 0
+          ? `emits: [${
+            emitsKeys.join(', ')
+          }],`
           : '/* No emits */'
       }\n`)
       ms.appendRight(lastStmt.end!, '\n})')
+
       // Defaultly set `export` for all component functions
       // because it's required by HMR context.
       ms.prependLeft(firstStmt.start!, `\nexport const ${
@@ -367,6 +463,7 @@ export function transformFile(
           .get(vineCompFnCtx)
           ?.join('\n') ?? ''
       }\n`)
+
       ms.appendRight(lastStmt.end!, `\n${
         inline
           ? ''
@@ -375,8 +472,8 @@ export function transformFile(
           : `${
             templateCompileResults.get(vineCompFnCtx) ?? ''
           }\n__vine.render = __sfc_render`
-      }\n${
-        showIf(
+        }\n${
+          showIf(
           Boolean(vineFileCtx.styleDefine[vineCompFnCtx.scopeId]),
           `__vine.__scopeId = 'data-v-${vineCompFnCtx.scopeId}';\n${
             isDev ? `__vine.__hmrId = '${vineCompFnCtx.scopeId}';` : ''
@@ -386,6 +483,7 @@ export function transformFile(
           Boolean(vineCompFnCtx.isCustomElement),
           `__vine.styles = [__${vineCompFnCtx.fnName.toLowerCase()}_styles];\n`,
         )}\nreturn __vine\n})();`)
+
       // Record component function to HMR
       if (isDev) {
         ms.appendRight(
@@ -396,7 +494,7 @@ export function transformFile(
     }
   }
 
-  // HMR
+  // HMR helper code
   if (isDev) {
     ms.appendRight(
       ms.length(),

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -30,6 +30,7 @@ export type CountingMacros = Exclude<
   | 'vineStyle.scoped'
   | 'vineProp.optional'
   | 'vineProp.withDefault'
+  | 'vineModel'
 >
 export type VineStyleValidArg = StringLiteral | TemplateLiteral | TaggedTemplateExpression
 
@@ -153,6 +154,12 @@ export interface VineCompFnCtx {
   /** Store every slot's props definition */
   slots: Record<string, {
     props: TSTypeLiteral
+  }>
+  /** Store `vineModel` defines */
+  vineModels: Record<string, {
+    varName: string
+    modelModifiersName: string
+    modelOptions: Node | null
   }>
   slotsAlias: string
   hoistSetupStmts: Node[]

--- a/packages/compiler/tests/__snapshots__/transform.spec.ts.snap
+++ b/packages/compiler/tests/__snapshots__/transform.spec.ts.snap
@@ -16,6 +16,7 @@ import {
   useCssVars as _useCssVars,
   unref as _unref,
   useSlots as _useSlots,
+  useModel as _useModel,
   toRefs as _toRefs,
   createVNode as _createVNode,
 } from "vue";
@@ -48,18 +49,28 @@ export const MyProfile = (() => {
       bio: {
         /* Simple prop */
       },
+      modelValue: { default: "test" },
+      modelModifiers: {},
+      title: { default: "" },
+      titleModifiers: {},
+      count: {},
+      countModifiers: {},
     },
-    /* No emits */
+    emits: ["update:modelValue", "update:title", "update:count"],
     setup(__props, { expose: __expose }) {
       const props = _useDefaults(__props, {
         age: 18,
       });
+      const { name, age, bio } = _toRefs(props);
 
       _useCssVars((_ctx) => ({
         "601ae0ef": textColor.value,
       }));
+
+      const defaultModelWithValue = _useModel(__props, "modelValue");
+      const title = _useModel(__props, "title");
+      const count = _useModel(__props, "count");
       const mySlots = _useSlots();
-      const { name, age, bio } = _toRefs(props);
 
       const textColor = ref("#1c1c1c");
       const handleRefresh = () => {
@@ -193,6 +204,7 @@ import {
   useCssVars as _useCssVars,
   unref as _unref,
   useSlots as _useSlots,
+  useModel as _useModel,
   toRefs as _toRefs,
   createVNode as _createVNode,
 } from "vue";
@@ -225,18 +237,28 @@ export const MyProfile = (() => {
       bio: {
         /* Simple prop */
       },
+      modelValue: { default: "test" },
+      modelModifiers: {},
+      title: { default: "" },
+      titleModifiers: {},
+      count: {},
+      countModifiers: {},
     },
-    /* No emits */
+    emits: ["update:modelValue", "update:title", "update:count"],
     setup(__props, { expose: __expose }) {
       const props = _useDefaults(__props, {
         age: 18,
       });
+      const { name, age, bio } = _toRefs(props);
 
       _useCssVars((_ctx) => ({
         "601ae0ef": textColor.value,
       }));
+
+      const defaultModelWithValue = _useModel(__props, "modelValue");
+      const title = _useModel(__props, "title");
+      const count = _useModel(__props, "count");
       const mySlots = _useSlots();
-      const { name, age, bio } = _toRefs(props);
 
       const textColor = ref("#1c1c1c");
       const handleRefresh = () => {
@@ -344,6 +366,7 @@ import {
   defineComponent as _defineComponent,
   useCssVars as _useCssVars,
   useSlots as _useSlots,
+  useModel as _useModel,
   toRefs as _toRefs,
   createVNode as _createVNode,
 } from "vue";
@@ -376,18 +399,28 @@ export const MyProfile = (() => {
       bio: {
         /* Simple prop */
       },
+      modelValue: { default: "test" },
+      modelModifiers: {},
+      title: { default: "" },
+      titleModifiers: {},
+      count: {},
+      countModifiers: {},
     },
-    /* No emits */
+    emits: ["update:modelValue", "update:title", "update:count"],
     setup(__props, { expose: __expose }) {
       const props = _useDefaults(__props, {
         age: 18,
       });
+      const { name, age, bio } = _toRefs(props);
 
       _useCssVars((_ctx) => ({
         "601ae0ef": _ctx.textColor,
       }));
+
+      const defaultModelWithValue = _useModel(__props, "modelValue");
+      const title = _useModel(__props, "title");
+      const count = _useModel(__props, "count");
       const mySlots = _useSlots();
-      const { name, age, bio } = _toRefs(props);
 
       const textColor = ref("#1c1c1c");
       const handleRefresh = () => {
@@ -403,6 +436,9 @@ export const MyProfile = (() => {
         name,
         age,
         bio,
+        defaultModelWithValue,
+        title,
+        count,
         textColor,
         handleRefresh,
         ref,

--- a/packages/compiler/tests/transform.spec.ts
+++ b/packages/compiler/tests/transform.spec.ts
@@ -30,6 +30,10 @@ function MyProfile() {
     default(props: { msg: string }): any
   }>()
 
+  const defaultModelWithValue = vineModel({ default: 'test' })
+  const title = vineModel('title', { default: '' })
+  const count = vineModel<number>('count')
+
   vineExpose({
     age,
     bio,

--- a/packages/compiler/tests/validate.spec.ts
+++ b/packages/compiler/tests/validate.spec.ts
@@ -105,6 +105,11 @@ function Box() {
     footer: Boolean;
   }>()
 
+  vineModel()
+  const { val } = vineModel<string, Object>(SomeString, SomeOptions)
+  const m1 = vineModel()
+  const m2 = vineModel({ default: 1 })
+
   return vine\`
     <div class="box">Test Box</div>
   \`
@@ -133,18 +138,36 @@ function App() {
 `
     const { mockCompilerCtx, mockCompilerHooks } = createMockTransformCtx()
     compileVineTypeScriptFile(content, 'testVineMacrosUsage', mockCompilerHooks)
-    expect(mockCompilerCtx.vineCompileErrors.length).toMatchInlineSnapshot('11')
-    expect(mockCompilerCtx.vineCompileErrors[0].msg).toMatchInlineSnapshot('"vineStyle CSS language only supports: `css`, `scss`, `sass`, `less`, `stylus` and `postcss`"')
-    expect(mockCompilerCtx.vineCompileErrors[1].msg).toMatchInlineSnapshot('"Every property of Vue Vine component function\'s `vineSlots` type must be function signature"')
-    expect(mockCompilerCtx.vineCompileErrors[2].msg).toMatchInlineSnapshot('"Function signature of `vineSlots` can only have one parameter named `props`, and its type annotation must be object literal"')
-    expect(mockCompilerCtx.vineCompileErrors[3].msg).toMatchInlineSnapshot('"Function signature of `vineSlots` definition can only have one parameter named `props`, and its parameter name must be `props`, but got `yyy`"')
-    expect(mockCompilerCtx.vineCompileErrors[4].msg).toMatchInlineSnapshot('"Properties of `vineSlots` can only have function type annotation"')
-    expect(mockCompilerCtx.vineCompileErrors[5].msg).toMatchInlineSnapshot('"`vineCustomElement` macro call is not allowed to be inside a variable declaration"')
-    expect(mockCompilerCtx.vineCompileErrors[6].msg).toMatchInlineSnapshot('"`vineStyle` can only have one string argument\'"')
-    expect(mockCompilerCtx.vineCompileErrors[7].msg).toMatchInlineSnapshot('"`vineEmits` must have 1 type parameter"')
-    expect(mockCompilerCtx.vineCompileErrors[8].msg).toMatchInlineSnapshot('"`vineSlots` can only have 1 type parameter"')
-    expect(mockCompilerCtx.vineCompileErrors[9].msg).toMatchInlineSnapshot('"`vineExpose` must have one object literal argument"')
-    expect(mockCompilerCtx.vineCompileErrors[10].msg).toMatchInlineSnapshot('"`vineOptions` must have one object literal argument"')
+    expect(mockCompilerCtx.vineCompileErrors.length).toMatchInlineSnapshot(`14`)
+
+    expect(mockCompilerCtx.vineCompileErrors[0].msg)
+      .toMatchInlineSnapshot('"vineStyle CSS language only supports: `css`, `scss`, `sass`, `less`, `stylus` and `postcss`"')
+    expect(mockCompilerCtx.vineCompileErrors[1].msg)
+      .toMatchInlineSnapshot('"Every property of Vue Vine component function\'s `vineSlots` type must be function signature"')
+    expect(mockCompilerCtx.vineCompileErrors[2]?.msg)
+      .toMatchInlineSnapshot('"Function signature of `vineSlots` can only have one parameter named `props`, and its type annotation must be object literal"')
+    expect(mockCompilerCtx.vineCompileErrors[3]?.msg)
+      .toMatchInlineSnapshot('"Function signature of `vineSlots` definition can only have one parameter named `props`, and its parameter name must be `props`, but got `yyy`"')
+    expect(mockCompilerCtx.vineCompileErrors[4]?.msg)
+      .toMatchInlineSnapshot('"Properties of `vineSlots` can only have function type annotation"')
+    expect(mockCompilerCtx.vineCompileErrors[5]?.msg)
+      .toMatchInlineSnapshot(`"the declaration of \`vineModel\` macro call must be inside a variable declaration"`)
+    expect(mockCompilerCtx.vineCompileErrors[6]?.msg)
+      .toMatchInlineSnapshot(`"the declaration of macro \`vineModel\` call must be an identifier"`)
+    expect(mockCompilerCtx.vineCompileErrors[7]?.msg)
+      .toMatchInlineSnapshot(`"Vue Vine component function can only have one default model"`)
+    expect(mockCompilerCtx.vineCompileErrors[8]?.msg)
+      .toMatchInlineSnapshot(`"\`vineCustomElement\` macro call is not allowed to be inside a variable declaration"`)
+    expect(mockCompilerCtx.vineCompileErrors[9]?.msg)
+      .toMatchInlineSnapshot(`"\`vineStyle\` can only have one string argument'"`)
+    expect(mockCompilerCtx.vineCompileErrors[10]?.msg)
+      .toMatchInlineSnapshot(`"\`vineEmits\` must have 1 type parameter"`)
+    expect(mockCompilerCtx.vineCompileErrors[11]?.msg)
+      .toMatchInlineSnapshot(`"\`vineSlots\` can only have 1 type parameter"`)
+    expect(mockCompilerCtx.vineCompileErrors[12]?.msg)
+      .toMatchInlineSnapshot(`"\`vineExpose\` must have one object literal argument"`)
+    expect(mockCompilerCtx.vineCompileErrors[13]?.msg)
+      .toMatchInlineSnapshot(`"\`vineOptions\` must have one object literal argument"`)
   })
 
   it('validate vineStyle can not be inside a lexical declaration', () => {
@@ -236,7 +259,7 @@ function TestComp() {
     expect(mockCompilerCtx.vineCompileErrors[0].msg)
       .toMatchInlineSnapshot('"`vineEmits` must have 1 type parameter"')
     expect(mockCompilerCtx.vineCompileErrors[1].msg)
-      .toMatchInlineSnapshot('"the declaration of macro call must be an identifier"')
+      .toMatchInlineSnapshot(`"the declaration of macro \`vineEmits\` call must be an identifier"`)
   })
 
   it('validate template invalid top level tags', () => {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@vueuse/core": "^9.13.0",
     "sass": "^1.66.1",
-    "vue": "^3.3.4",
+    "vue": "^3.4.21",
     "vue-router": "^4.2.4"
   },
   "devDependencies": {

--- a/packages/playground/src/vine/app.vine.ts
+++ b/packages/playground/src/vine/app.vine.ts
@@ -58,6 +58,7 @@ export function App() {
   const randomState = () => {
     id.value = String(Math.floor(Math.random() * 100) + 1)
   }
+  const userInputText = vineModel<string>()
 
   console.log('%c VINE %c Click the link to explore source code ->', 'background: green;', '')
 
@@ -84,6 +85,14 @@ export function App() {
       <button class="random-state-change-btn" @click="randomState">
         Click to change random string
       </button>
+    </div>
+    <div class="flex flex-col items-center justify-center my-4">
+      <p class="my-4">{{ userInputText || 'Please input something here...' }}</p>
+      <input
+        type="text"
+        class="bg-blueGray-200 border-none outline-none p-2 rounded w-300px"
+        v-model="userInputText"
+      />
     </div>
   `
 }

--- a/packages/vue-vine/types/macros.d.ts
+++ b/packages/vue-vine/types/macros.d.ts
@@ -38,6 +38,20 @@ declare global {
   const vineSlots: <D extends Record<string, (props: any) => any>>() => D
   const vineExpose: (exposed: Record<string, any>) => void
   const vineOptions: (options: VineOptionsDef) => void
+
+  function vineModel<T>(): Ref<T>
+  function vineModel<T>(modelOptions: {
+    default?: T
+    required?: boolean
+  }): Ref<T>
+  function vineModel<T>(
+    modelName: string,
+    modelOptions?: {
+      default?: T
+      required?: boolean
+    }
+  ): Ref<T>
+
   const vineStyle: VineStyleMacro
 
   const vine: (template: TemplateStringsArray) => VueVineComponent

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,16 +275,16 @@ importers:
     dependencies:
       '@vueuse/core':
         specifier: ^9.13.0
-        version: 9.13.0(vue@3.3.4)
+        version: 9.13.0(vue@3.4.21)
       sass:
         specifier: ^1.66.1
         version: 1.66.1
       vue:
-        specifier: ^3.3.4
-        version: 3.3.4
+        specifier: ^3.4.21
+        version: 3.4.21(typescript@5.2.2)
       vue-router:
         specifier: ^4.2.4
-        version: 4.2.4(vue@3.3.4)
+        version: 4.2.4(vue@3.4.21)
     devDependencies:
       '@iconify-json/carbon':
         specifier: ^1.1.20
@@ -362,7 +362,7 @@ importers:
         version: link:../vite-plugin
       '@vueuse/core':
         specifier: ^10.4.1
-        version: 10.4.1(vue@3.3.4)
+        version: 10.4.1(vue@3.4.21)
 
 packages:
 
@@ -2851,11 +2851,30 @@ packages:
       postcss: 8.4.35
       source-map-js: 1.0.2
 
+  /@vue/compiler-sfc@3.4.21:
+    resolution: {integrity: sha512-me7epoTxYlY+2CUM7hy9PCDdpMPfIwrOvAXud2Upk10g4YLv9UBW7kL798TvMeDhPthkZ0CONNrK2GoeI1ODiQ==}
+    dependencies:
+      '@babel/parser': 7.24.0
+      '@vue/compiler-core': 3.4.21
+      '@vue/compiler-dom': 3.4.21
+      '@vue/compiler-ssr': 3.4.21
+      '@vue/shared': 3.4.21
+      estree-walker: 2.0.2
+      magic-string: 0.30.8
+      postcss: 8.4.35
+      source-map-js: 1.0.2
+
   /@vue/compiler-ssr@3.3.4:
     resolution: {integrity: sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==}
     dependencies:
       '@vue/compiler-dom': 3.3.4
       '@vue/shared': 3.3.4
+
+  /@vue/compiler-ssr@3.4.21:
+    resolution: {integrity: sha512-M5+9nI2lPpAsgXOGQobnIueVqc9sisBFexh5yMIMRAPYLa7+5wEJs8iqOZc1WAa9WQbx9GR2twgznU8LTIiZ4Q==}
+    dependencies:
+      '@vue/compiler-dom': 3.4.21
+      '@vue/shared': 3.4.21
 
   /@vue/devtools-api@6.5.0:
     resolution: {integrity: sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q==}
@@ -2936,11 +2955,22 @@ packages:
     dependencies:
       '@vue/shared': 3.3.4
 
+  /@vue/reactivity@3.4.21:
+    resolution: {integrity: sha512-UhenImdc0L0/4ahGCyEzc/pZNwVgcglGy9HVzJ1Bq2Mm9qXOpP8RyNTjookw/gOCUlXSEtuZ2fUg5nrHcoqJcw==}
+    dependencies:
+      '@vue/shared': 3.4.21
+
   /@vue/runtime-core@3.3.4:
     resolution: {integrity: sha512-R+bqxMN6pWO7zGI4OMlmvePOdP2c93GsHFM/siJI7O2nxFRzj55pLwkpCedEY+bTMgp5miZ8CxfIZo3S+gFqvA==}
     dependencies:
       '@vue/reactivity': 3.3.4
       '@vue/shared': 3.3.4
+
+  /@vue/runtime-core@3.4.21:
+    resolution: {integrity: sha512-pQthsuYzE1XcGZznTKn73G0s14eCJcjaLvp3/DKeYWoFacD9glJoqlNBxt3W2c5S40t6CCcpPf+jG01N3ULyrA==}
+    dependencies:
+      '@vue/reactivity': 3.4.21
+      '@vue/shared': 3.4.21
 
   /@vue/runtime-dom@3.3.4:
     resolution: {integrity: sha512-Aj5bTJ3u5sFsUckRghsNjVTtxZQ1OyMWCr5dZRAPijF/0Vy4xEoRCwLyHXcj4D0UFbJ4lbx3gPTgg06K/GnPnQ==}
@@ -2948,6 +2978,13 @@ packages:
       '@vue/runtime-core': 3.3.4
       '@vue/shared': 3.3.4
       csstype: 3.1.2
+
+  /@vue/runtime-dom@3.4.21:
+    resolution: {integrity: sha512-gvf+C9cFpevsQxbkRBS1NpU8CqxKw0ebqMvLwcGQrNpx6gqRDodqKqA+A2VZZpQ9RpK2f9yfg8VbW/EpdFUOJw==}
+    dependencies:
+      '@vue/runtime-core': 3.4.21
+      '@vue/shared': 3.4.21
+      csstype: 3.1.3
 
   /@vue/server-renderer@3.3.4(vue@3.3.4):
     resolution: {integrity: sha512-Q6jDDzR23ViIb67v+vM1Dqntu+HUexQcsWKhhQa4ARVzxOY2HbC7QRW/ggkDBd5BU+uM1sV6XOAP0b216o34JQ==}
@@ -2957,6 +2994,15 @@ packages:
       '@vue/compiler-ssr': 3.3.4
       '@vue/shared': 3.3.4
       vue: 3.3.4
+
+  /@vue/server-renderer@3.4.21(vue@3.4.21):
+    resolution: {integrity: sha512-aV1gXyKSN6Rz+6kZ6kr5+Ll14YzmIbeuWe7ryJl5muJ4uwSwY/aStXTixx76TwkZFJLm1aAlA/HSWEJ4EyiMkg==}
+    peerDependencies:
+      vue: 3.4.21
+    dependencies:
+      '@vue/compiler-ssr': 3.4.21
+      '@vue/shared': 3.4.21
+      vue: 3.4.21(typescript@5.2.2)
 
   /@vue/shared@3.3.4:
     resolution: {integrity: sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==}
@@ -3001,14 +3047,27 @@ packages:
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
+    dev: true
 
-  /@vueuse/core@9.13.0(vue@3.3.4):
+  /@vueuse/core@10.4.1(vue@3.4.21):
+    resolution: {integrity: sha512-DkHIfMIoSIBjMgRRvdIvxsyboRZQmImofLyOHADqiVbQVilP8VVHDhBX2ZqoItOgu7dWa8oXiNnScOdPLhdEXg==}
+    dependencies:
+      '@types/web-bluetooth': 0.0.17
+      '@vueuse/metadata': 10.4.1
+      '@vueuse/shared': 10.4.1(vue@3.4.21)
+      vue-demi: 0.14.5(vue@3.4.21)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+    dev: false
+
+  /@vueuse/core@9.13.0(vue@3.4.21):
     resolution: {integrity: sha512-pujnclbeHWxxPRqXWmdkKV5OX4Wk4YeK7wusHqRwU0Q7EFusHoqNA/aPhB6KCh9hEqJkLAJo7bb0Lh9b+OIVzw==}
     dependencies:
       '@types/web-bluetooth': 0.0.16
       '@vueuse/metadata': 9.13.0
-      '@vueuse/shared': 9.13.0(vue@3.3.4)
-      vue-demi: 0.14.5(vue@3.3.4)
+      '@vueuse/shared': 9.13.0(vue@3.4.21)
+      vue-demi: 0.14.5(vue@3.4.21)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -3076,11 +3135,21 @@ packages:
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
+    dev: true
 
-  /@vueuse/shared@9.13.0(vue@3.3.4):
+  /@vueuse/shared@10.4.1(vue@3.4.21):
+    resolution: {integrity: sha512-vz5hbAM4qA0lDKmcr2y3pPdU+2EVw/yzfRsBdu+6+USGa4PxqSQRYIUC9/NcT06y+ZgaTsyURw2I9qOFaaXHAg==}
+    dependencies:
+      vue-demi: 0.14.5(vue@3.4.21)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+    dev: false
+
+  /@vueuse/shared@9.13.0(vue@3.4.21):
     resolution: {integrity: sha512-UrnhU+Cnufu4S6JLCPZnkWh0WwZGUp72ktOF2DFptMlOs3TOdVv8xJN53zhHGARmVOsz5KqOls09+J1NR6sBKw==}
     dependencies:
-      vue-demi: 0.14.5(vue@3.3.4)
+      vue-demi: 0.14.5(vue@3.4.21)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -3833,6 +3902,9 @@ packages:
 
   /csstype@3.1.2:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
+
+  /csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   /csv-generate@3.4.3:
     resolution: {integrity: sha512-w/T+rqR0vwvHqWs/1ZyMDWtHHSJaN06klRqJXBEpDJaM/+dZkso0OKh1VcuuYvK3XM53KysVNq8Ko/epCK8wOw==}
@@ -8316,7 +8388,7 @@ packages:
     dependencies:
       '@antfu/utils': 0.7.5
       '@rollup/pluginutils': 5.0.4
-      '@vueuse/core': 9.13.0(vue@3.3.4)
+      '@vueuse/core': 9.13.0(vue@3.4.21)
       fast-glob: 3.3.1
       local-pkg: 0.4.3
       magic-string: 0.30.3
@@ -8996,6 +9068,21 @@ packages:
         optional: true
     dependencies:
       vue: 3.3.4
+    dev: true
+
+  /vue-demi@0.14.5(vue@3.4.21):
+    resolution: {integrity: sha512-o9NUVpl/YlsGJ7t+xuqJKx8EBGf1quRhCiT6D/J0pfwmk9zUwYkC7yrF4SZCe6fETvSM3UNL2edcbYrSyc4QHA==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+    dependencies:
+      vue: 3.4.21(typescript@5.2.2)
 
   /vue-eslint-parser@9.4.2(eslint@8.57.0):
     resolution: {integrity: sha512-Ry9oiGmCAK91HrKMtCrKFWmSFWvYkpGglCeFAIqDdr9zdXmMMpJOmUJS7WWsW7fX81h6mwHmUZCQQ1E0PkSwYQ==}
@@ -9015,13 +9102,13 @@ packages:
       - supports-color
     dev: true
 
-  /vue-router@4.2.4(vue@3.3.4):
+  /vue-router@4.2.4(vue@3.4.21):
     resolution: {integrity: sha512-9PISkmaCO02OzPVOMq2w82ilty6+xJmQrarYZDkjZBfl4RvYAlt4PKnEX21oW4KTtWfa9OuO/b3qk1Od3AEdCQ==}
     peerDependencies:
       vue: ^3.2.0
     dependencies:
       '@vue/devtools-api': 6.5.0
-      vue: 3.3.4
+      vue: 3.4.21(typescript@5.2.2)
     dev: false
 
   /vue-template-compiler@2.7.14:
@@ -9050,6 +9137,21 @@ packages:
       '@vue/runtime-dom': 3.3.4
       '@vue/server-renderer': 3.3.4(vue@3.3.4)
       '@vue/shared': 3.3.4
+
+  /vue@3.4.21(typescript@5.2.2):
+    resolution: {integrity: sha512-5hjyV/jLEIKD/jYl4cavMcnzKwjMKohureP8ejn3hhEjwhWIhWeuzL2kJAjzl/WyVsgPY56Sy4Z40C3lVshxXA==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@vue/compiler-dom': 3.4.21
+      '@vue/compiler-sfc': 3.4.21
+      '@vue/runtime-dom': 3.4.21
+      '@vue/server-renderer': 3.4.21(vue@3.4.21)
+      '@vue/shared': 3.4.21
+      typescript: 5.2.2
 
   /w3c-xmlserializer@4.0.0:
     resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}


### PR DESCRIPTION
Same usage as Vue.js official `defineModel`.

https://vuejs.org/api/sfc-script-setup.html#definemodel

### Todo in plan (may not done by this PR)

- [ ] E2E test for `vineModel`
- [ ] More clean code splitting for transforming process