### PR TITLE
fix(vite-plugin): Fixed prompt type missing in development mode

### DIFF
--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -10,12 +10,14 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
   },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -10,6 +10,7 @@
   ],
   "exports": {
     ".": {
+      "dev": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
@@ -17,7 +18,6 @@
   },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Fixed an error that occurred when using `pnpm dev`.

src/vite/index.ts(3,8): error TS7016: Could not find a declaration file for module '@vue-vine/vite-plugin'. '/Users/tianteng/workspace/github/fork/vue-vine/packages/vite-plugin/dist/index.mjs' implicitly has an 'any' type.
  MAIN     Try `npm i --save-dev @types/vue-vine__vite-plugin` if it exists or add a new declaration (.d.ts) file containing `declare module '@vue-vine/vite-plugin';`
  
  
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/28a3fed5-7854-4f71-9707-9c529642b0f7">
