### PR TITLE
docs: add playground

### DIFF
--- a/packages/docs/src/.vitepress/config.ts
+++ b/packages/docs/src/.vitepress/config.ts
@@ -100,6 +100,10 @@ export default defineConfig({
       themeConfig: {
         nav: [
           { text: 'Guide', link: '/introduction/quick-start' },
+          {
+            text: 'Playground',
+            link: 'https://stackblitz.com/github/wzc520pyfm/vine-router-template/tree/main?file=README.md',
+          },
         ],
       },
     },
@@ -109,6 +113,10 @@ export default defineConfig({
       themeConfig: {
         nav: [
           { text: '指引', link: '/zh/introduction/quick-start' },
+          {
+            text: '演练场',
+            link: 'https://stackblitz.com/github/wzc520pyfm/vine-router-template/tree/main?file=README.md',
+          },
         ],
       },
     },


### PR DESCRIPTION
I used `create-vue-vine` to create an initial project to experience vue vine online. (I wasn’t sure if such a template should be integrated into our monorepo or create a new repository in our organization, so I temporarily created it under my personal account. In the future, we can always move to it.)

I'll link this initial template to stackblitz so that users can experience vue vine online.

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/2fe74728-5eba-49bc-b964-4a0088b92679">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/8ae92ee0-d8fa-4b53-a9ea-32f1ac2f240b">
