### PR TITLE
feat(vscode-ext): add snippets

### DIFF
--- a/packages/playground/src/pages/home.vine.ts
+++ b/packages/playground/src/pages/home.vine.ts
@@ -70,8 +70,6 @@ async function RandomStringButton() {
     }
   `)
 
-  vineStyle(``)
-
   const emit = vineEmits<{
     tap: [number, number],
     move: [number, number, number]
@@ -128,5 +126,15 @@ export async function Home() {
         v-model="userInputText"
       />
     </div>
+  `
+}
+
+function TestComp() {
+  vineStyle.scoped(`
+  
+  `)
+
+  return vine`
+
   `
 }

--- a/packages/playground/src/pages/home.vine.ts
+++ b/packages/playground/src/pages/home.vine.ts
@@ -128,13 +128,3 @@ export async function Home() {
     </div>
   `
 }
-
-function TestComp() {
-  vineStyle.scoped(`
-  
-  `)
-
-  return vine`
-
-  `
-}

--- a/packages/vscode-ext/package.json
+++ b/packages/vscode-ext/package.json
@@ -74,6 +74,12 @@
         "name": "@vue-vine/typescript-plugin",
         "enableForWorkspaceTypeScriptVersions": true
       }
+    ],
+    "snippets": [
+      {
+        "language": "typescript",
+        "path": "./snippets/vine-snippets.code-snippets"
+      }
     ]
   },
   "scripts": {

--- a/packages/vscode-ext/snippets/vine-snippets.code-snippets
+++ b/packages/vscode-ext/snippets/vine-snippets.code-snippets
@@ -28,5 +28,14 @@
       "`)"
 		],
 		"description": "create vine-style."
+	},
+  "vineStyleScoped": {
+		"prefix": "vstysc",
+		"body": [
+			"vineStyle.scoped(`",
+      "  $0",
+      "`)"
+		],
+		"description": "create vine-style-scoped."
 	}
 }

--- a/packages/vscode-ext/snippets/vine-snippets.code-snippets
+++ b/packages/vscode-ext/snippets/vine-snippets.code-snippets
@@ -1,4 +1,13 @@
 {
+  "vineTemplate": {
+		"prefix": "vtpl",
+		"body": [
+			"vine`",
+      "  $0",
+      "`"
+		],
+		"description": "create vine template."
+	},
   "vineStyle": {
 		"prefix": "vsty",
 		"body": [

--- a/packages/vscode-ext/snippets/vine-snippets.code-snippets
+++ b/packages/vscode-ext/snippets/vine-snippets.code-snippets
@@ -37,5 +37,26 @@
       "`)"
 		],
 		"description": "quickly insert vine-style-scoped."
+	},
+  "Quickly insert vineProp": {
+		"prefix": "vpr",
+		"body": [
+			"const ${1:propName} = vineProp<$2>($3)"
+		],
+		"description": "quickly insert vine-prop."
+	},
+  "Quickly insert vineProp.withDefault": {
+		"prefix": "vprdf",
+		"body": [
+			"const ${1:propName} = vineProp.withDefault($2)"
+		],
+		"description": "quickly insert vine-prop-with-default."
+	},
+  "Quickly insert vineProp.optional": {
+		"prefix": "vpr?",
+		"body": [
+			"const ${1:propName} = vineProp.optional<$2>($3)"
+		],
+		"description": "quickly insert vine-prop-optional."
 	}
 }

--- a/packages/vscode-ext/snippets/vine-snippets.code-snippets
+++ b/packages/vscode-ext/snippets/vine-snippets.code-snippets
@@ -58,5 +58,11 @@
 			"const ${1:propName} = vineProp.optional<$2>($3)"
 		],
 		"description": "quickly insert vine-prop-optional."
-	}
+	},
+  "Quicly insert vineEmits": {
+    "prefix": "vemt",
+    "body": [
+      "const ${1:emit} = vineEmits<{$2}>()",
+    ],
+  }
 }

--- a/packages/vscode-ext/snippets/vine-snippets.code-snippets
+++ b/packages/vscode-ext/snippets/vine-snippets.code-snippets
@@ -1,4 +1,16 @@
 {
+  "vineComponentFunction": {
+		"prefix": "vcf",
+		"body": [
+			"function ${1:Component}($2) {",
+      "  $3",
+      "  return vine`",
+      "    $0",
+      "  `",
+      "}"
+		],
+		"description": "create vine component function."
+	},
   "vineTemplate": {
 		"prefix": "vtpl",
 		"body": [

--- a/packages/vscode-ext/snippets/vine-snippets.code-snippets
+++ b/packages/vscode-ext/snippets/vine-snippets.code-snippets
@@ -1,17 +1,17 @@
 {
-  "vineComponentFunction": {
+  "Vine component function": {
 		"prefix": "vcf",
 		"body": [
 			"function ${1:Component}($2) {",
-      "  $3",
+      "  $4",
       "  return vine`",
-      "    $0",
+      "    $3",
       "  `",
       "}"
 		],
 		"description": "create vine component function."
 	},
-  "vineTemplate": {
+  "Vine template": {
 		"prefix": "vtpl",
 		"body": [
 			"vine`",
@@ -20,22 +20,22 @@
 		],
 		"description": "create vine template."
 	},
-  "vineStyle": {
+  "Quickly insert vineStyle": {
 		"prefix": "vsty",
 		"body": [
-			"vineStyle(`",
-      "  $0",
+			"vineStyle($1`",
+      "  $2",
       "`)"
 		],
 		"description": "create vine-style."
 	},
-  "vineStyleScoped": {
+  "Quickly insert vineStyle.scoped": {
 		"prefix": "vstysc",
 		"body": [
-			"vineStyle.scoped(`",
-      "  $0",
+			"vineStyle.scoped($1`",
+      "  $2",
       "`)"
 		],
-		"description": "create vine-style-scoped."
+		"description": "quickly insert vine-style-scoped."
 	}
 }

--- a/packages/vscode-ext/snippets/vine-snippets.code-snippets
+++ b/packages/vscode-ext/snippets/vine-snippets.code-snippets
@@ -1,11 +1,11 @@
 {
-  "vineStyleForScss": {
-		"prefix": "vineStyle",
+  "vineStyle": {
+		"prefix": "vsty",
 		"body": [
-			"vineStyle.scoped(${1:scss}`",
-			"   $0",
+			"vineStyle(`",
+      "  $0",
       "`)"
 		],
-		"description": "create vine-style with scss."
+		"description": "create vine-style."
 	}
 }

--- a/packages/vscode-ext/snippets/vine-snippets.code-snippets
+++ b/packages/vscode-ext/snippets/vine-snippets.code-snippets
@@ -1,0 +1,11 @@
+{
+  "vineStyleForScss": {
+		"prefix": "vineStyle",
+		"body": [
+			"vineStyle.scoped(${1:scss}`",
+			"   $0",
+      "`)"
+		],
+		"description": "create vine-style with scss."
+	}
+}


### PR DESCRIPTION
### Snippets

* `vcf`: means `v(ine) c(omponent) f(unction)`

   For quick inserting a component function

   https://github.com/user-attachments/assets/5b0a875a-4cbb-4c3a-8fa0-e065669330ca

* `vtpl`: means `v(ine) t(em)pl(ate)`

   For quick inserting a vine\`...\` with a prettier-formated new line inside it

   Preview image: 
   
   https://github.com/user-attachments/assets/7fd0787b-a36a-4dbf-a4ed-7976bc8ec84f

* `vsty`: means `v(ine) sty(le)`

   For quick inserting a vineStyle(...)

   Preview image: 
   
   https://github.com/user-attachments/assets/427af17b-71e6-42d3-b64b-11d020eb796a

* `vstysc`: means `v(ine) sty(le) sc(oped)`

   For quick inserting a vineStyle.scoped(...)

   Preview image: 
   
   https://github.com/user-attachments/assets/64d4dd5a-cf52-4fc1-b2f7-090c67804afe

* `vpr`: means `v(ine) pr(op)`

   For quick inserting a `const ${2:propName} = vineProp<$1>($3)`

   Preview image:

   https://github.com/user-attachments/assets/d3f509fa-33d3-412c-a868-8262ba0d7c23

* `vprdf`: means `v(ine) pr(op) with d(e)f(ault)`

   For quick inserting a `const ${1:propName} = vineProp.withDefault($2)`

   Preview image:

   https://github.com/user-attachments/assets/9523a1a0-0bcc-48b0-bd73-01120f1b098c

* `vpr?`: means `v(ine) pr(op) (optional)`

   For quick inserting a `const ${1:propName} = vineProp.optional<$2>($3)`

   Preview image:

   https://github.com/user-attachments/assets/934b3047-c8e8-4c34-be65-d1dfbc588481

* `vemt`: means `v(ine) em(i)t(s)`

   For quick inserting a `const ${1:emits} = vineEmits<$2>()`

   Preview image:
   
   https://github.com/user-attachments/assets/829ddd99-b305-41ce-8baa-b8aa18001e9f



