### PR TITLE
fix(compiler): parse simple component definition

### DIFF
--- a/packages/compiler/src/babel-helpers/ast.ts
+++ b/packages/compiler/src/babel-helpers/ast.ts
@@ -63,6 +63,14 @@ export function isVineCompFnDecl(target: Node) {
         ) {
           throw new Error(EXPECTED_ERROR)
         }
+
+        // issue#100: simple function component like () => vine`...`
+        if (
+          isArrowFunctionExpression(node)
+          && isVineTaggedTemplateString(node.body)
+        ) {
+          throw new Error(EXPECTED_ERROR)
+        }
       })
     }
     catch (error: any) {

--- a/packages/compiler/tests/ast.spec.ts
+++ b/packages/compiler/tests/ast.spec.ts
@@ -23,7 +23,16 @@ import {
   isVineMacroOf,
 } from '../src/babel-helpers/ast'
 
-describe('find Vine Function Component Declarations', () => {
+function parseForTest(content: string) {
+  return babelParse(content, {
+    sourceType: 'module',
+    plugins: [
+      'typescript',
+    ],
+  })
+}
+
+describe('find Vine function component declarations', () => {
   it('should be able to find out all Vine component function', () => {
     const content = `
 const Caculator = (props: { expr: string }) => {
@@ -42,17 +51,23 @@ export default function App() {
   \`
 }
 `
-    const root = babelParse(content, {
-      sourceType: 'module',
-      plugins: [
-        'typescript',
-      ],
-    })
+    const root = parseForTest(content)
 
     const foundVCFs = findVineCompFnDecls(root)
     expect(foundVCFs).toHaveLength(2)
     expect(((foundVCFs[0] as VariableDeclaration).declarations[0]?.id as Identifier).name).toBe('Caculator')
     expect(((foundVCFs[1] as ExportDefaultDeclaration).declaration as FunctionDeclaration).id?.name).toBe('App')
+  })
+})
+
+// issue#100
+describe('function component can simply return vine template', () => {
+  it('should recongnize a simple function component', () => {
+    const content = `const App = () => vine\`<div>Hello Vine</div>\``
+    const root = parseForTest(content)
+    const foundVCFs = findVineCompFnDecls(root)
+    expect(foundVCFs).toHaveLength(1)
+    expect(((foundVCFs[0] as VariableDeclaration).declarations[0]?.id as Identifier).name).toBe('App')
   })
 })
 

--- a/packages/compiler/tests/transform.spec.ts
+++ b/packages/compiler/tests/transform.spec.ts
@@ -119,7 +119,7 @@ describe('test transform', () => {
     expect(formated.includes('__VUE_HMR_RUNTIME__')).toBe(false)
   })
 
-  // #83
+  // issue#83
   it('hmrId should be generated If there is no style', async () => {
     const { mockCompilerCtx, mockCompilerHooks } = createMockTransformCtx({
       envMode: 'development',

--- a/packages/vscode-ext/package.json
+++ b/packages/vscode-ext/package.json
@@ -17,7 +17,7 @@
     "vscode": "^1.85.0"
   },
   "activationEvents": [
-    "onLanguage:typescript"
+    "onFile:*.vine.ts"
   ],
   "contributes": {
     "languages": [


### PR DESCRIPTION
Fix: #100 

## Other changes
Make VSCode extension only activate on `*.vine.ts` files.