### PR TITLE
feat(Import external CSS files):

### DIFF
--- a/packages/compiler/src/analyze.ts
+++ b/packages/compiler/src/analyze.ts
@@ -593,9 +593,10 @@ const analyzeVineStyle: AnalyzeRunner = (
     if (!vineStyleArg) {
       return
     }
-    const { styleLang, styleSource, range } = getVineStyleSource(
+    let { styleLang, styleSource, range } = getVineStyleSource(
       vineStyleArg as VineStyleValidArg,
     )
+
     const styleMeta: VineStyleMeta = {
       lang: styleLang,
       source: styleSource,

--- a/packages/compiler/src/style/create-import-statement.ts
+++ b/packages/compiler/src/style/create-import-statement.ts
@@ -8,6 +8,9 @@ export function createStyleImportStmt(
   index: number,
 ) {
   const styleLangExt = getStyleLangFileExt(styleDefine.lang)
+  const genImportTag = (source: string) => {
+    return source.endsWith('.css')
+  }
   return `import ${showIf(
     // handle web component styles
     Boolean(vineCompFnCtx.isCustomElement),
@@ -23,5 +26,5 @@ export function createStyleImportStmt(
       Boolean(styleDefine.scoped),
       '&scoped=true',
     )
-  }&index=${index}&virtual.${styleLangExt}';`
+  }&index=${index}${showIf(genImportTag(styleDefine.source), '&importTag=true')}&virtual.${styleLangExt}';`
 }

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -107,6 +107,7 @@ export interface VineFileCtx {
   readonly root: ParseResult<File>
   readonly originCode: string
   readonly isCRLF: boolean
+  importStyleOriginCode?: string
   /**
    * Hot update only executes the
    * markup of the render function

--- a/packages/compiler/tests/transform.spec.ts
+++ b/packages/compiler/tests/transform.spec.ts
@@ -83,14 +83,13 @@ export default async function MyApp() {
 describe('test transform', () => {
   it('inline mode output result', async () => {
     const { mockCompilerCtx, mockCompilerHooks } = createMockTransformCtx()
-    compileVineTypeScriptFile(testContent, 'testTransformInlineResult', { compilerHooks: mockCompilerHooks })
+    compileVineTypeScriptFile(testContent, 'testTransformInlineResult', {
+      compilerHooks: mockCompilerHooks,
+    })
     expect(mockCompilerCtx.vineCompileErrors.length).toBe(0)
     const fileCtx = mockCompilerCtx.fileCtxMap.get('testTransformInlineResult')
     const transformed = fileCtx?.fileMagicCode.toString() ?? ''
-    const formated = await format(
-      transformed,
-      { parser: 'babel-ts' },
-    )
+    const formated = await format(transformed, { parser: 'babel-ts' })
     expect(formated).toMatchSnapshot()
   })
 
@@ -98,14 +97,15 @@ describe('test transform', () => {
     const { mockCompilerCtx, mockCompilerHooks } = createMockTransformCtx({
       inlineTemplate: false,
     })
-    compileVineTypeScriptFile(testContent, 'testTransformSeparatedResult', { compilerHooks: mockCompilerHooks })
+    compileVineTypeScriptFile(testContent, 'testTransformSeparatedResult', {
+      compilerHooks: mockCompilerHooks,
+    })
     expect(mockCompilerCtx.vineCompileErrors.length).toBe(0)
-    const fileCtx = mockCompilerCtx.fileCtxMap.get('testTransformSeparatedResult')
-    const transformed = fileCtx?.fileMagicCode.toString() ?? ''
-    const formated = await format(
-      transformed,
-      { parser: 'babel-ts' },
+    const fileCtx = mockCompilerCtx.fileCtxMap.get(
+      'testTransformSeparatedResult',
     )
+    const transformed = fileCtx?.fileMagicCode.toString() ?? ''
+    const formated = await format(transformed, { parser: 'babel-ts' })
     expect(formated).toMatchSnapshot()
   })
 
@@ -113,14 +113,18 @@ describe('test transform', () => {
     const { mockCompilerCtx, mockCompilerHooks } = createMockTransformCtx({
       inlineTemplate: false,
     })
-    compileVineTypeScriptFile(testContent, 'testTransformSeparatedResult', { compilerHooks: mockCompilerHooks }, true)
-    expect(mockCompilerCtx.vineCompileErrors.length).toBe(0)
-    const fileCtx = mockCompilerCtx.fileCtxMap.get('testTransformSeparatedResult')
-    const transformed = fileCtx?.fileMagicCode.toString() ?? ''
-    const formated = await format(
-      transformed,
-      { parser: 'babel-ts' },
+    compileVineTypeScriptFile(
+      testContent,
+      'testTransformSeparatedResult',
+      { compilerHooks: mockCompilerHooks },
+      true,
     )
+    expect(mockCompilerCtx.vineCompileErrors.length).toBe(0)
+    const fileCtx = mockCompilerCtx.fileCtxMap.get(
+      'testTransformSeparatedResult',
+    )
+    const transformed = fileCtx?.fileMagicCode.toString() ?? ''
+    const formated = await format(transformed, { parser: 'babel-ts' })
     expect(formated).toMatchSnapshot()
   })
 
@@ -128,14 +132,15 @@ describe('test transform', () => {
     const { mockCompilerCtx, mockCompilerHooks } = createMockTransformCtx({
       envMode: 'production',
     })
-    compileVineTypeScriptFile(testContent, 'testNoHMRContentOnProduction', { compilerHooks: mockCompilerHooks })
+    compileVineTypeScriptFile(testContent, 'testNoHMRContentOnProduction', {
+      compilerHooks: mockCompilerHooks,
+    })
     expect(mockCompilerCtx.vineCompileErrors.length).toBe(0)
-    const fileCtx = mockCompilerCtx.fileCtxMap.get('testNoHMRContentOnProduction')
-    const transformed = fileCtx?.fileMagicCode.toString() ?? ''
-    const formated = await format(
-      transformed,
-      { parser: 'babel-ts' },
+    const fileCtx = mockCompilerCtx.fileCtxMap.get(
+      'testNoHMRContentOnProduction',
     )
+    const transformed = fileCtx?.fileMagicCode.toString() ?? ''
+    const formated = await format(transformed, { parser: 'babel-ts' })
     expect(formated).toMatchSnapshot()
     expect(formated.includes('__hmrId')).toBe(false)
     expect(formated.includes('__VUE_HMR_RUNTIME__')).toBe(false)
@@ -154,16 +159,32 @@ describe('test transform', () => {
         </div>
       \`
     }`
-    compileVineTypeScriptFile(testContent, 'testHMRContentOnNoStyle', { compilerHooks: mockCompilerHooks })
+    compileVineTypeScriptFile(testContent, 'testHMRContentOnNoStyle', {
+      compilerHooks: mockCompilerHooks,
+    })
     expect(mockCompilerCtx.vineCompileErrors.length).toBe(0)
     const fileCtx = mockCompilerCtx.fileCtxMap.get('testHMRContentOnNoStyle')
     const transformed = fileCtx?.fileMagicCode.toString() ?? ''
-    const formated = await format(
-      transformed,
-      { parser: 'babel-ts' },
-    )
+    const formated = await format(transformed, { parser: 'babel-ts' })
     expect(formated).toMatchSnapshot()
     expect(formated.includes('__hmrId')).toBe(true)
     expect(formated.includes('__VUE_HMR_RUNTIME__')).toBe(true)
+  })
+
+  // issue#151
+  it('import external CSS files', async () => {
+    const { mockCompilerHooks } = createMockTransformCtx({
+      envMode: 'development',
+    })
+    const testContent = `
+      function App() {
+          vineStyle.scoped("../styles/test.css")
+          return vine\`
+          <div>Hello</div>
+              \`
+      }`
+    compileVineTypeScriptFile(testContent, 'testImportExternalCSS', {
+      compilerHooks: mockCompilerHooks,
+    })
   })
 })

--- a/packages/playground/src/pages/home.vine.ts
+++ b/packages/playground/src/pages/home.vine.ts
@@ -8,17 +8,20 @@ function OutsideExample(props: { id: string }) {
       margin: 1rem 0;
     }
   `)
+  vineStyle.scoped('../styles/test.css')
   vineStyle.scoped(`
     .state-container-meta {
-      margin-top: 16px;
+      margin-top: 10px;
       font-style: italic;
     }
-    .state-container-title {
+  `)
+  vineStyle.scoped(`
+  .state-container-title {
       margin: 0.5rem 0;
       font-weight: bold;
-      opacity: 0.8;
-    }
-  `)
+      opacity: 0.2;
+    }`
+  )
 
   const randomStr = ref('')
   const loading = ref(true)
@@ -26,7 +29,7 @@ function OutsideExample(props: { id: string }) {
     loading.value = true
     setTimeout(() => {
       loading.value = false
-      randomStr.value = generateRandomString(30)
+      randomStr.value = generateRandomString(10)
     }, 2000)
   }
 
@@ -59,18 +62,18 @@ function OutsideExample(props: { id: string }) {
 }
 
 function RandomStringButton() {
-  vineStyle(`
-    .random-state-change-btn {
-      font-size: 1rem;
-      background: #334155c6;
-      border-radius: 0.25rem;
-      color: #fff;
-      padding: 0.5rem 1rem;
-      border: none;
-      outline: none;
-      cursor: pointer;
-    }
-  `)
+  // vineStyle(`
+  //   .random-state-change-btn {
+  //     font-size: 1rem;
+  //     background: #334155c6;
+  //     border-radius: 0.25rem;
+  //     color: #fff;
+  //     padding: 0.5rem 1rem;
+  //     border: none;
+  //     outline: none;
+  //     cursor: pointer;
+  //   }
+  // `)
 
   const emit = vineEmits<{
     tap: [number, number],

--- a/packages/vite-plugin/src/import-css.ts
+++ b/packages/vite-plugin/src/import-css.ts
@@ -1,0 +1,48 @@
+import path from 'node:path'
+import fs, { readFileSync } from 'node:fs'
+import type { VineCompilerCtx } from '@vue-vine/compiler'
+import type { HmrContext } from 'vite'
+import type { VineQuery } from './parse-query'
+import { parseQuery } from './parse-query'
+
+export function saveImportCssFile(fileId: string, styleSource: string, compilerCtx: VineCompilerCtx, fullFileId: string) {
+  const stylePath = path.resolve(path.dirname(fileId), styleSource)
+  styleSource = fs.readFileSync(stylePath, 'utf-8')
+  const data = Object.assign({}, compilerCtx.fileCtxMap.get(fullFileId))
+  compilerCtx.fileCtxMap.set(stylePath, data!)
+  compilerCtx.fileCtxMap.get(stylePath)!.importStyleOriginCode = styleSource
+  return {
+    stylePath,
+    styleSource,
+  }
+}
+export async function hmrImportCss(ctx: HmrContext, file: string, compilerCtx: VineCompilerCtx, watchedFiles: Map<string, string>) {
+  let prevImportStyleCode = ''
+  let styleFileQuery: VineQuery
+  prevImportStyleCode = compilerCtx.fileCtxMap.get(file)!.importStyleOriginCode!
+
+  const virtualId = watchedFiles.get(file)
+  const { query } = parseQuery(virtualId!)
+  styleFileQuery = query
+  const module = ctx.server.moduleGraph.getModuleById(virtualId!)
+  for (let d of module!.importers.entries()!) {
+    // 得到父模块
+    let parentModule = ctx.server.moduleGraph.getModuleById(d[0].id!)
+    const currentVineFileCtx = compilerCtx.fileCtxMap.get(ctx.file)
+    if (currentVineFileCtx) {
+      // 将父模块添加到当前文件的依赖列表中
+      currentVineFileCtx.styleDefine[query.scopeId][query.index].source = await ctx.read()
+      ctx.modules.push(parentModule!)
+      ctx.file = <string>parentModule?.file
+      // 更新外部css文件内容的读取
+      ctx.read = () => readFileSync(ctx.file!, 'utf-8')
+      const parentVineFileCtx = compilerCtx.fileCtxMap.get(ctx.file)!
+      // 更新父模块的vineCtx外部导入到css内容
+      parentVineFileCtx.importStyleOriginCode = currentVineFileCtx.styleDefine[query.scopeId][query.index].source
+    }
+  }
+  return {
+    prevImportStyleCode,
+    styleFileQuery,
+  }
+}

--- a/packages/vite-plugin/src/parse-query.ts
+++ b/packages/vite-plugin/src/parse-query.ts
@@ -6,6 +6,9 @@ export interface VineQuery {
   scoped: boolean
   lang: string
   index: number
+  importTag: boolean
+
+  [key: string]: string
 }
 type VineQueryRaw = Record<keyof VineQuery, string>
 
@@ -18,6 +21,7 @@ export function parseQuery(id: string) {
     scopeId: rawQuery.scopeId,
     scoped: rawQuery.scoped === 'true',
     index: Number(rawQuery.index),
+    importTag: rawQuery.importTag === 'true',
   }
 
   return {


### PR DESCRIPTION
Support importing external CSS files and optimizing HMR mechanism

- Added the function of importing external CSS files, supporting importing CSS files through vineStyle.copied 
- Optimize HMR mechanism, support updating only changed style files, and improve hot update efficiency 
- Add the importTag property to identify the imported CSS file 
- Fixed some issues related to importing style files

close #151 
<img width="357" alt="image" src="https://github.com/user-attachments/assets/d92f345a-0399-4a4f-a0ac-569d9409a5ce">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/2a7fa8a9-1c2c-45a4-9193-426bf2dee8d4">
