### PR TITLE
fix(vite-plugin): fix read styleDefine of undefined

### DIFF
--- a/packages/nuxt-module/playground/welcome.vine.ts
+++ b/packages/nuxt-module/playground/welcome.vine.ts
@@ -1,11 +1,23 @@
 function Welcome() {
   const content = vineProp<string>()
   const counter = ref(0)
+  const contentBgColor = ref('red')
+
+  vineStyle.scoped(scss`
+    .content-view {
+      margin: 1rem 0;
+      color: v-bind(contentBgColor);
+    }
+  `)
+
+  vineExpose({
+    contentBgColor,
+  })
 
   return vine`
     <div>
       <div>Vue Vine!</div>
-      <div>{{ content }}</div>
+      <div class="content-view">{{ content }}</div>
       <div>
         <button @click="() => counter++">+</button>
         {{ counter }}

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -113,9 +113,8 @@ function createVinePlugin(options: VineCompilerOptions = {}): Plugin {
       if (query.type === QUERY_TYPE_STYLE && query.scopeId) {
         const fullFileId = `${fileId}.vine.ts`
         const styleSource = compilerCtx.fileCtxMap
-          .get(fullFileId)!
-          .styleDefine[query.scopeId][query.index]
-          .source
+          .get(fullFileId)?.styleDefine[query.scopeId][query.index]
+          .source ?? ''
         const compiledStyle = await runCompileStyle(
           styleSource,
           query,


### PR DESCRIPTION
I found StyleDefine maybe be read from undefined, when using vineStyle in SSR.

When I added the compatibility logic, it working.

<img width="1033" alt="image" src="https://github.com/user-attachments/assets/d15d6811-090e-431f-b8eb-b7d0adb76dd9">

<img width="260" alt="image" src="https://github.com/user-attachments/assets/40b66e28-3a45-4285-9fbf-fb6bdbf4556d">
