### PR TITLE
fix:correct navigation links for multilingual support

### DIFF
--- a/packages/docs/src/.vitepress/config.ts
+++ b/packages/docs/src/.vitepress/config.ts
@@ -48,7 +48,6 @@ export default defineConfig({
 
     // https://vitepress.dev/reference/default-theme-config
     nav: [
-      { text: 'Guide', link: '/introduction/quick-start' },
     ],
 
     sidebar: {
@@ -96,10 +95,20 @@ export default defineConfig({
     root: {
       label: 'English',
       lang: 'en-US',
+      themeConfig: {
+        nav: [
+          { text: 'Guide', link: '/introduction/quick-start' },
+        ],
+      },
     },
     zh: {
       label: '简体中文',
       lang: 'zh-CN',
+      themeConfig: {
+        nav: [
+          { text: '指引', link: '/zh/introduction/quick-start' },
+        ],
+      },
     },
   },
   markdown: {


### PR DESCRIPTION
I noticed some minor issues with the Vue Vine documentation. When I selected Simplified Chinese, the nav still displayed “Guide,” and clicking on it redirected to the English “Quick start.” It should have redirected to the Simplified Chinese Quick Start. 
![Error](https://s2.loli.net/2024/07/07/H1bS4ODTQ5ZnsUC.png)
So, I fixed this issue.
![Now](https://s2.loli.net/2024/07/07/96J1wnAWMlq4K5j.png)