### PR TITLE
fix(create-vue-vine): get correct template dir in `Windows`

### DIFF
--- a/packages/create-vue-vine/src/utils/project.ts
+++ b/packages/create-vue-vine/src/utils/project.ts
@@ -1,11 +1,12 @@
 import { basename, resolve } from 'node:path'
 import { exists } from './fs'
+import { fileURLToPath } from 'node:url'
 
 export function validateProjectName(path: string) {
   return basename(path) === path
 }
 
-const __dirname = new URL('.', import.meta.url).pathname
+const __dirname = fileURLToPath(import.meta.url)
 
 export async function getTemplateDirectory() {
   const templateRoot = resolve(__dirname, '../template')


### PR DESCRIPTION
fix #158