### PR TITLE
fix(compiler): top-level await transform

### DIFF
--- a/packages/compiler/tests/__snapshots__/transform.spec.ts.snap
+++ b/packages/compiler/tests/__snapshots__/transform.spec.ts.snap
@@ -893,3 +893,76 @@ import.meta.hot?.accept((mod) => {
 });
 "
 `;
+
+exports[`test transform > should transform top-level await expressions 1`] = `
+"import {
+  openBlock as _openBlock,
+  createElementBlock as _createElementBlock,
+  defineComponent as _defineComponent,
+  useCssVars as _useCssVars,
+  unref as _unref,
+  withAsyncContext as _withAsyncContext,
+} from "vue";
+
+export const MyComp = (() => {
+  const __vine = _defineComponent({
+    name: "MyComp",
+    /* No props */
+    /* No emits */
+    async setup(__props, { expose: __expose }) {
+      __expose();
+      let __temp, __restore;
+      const props = __props;
+      ([__temp, __restore] = _withAsyncContext(() => someAsyncFunction())),
+        await __temp,
+        __restore();
+      const data =
+        (([__temp, __restore] = _withAsyncContext(() =>
+          fetch("https://test-api.com"),
+        )),
+        (__temp = await __temp),
+        __restore(),
+        __temp);
+      window.fooList[
+        (([__temp, __restore] = _withAsyncContext(() => bar())),
+        (__temp = await __temp),
+        __restore(),
+        __temp)
+      ] = true;
+
+      useDebounceFn(async () => {
+        await doSomeAsync();
+      });
+
+      return (_ctx, _cache) => {
+        return _openBlock(), _createElementBlock("div", null, "Test");
+      };
+    },
+  });
+
+  __vine.__hmrId = "31ff5352";
+
+  return __vine;
+})();
+
+typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
+  __VUE_HMR_RUNTIME__.createRecord(MyComp.__hmrId, MyComp);
+export const _rerender_only = false;
+export const _rerender_vcf_fn_name = "";
+import.meta.hot?.accept((mod) => {
+  if (!mod) {
+    return;
+  }
+  const { _rerender_only, _rerender_vcf_fn_name } = mod;
+  if (!_rerender_vcf_fn_name) {
+    return;
+  }
+  const component = mod[_rerender_vcf_fn_name];
+  if (_rerender_only) {
+    __VUE_HMR_RUNTIME__.rerender(component.__hmrId, component.render);
+  } else {
+    __VUE_HMR_RUNTIME__.reload(component.__hmrId, component);
+  }
+});
+"
+`;

--- a/packages/compiler/tests/transform.spec.ts
+++ b/packages/compiler/tests/transform.spec.ts
@@ -270,4 +270,35 @@ export function MyComp() {
       "
     `)
   })
+
+  // issue#
+  it('should transform top-level await expressions', async () => {
+    const { mockCompilerCtx, mockCompilerHooks } = createMockTransformCtx({
+      envMode: 'development',
+    })
+    const specContent = `
+export async function MyComp() {
+  await someAsyncFunction()
+  const data = await fetch('https://test-api.com')
+  window.fooList[await bar()] = true
+
+  useDebounceFn(async () => {
+    await doSomeAsync()
+  })
+
+  return vine\`
+    <div>Test</div>
+  \`
+}
+    `
+    compileVineTypeScriptFile(specContent, 'testTransformTopLevelAwait', { compilerHooks: mockCompilerHooks })
+    expect(mockCompilerCtx.vineCompileErrors.length).toBe(0)
+    const fileCtx = mockCompilerCtx.fileCtxMap.get('testTransformTopLevelAwait')
+    const transformed = fileCtx?.fileMagicCode.toString() ?? ''
+    const formated = await format(
+      transformed,
+      { parser: 'babel-ts' },
+    )
+    expect(formated).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
Close: #173 

- New unit test added: 
  `packages/compiler/tests/transform.spec.ts` —— `'should transform top-level await expressions'`