### PR TITLE
chore: speed up build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "play": "pnpm --filter @vue-vine/playground run dev",
     "dev": "esno scripts/run-dev.js",
-    "build": "pnpm build:compiler && pnpm build:ls && pnpm build:vite && pnpm build:main && pnpm build:eslint-parser && pnpm build:ls && pnpm build:ext",
+    "build": "pnpm --filter=\"./packages/*\" --stream build",
     "dev:compiler": "cross-env NODE_ENV=development pnpm --filter @vue-vine/compiler run dev",
     "dev:vite": "cross-env NODE_ENV=development pnpm --filter @vue-vine/vite-plugin run dev",
     "dev:main": "cross-env NODE_ENV=development pnpm --filter vue-vine run dev",


### PR DESCRIPTION
As the [pnpm docs](https://pnpm.io/cli/run#--stream) says, stream build will follow topological sorting, and build parallelly by sub-processes. This will save a **LOT** of time on build execution time.
