### PR TITLE
fix(vite): esbuild should be processed after vue-vine

### DIFF
--- a/packages/playground/src/pages/about.vine.ts
+++ b/packages/playground/src/pages/about.vine.ts
@@ -1,6 +1,11 @@
 import { PageHeader } from '../components/page-header.vine'
 
 export function About() {
+
+  const fn = (a: string) => {
+
+  }
+
   return vine`
     <PageHeader />
     <div>

--- a/packages/playground/src/pages/about.vine.ts
+++ b/packages/playground/src/pages/about.vine.ts
@@ -1,11 +1,6 @@
 import { PageHeader } from '../components/page-header.vine'
 
 export function About() {
-
-  const fn = (a: string) => {
-
-  }
-
   return vine`
     <PageHeader />
     <div>

--- a/packages/playground/src/pages/home.vine.ts
+++ b/packages/playground/src/pages/home.vine.ts
@@ -28,6 +28,10 @@ function OutsideExample(props: { id: string }) {
     }, 2000)
   }
 
+  const a = (a: string) => {
+
+  }
+
   // Mock result of a network request
   watch(() => props.id, () => {
     mockUpdate()

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -92,33 +92,7 @@ function createVinePlugin(options: VineCompilerOptions = {}): Plugin {
 
   return {
     name: 'vue-vine-plugin',
-    config(config) {
-      // We need to exclude vine files from esbuild
-      // because we don't want them to be transpiled to JS that early.
-      if (!config.esbuild) {
-        config.esbuild = {}
-      }
-
-      if (!config.esbuild.include) {
-        config.esbuild.exclude = [
-          /\.vine\.ts$/,
-        ]
-      }
-      else if (
-        typeof config.esbuild.exclude === 'string'
-        || config.esbuild.exclude instanceof RegExp
-      ) {
-        // merge the original config value into an array
-        config.esbuild.exclude = [
-          config.esbuild.exclude,
-          /\.vine\.ts$/,
-        ] as any
-      }
-      else if (Array.isArray(config.esbuild.exclude)) {
-        (config.esbuild.exclude as Array<(string | RegExp)>)
-          .push(/\.vine\.ts$/)
-      }
-    },
+    enforce: 'pre',
     async resolveId(id) {
       const { query } = parseQuery(id)
       if (query.type === QUERY_TYPE_STYLE) {


### PR DESCRIPTION
Vite won't transpile ts code if we override esbuild config to exclude `/*,vine.ts$/`.

We can process before esbuild.