### PR TITLE
fix: test script

### DIFF
--- a/scripts/run-test.js
+++ b/scripts/run-test.js
@@ -3,6 +3,6 @@ import { runCommand } from './utils'
 const testCommand = 'cross-env NODE_ENV=test '
   + 'pnpm run test:compiler --run && '
   + 'pnpm run test:e2e --run && '
-  + 'pnpm run test:eslint-parser --run'
+  + 'pnpm run test:eslint-parser'
 
 runCommand(testCommand)


### PR DESCRIPTION
The test will fail in CI, but will never throw, which means CI never run test in `eslint-parser`

![image](https://github.com/vue-vine/vue-vine/assets/49969959/7bea1830-678f-4849-a9be-b2e4fdfe8c9a)
