### PR TITLE
docs: rename to 'emit' in event convention

### DIFF
--- a/packages/docs/src/specification/macros.md
+++ b/packages/docs/src/specification/macros.md
@@ -13,11 +13,11 @@ This macro has zero parameter, and returns the emits function, you **must** defi
 This type parameter's syntax is the same as Vue 3.3's more succinct one, check the [official documentaion](https://vuejs.org/api/sfc-script-setup.html#defineprops-defineemits) for more details.
 
 ```vue-vine
-const myEmits = vineEmits<{
+const myEmit = vineEmits<{
   update: [foo: string, bar: number]
 }>()
 
-myEmits('update', 'foo', 1)
+myEmit('update', 'foo', 1)
 ```
 
 ## `vineExpose`

--- a/packages/docs/src/zh/specification/macros.md
+++ b/packages/docs/src/zh/specification/macros.md
@@ -13,11 +13,11 @@
 这个类型参数的语法与 Vue 3.3 更简洁的语法相同，请查阅[官方文档](https://vuejs.org/api/sfc-script-setup.html#defineprops-defineemits)了解更多细节。
 
 ```vue-vine
-const myEmits = vineEmits<{
+const myEmit = vineEmits<{
   update: [foo: string, bar: number]
 }>()
 
-myEmits('update', 'foo', 1)
+myEmit('update', 'foo', 1)
 ```
 
 ## `vineExpose` {#vineexpose}


### PR DESCRIPTION
[Vue convention](https://vuejs.org/api/sfc-script-setup.html#type-only-props-emit-declarations) is to call the return value of `defineEmits` `emit`, since it is a function that will emit the given event. 😎