### PR TITLE
feat(compiler): use ts-morph to analyze external props type

### DIFF
--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -43,7 +43,9 @@
     "postcss": "^8.4.29",
     "postcss-selector-parser": "^6.0.13",
     "prettier": "^3.3.2",
-    "source-map-js": "^1.0.2"
+    "source-map-js": "^1.0.2",
+    "ts-morph": "^25.0.0",
+    "typescript": "^5.6.3"
   },
   "devDependencies": {
     "@types/hash-sum": "^1.0.0",

--- a/packages/compiler/src/analyze.ts
+++ b/packages/compiler/src/analyze.ts
@@ -50,6 +50,7 @@ import {
   isTemplateLiteral,
   isTSMethodSignature,
   isTSPropertySignature,
+  isTSTypeAnnotation,
   isTSTypeLiteral,
   isVariableDeclaration,
   isVariableDeclarator,
@@ -84,6 +85,7 @@ import { DEFAULT_MODEL_MODIFIERS_NAME, SUPPORTED_STYLE_FILE_EXTS, VineBindingTyp
 import { vineErr, vineWarn } from './diagnostics'
 import { parseCssVars } from './style/analyze-css-vars'
 import { isImportUsed } from './template/import-usage-check'
+import { resolveVineCompFnProps } from './ts-morph/resolve-props-type'
 import { _breakableTraverse, exitTraverse } from './utils'
 
 interface AnalyzeCtx {
@@ -374,35 +376,60 @@ const analyzeVineProps: AnalyzeRunner = (
     // its type is `identifier`, and it must have an object literal type annotation.
     // Save this parameter's name as `propsAlias`
     const propsFormalParam = formalParams[0] as Identifier
-    const propsTypeAnnotation = (propsFormalParam.typeAnnotation as TSTypeAnnotation)?.typeAnnotation as TSTypeLiteral | undefined
-    if (!propsTypeAnnotation) {
+    const propsTypeAnnotation = propsFormalParam.typeAnnotation
+    if (!isTSTypeAnnotation(propsTypeAnnotation)) {
       return
     }
 
-    vineCompFnCtx.propsFormalParam = propsTypeAnnotation
-    vineCompFnCtx.propsAlias = propsFormalParam.name;
-    // Analyze the object literal type annotation
-    // and save the props info into `vineCompFnCtx.props`
-    (propsTypeAnnotation.members as TSPropertySignature[])?.forEach((member) => {
-      if (!isIdentifier(member.key) || !member.typeAnnotation) {
+    const { typeAnnotation } = propsTypeAnnotation
+    vineCompFnCtx.propsFormalParam = typeAnnotation
+
+    if (isTSTypeLiteral(typeAnnotation)) {
+      vineCompFnCtx.propsAlias = propsFormalParam.name;
+      // Analyze the object literal type annotation
+      // and save the props info into `vineCompFnCtx.props`
+      (typeAnnotation.members as TSPropertySignature[])?.forEach((member) => {
+        if (!isIdentifier(member.key) || !member.typeAnnotation) {
+          return
+        }
+        const propName = member.key.name
+        const propType = vineFileCtx.getAstNodeContent(member.typeAnnotation.typeAnnotation)
+        const propMeta: VinePropMeta = {
+          isFromMacroDefine: false,
+          isRequired: member.optional === undefined ? true : !member.optional,
+          isBool: [
+            'boolean',
+            'Boolean',
+            'true',
+            'false',
+          ].includes(propType),
+          typeAnnotationRaw: propType,
+        }
+        vineCompFnCtx.props[propName] = propMeta
+        vineCompFnCtx.bindings[propName] = VineBindingTypes.PROPS
+      })
+    }
+    else {
+      if (vineCompilerHooks.getCompilerCtx().options.disableTsMorph) {
         return
       }
-      const propName = member.key.name
-      const propType = vineFileCtx.getAstNodeContent(member.typeAnnotation.typeAnnotation)
-      const propMeta: VinePropMeta = {
-        isFromMacroDefine: false,
-        isRequired: member.optional === undefined ? true : !member.optional,
-        isBool: [
-          'boolean',
-          'Boolean',
-          'true',
-          'false',
-        ].includes(propType),
-        typeAnnotationRaw: propType,
-      }
-      vineCompFnCtx.props[propName] = propMeta
-      vineCompFnCtx.bindings[propName] = VineBindingTypes.PROPS
-    })
+
+      // Use ts-morph to analyze props info
+      const { project, typeChecker } = vineCompilerHooks.getTsMorph()
+      const sourceFile = project.createSourceFile(
+        vineFileCtx.fileId,
+        vineFileCtx.originCode,
+        { overwrite: true },
+      )
+      const propsInfo = resolveVineCompFnProps({
+        typeChecker,
+        sourceFile,
+        vineFileCtx,
+        vineCompFnCtx,
+        compilerHooks: vineCompilerHooks,
+      })
+      vineCompFnCtx.props = propsInfo
+    }
   }
   else if (formalParams.length === 0) {
     vineCompFnCtx.propsDefinitionBy = 'macro'
@@ -417,7 +444,7 @@ const analyzeVineProps: AnalyzeRunner = (
         isRequired: macroCalleeName !== 'vineProp.optional',
         isBool: false,
         typeAnnotationRaw: 'any',
-        declaredIdentifier: propVarIdentifier,
+        macroDeclaredIdentifier: propVarIdentifier,
       }
 
       if (macroCalleeName === 'vineProp.withDefault') {
@@ -1012,7 +1039,7 @@ function buildVineCompFnCtx(
             ) + (
               propMeta.isRequired ? '' : '?'
             )
-          }: ${propMeta.typeAnnotationRaw}`,
+          }: ${propMeta.typeAnnotationRaw ?? 'any'}`,
         )
         .filter(Boolean)
         .join(joinStr)

--- a/packages/compiler/src/analyze.ts
+++ b/packages/compiler/src/analyze.ts
@@ -382,7 +382,7 @@ const analyzeVineProps: AnalyzeRunner = (
     }
 
     const { typeAnnotation } = propsTypeAnnotation
-    vineCompFnCtx.propsFormalParam = typeAnnotation
+    vineCompFnCtx.propsFormalParamType = typeAnnotation
 
     if (isTSTypeLiteral(typeAnnotation)) {
       vineCompFnCtx.propsAlias = propsFormalParam.name;
@@ -417,9 +417,7 @@ const analyzeVineProps: AnalyzeRunner = (
       try {
         // Use ts-morph to analyze props info
         const { project, typeChecker } = vineCompilerHooks.getTsMorph()
-        const sourceFile = project.getSourceFileOrThrow(
-          vineFileCtx.fileId,
-        )
+        const sourceFile = project.getSourceFileOrThrow(vineFileCtx.fileId)
         const propsInfo = resolveVineCompFnProps({
           typeChecker,
           sourceFile,
@@ -432,7 +430,7 @@ const analyzeVineProps: AnalyzeRunner = (
           vineErr(
             { vineFileCtx, vineCompFnCtx },
             {
-              msg: `Failed to resolve props type, err: ${err}`,
+              msg: `Failed to resolve props type '${vineFileCtx.getAstNodeContent(typeAnnotation)}'. Error: ${err}`,
               location: vineCompFnCtx.fnItselfNode?.params?.[0]?.loc,
             },
           ),

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -25,6 +25,10 @@ export {
   walkVueTemplateAst,
 } from './template/walk'
 
+export {
+  createTsMorph,
+} from './ts-morph/create'
+
 export type {
   HMRCompFnsName,
   VineCompFnCtx as VineFnCompCtx,

--- a/packages/compiler/src/ts-morph/create.ts
+++ b/packages/compiler/src/ts-morph/create.ts
@@ -1,0 +1,33 @@
+import type { TsMorphCache } from '../types'
+import { existsSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { Project } from 'ts-morph'
+import { findConfigFile } from 'typescript'
+
+export function createTsMorph(fileId?: string): TsMorphCache {
+  let project: Project
+
+  if (fileId) {
+    const tsConfigFilePath = findConfigFile(
+      dirname(fileId),
+      f => existsSync(f),
+    )
+    if (!tsConfigFilePath) {
+      throw new Error('Cannot locate project\'s tsconfig.json')
+    }
+
+    project = new Project({
+      tsConfigFilePath,
+    })
+  }
+  else {
+    fileId ??= 'vine.ts'
+    project = new Project()
+  }
+
+  const typeChecker = project.getTypeChecker()
+  return {
+    project,
+    typeChecker,
+  }
+}

--- a/packages/compiler/src/ts-morph/resolve-props-type.ts
+++ b/packages/compiler/src/ts-morph/resolve-props-type.ts
@@ -1,7 +1,6 @@
 import type { ArrowFunction, FunctionDeclaration, FunctionExpression, SourceFile, TaggedTemplateExpression, Type, TypeChecker, VariableDeclaration } from 'ts-morph'
-import type { VineCompFnCtx, VineCompilerHooks, VineFileCtx, VinePropMeta } from '../types'
+import type { VineCompFnCtx, VinePropMeta } from '../types'
 import { Node } from 'ts-morph'
-import { vineErr } from '../diagnostics'
 
 function isBooleanType(
   typeChecker: TypeChecker,

--- a/packages/compiler/src/ts-morph/resolve-props-type.ts
+++ b/packages/compiler/src/ts-morph/resolve-props-type.ts
@@ -1,0 +1,122 @@
+import type { ArrowFunction, FunctionDeclaration, FunctionExpression, SourceFile, TaggedTemplateExpression, Type, TypeChecker, VariableDeclaration } from 'ts-morph'
+import type { VineCompFnCtx, VineCompilerHooks, VineFileCtx, VinePropMeta } from '../types'
+import { Node } from 'ts-morph'
+import { vineErr } from '../diagnostics'
+
+function isBooleanType(
+  typeChecker: TypeChecker,
+  type: Type,
+) {
+  // 直接 boolean
+  if (type.isBoolean())
+    return true
+
+  // 联合类型 (true | false 或 boolean | undefined 等)
+  if (type.isUnion()) {
+    return type.getUnionTypes().every(t =>
+      t.isBoolean()
+      || (t.isLiteral() && (t.getLiteralValue() === 'true' || t.getLiteralValue() === 'false')),
+    )
+  }
+
+  // 交叉类型
+  if (type.isIntersection()) {
+    return type.getIntersectionTypes().some(t => t.isBoolean())
+  }
+
+  // 别名类型，需要获取其实际类型
+  const aliasSymbol = type.getAliasSymbol()
+  if (aliasSymbol) {
+    const aliasType = typeChecker.getDeclaredTypeOfSymbol(aliasSymbol)
+    return isBooleanType(typeChecker, aliasType)
+  }
+
+  return false
+};
+
+export function resolveVineCompFnProps(params: {
+  typeChecker: TypeChecker
+  sourceFile: SourceFile
+  vineFileCtx: VineFileCtx
+  vineCompFnCtx: VineCompFnCtx
+  compilerHooks: VineCompilerHooks
+}) {
+  const { typeChecker, sourceFile, compilerHooks, vineFileCtx, vineCompFnCtx } = params
+  const propsInfo: Record<string, VinePropMeta> = {}
+
+  try {
+    const targetFn = sourceFile.getFirstDescendant(
+      (node) => {
+        // Function declaration: function ...() {}
+        if (!Node.isFunctionDeclaration(node)) {
+          // Variable declaration: const ... = () => {} / const ... = function() {}
+          if (
+            !Node.isVariableDeclaration(node)
+            || !node.getInitializer()
+            || (
+              !Node.isFunctionExpression(node.getInitializer())
+              && !Node.isArrowFunction(node.getInitializer())
+            )
+          ) {
+            return false
+          }
+        }
+
+        const body = (
+          Node.isFunctionDeclaration(node)
+            ? node.getBody()
+            : (node.getInitializer() as FunctionExpression | ArrowFunction).getBody()
+        )
+        if (!body) {
+          return false
+        }
+
+        // Look for return statement with tagged template literal tagged with `vine`
+        const returnStatement = body.getFirstDescendant(
+          node => (
+            Node.isReturnStatement(node)
+            && Node.isTaggedTemplateExpression(node.getExpression())
+            && (node.getExpression() as TaggedTemplateExpression | undefined)?.getTag().getText() === 'vine'
+          ),
+        )
+
+        const fnName = (
+          Node.isFunctionDeclaration(node)
+            ? node.getName()
+            : node.getNameNode()?.getText()
+        )
+
+        return !!returnStatement && fnName === vineCompFnCtx.fnName
+      },
+    ) as (FunctionDeclaration | VariableDeclaration)
+
+    const propsParams = (
+      Node.isFunctionDeclaration(targetFn)
+        ? targetFn.getParameters()
+        : (targetFn.getInitializer() as FunctionExpression | ArrowFunction).getParameters()
+    )[0]
+    const propsTypeAnnotation = propsParams.getTypeNode()!
+    const propsType = typeChecker.getTypeAtLocation(propsTypeAnnotation)
+
+    for (const prop of propsType.getProperties()) {
+      propsInfo[prop.getName()] = {
+        isFromMacroDefine: false,
+        isBool: isBooleanType(typeChecker, propsType),
+        isRequired: !prop.isOptional(),
+      }
+    }
+  }
+  catch (err) {
+    compilerHooks.onError(
+      vineErr(
+        { vineFileCtx, vineCompFnCtx },
+        {
+          msg: `Failed to resolve props type, err: ${err}`,
+          location: vineCompFnCtx.fnItselfNode?.params?.[0]?.loc,
+        },
+      ),
+    )
+  }
+
+  return propsInfo
+}

--- a/packages/compiler/src/ts-morph/resolve-props-type.ts
+++ b/packages/compiler/src/ts-morph/resolve-props-type.ts
@@ -37,85 +37,70 @@ function isBooleanType(
 export function resolveVineCompFnProps(params: {
   typeChecker: TypeChecker
   sourceFile: SourceFile
-  vineFileCtx: VineFileCtx
   vineCompFnCtx: VineCompFnCtx
-  compilerHooks: VineCompilerHooks
 }) {
-  const { typeChecker, sourceFile, compilerHooks, vineFileCtx, vineCompFnCtx } = params
+  const { typeChecker, sourceFile, vineCompFnCtx } = params
   const propsInfo: Record<string, VinePropMeta> = {}
 
-  try {
-    const targetFn = sourceFile.getFirstDescendant(
-      (node) => {
-        // Function declaration: function ...() {}
-        if (!Node.isFunctionDeclaration(node)) {
-          // Variable declaration: const ... = () => {} / const ... = function() {}
-          if (
-            !Node.isVariableDeclaration(node)
-            || !node.getInitializer()
-            || (
-              !Node.isFunctionExpression(node.getInitializer())
-              && !Node.isArrowFunction(node.getInitializer())
-            )
-          ) {
-            return false
-          }
-        }
-
-        const body = (
-          Node.isFunctionDeclaration(node)
-            ? node.getBody()
-            : (node.getInitializer() as FunctionExpression | ArrowFunction).getBody()
-        )
-        if (!body) {
+  const targetFn = sourceFile.getFirstDescendant(
+    (node) => {
+      // Function declaration: function ...() {}
+      if (!Node.isFunctionDeclaration(node)) {
+        // Variable declaration: const ... = () => {} / const ... = function() {}
+        if (
+          !Node.isVariableDeclaration(node)
+          || !node.getInitializer()
+          || (
+            !Node.isFunctionExpression(node.getInitializer())
+            && !Node.isArrowFunction(node.getInitializer())
+          )
+        ) {
           return false
         }
-
-        // Look for return statement with tagged template literal tagged with `vine`
-        const returnStatement = body.getFirstDescendant(
-          node => (
-            Node.isReturnStatement(node)
-            && Node.isTaggedTemplateExpression(node.getExpression())
-            && (node.getExpression() as TaggedTemplateExpression | undefined)?.getTag().getText() === 'vine'
-          ),
-        )
-
-        const fnName = (
-          Node.isFunctionDeclaration(node)
-            ? node.getName()
-            : node.getNameNode()?.getText()
-        )
-
-        return !!returnStatement && fnName === vineCompFnCtx.fnName
-      },
-    ) as (FunctionDeclaration | VariableDeclaration)
-
-    const propsParams = (
-      Node.isFunctionDeclaration(targetFn)
-        ? targetFn.getParameters()
-        : (targetFn.getInitializer() as FunctionExpression | ArrowFunction).getParameters()
-    )[0]
-    const propsTypeAnnotation = propsParams.getTypeNode()!
-    const propsType = typeChecker.getTypeAtLocation(propsTypeAnnotation)
-
-    for (const prop of propsType.getProperties()) {
-      propsInfo[prop.getName()] = {
-        isFromMacroDefine: false,
-        isBool: isBooleanType(typeChecker, propsType),
-        isRequired: !prop.isOptional(),
       }
+
+      const body = (
+        Node.isFunctionDeclaration(node)
+          ? node.getBody()
+          : (node.getInitializer() as FunctionExpression | ArrowFunction).getBody()
+      )
+      if (!body) {
+        return false
+      }
+
+      // Look for return statement with tagged template literal tagged with `vine`
+      const returnStatement = body.getFirstDescendant(
+        node => (
+          Node.isReturnStatement(node)
+          && Node.isTaggedTemplateExpression(node.getExpression())
+          && (node.getExpression() as TaggedTemplateExpression | undefined)?.getTag().getText() === 'vine'
+        ),
+      )
+
+      const fnName = (
+        Node.isFunctionDeclaration(node)
+          ? node.getName()
+          : node.getNameNode()?.getText()
+      )
+
+      return !!returnStatement && fnName === vineCompFnCtx.fnName
+    },
+  ) as (FunctionDeclaration | VariableDeclaration)
+
+  const propsParams = (
+    Node.isFunctionDeclaration(targetFn)
+      ? targetFn.getParameters()
+      : (targetFn.getInitializer() as FunctionExpression | ArrowFunction).getParameters()
+  )[0]
+  const propsTypeAnnotation = propsParams.getTypeNode()!
+  const propsType = typeChecker.getTypeAtLocation(propsTypeAnnotation)
+
+  for (const prop of propsType.getProperties()) {
+    propsInfo[prop.getName()] = {
+      isFromMacroDefine: false,
+      isBool: isBooleanType(typeChecker, propsType),
+      isRequired: !prop.isOptional(),
     }
-  }
-  catch (err) {
-    compilerHooks.onError(
-      vineErr(
-        { vineFileCtx, vineCompFnCtx },
-        {
-          msg: `Failed to resolve props type, err: ${err}`,
-          location: vineCompFnCtx.fnItselfNode?.params?.[0]?.loc,
-        },
-      ),
-    )
   }
 
   return propsInfo

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -12,6 +12,7 @@ import type {
   StringLiteral,
   TaggedTemplateExpression,
   TemplateLiteral,
+  TSType,
   TSTypeLiteral,
 } from '@babel/types'
 import type {
@@ -21,6 +22,7 @@ import type {
   SourceLocation as VueSourceLocation,
 } from '@vue/compiler-dom'
 import type MagicString from 'magic-string'
+import type { Project, TypeChecker } from 'ts-morph'
 import type { BARE_CALL_MACROS, VINE_MACROS } from './constants'
 
 // Types:
@@ -53,9 +55,14 @@ export type BabelFunctionNodeTypes =
 export type BabelFunctionParams = BabelFunctionNodeTypes['params']
 
 export declare type HMRCompFnsName = string | null
+export interface TsMorphCache {
+  project: Project
+  typeChecker: TypeChecker
+}
 
 export interface VineCompilerHooks {
   getCompilerCtx: () => VineCompilerCtx
+  getTsMorph: () => TsMorphCache
   onError: (err: VineDiagnostic) => void
   onWarn: (warn: VineDiagnostic) => void
   onBindFileCtx?: (fileId: string, fileCtx: VineFileCtx) => void
@@ -71,6 +78,7 @@ export interface VineCompilerOptions {
   preprocessOptions?: Record<string, any>
   postcssOptions?: any
   postcssPlugins?: any[]
+  disableTsMorph?: boolean
 }
 
 export interface VineStyleMeta {
@@ -84,7 +92,7 @@ export interface VineStyleMeta {
 }
 
 export interface VinePropMeta {
-  typeAnnotationRaw: string
+  typeAnnotationRaw?: string
   isFromMacroDefine: boolean
   isBool: boolean
   isRequired: boolean
@@ -93,7 +101,7 @@ export interface VinePropMeta {
   /** Source code node of given default value */
   default?: Node
   /** Declared identifier AST Node by vineProp */
-  declaredIdentifier?: Identifier
+  macroDeclaredIdentifier?: Identifier
 }
 
 export interface VineCompilerCtx {
@@ -183,7 +191,7 @@ export interface VineCompFnCtx {
   propsAlias: string
   props: Record<string, VinePropMeta>
   propsDefinitionBy: 'annotaion' | 'macro'
-  propsFormalParam?: TSTypeLiteral
+  propsFormalParam?: TSType
   emitsAlias: string
   emits: string[]
   emitsTypeParam?: TSTypeLiteral

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -191,7 +191,7 @@ export interface VineCompFnCtx {
   propsAlias: string
   props: Record<string, VinePropMeta>
   propsDefinitionBy: 'annotaion' | 'macro'
-  propsFormalParam?: TSType
+  propsFormalParamType?: TSType
   emitsAlias: string
   emits: string[]
   emitsTypeParam?: TSTypeLiteral

--- a/packages/compiler/src/validate.ts
+++ b/packages/compiler/src/validate.ts
@@ -981,7 +981,6 @@ function validatePropsForSingelFC(
 ) {
   const vineCompFnParams = fnItselfNode ? getFunctionParams(fnItselfNode) : []
   const vineCompFnParamsLength = vineCompFnParams.length
-  let vinePropMacroCallCount = 0
 
   const isCheckVinePropMacroCallPass = () => {
     // Check vineProp macro call,
@@ -993,7 +992,6 @@ function validatePropsForSingelFC(
         if (!isVineProp(node)) {
           return
         }
-        vinePropMacroCallCount += 1
         const macroCalleeName = getVineMacroCalleeName(node)
         if (!macroCalleeName) {
           return
@@ -1154,31 +1152,6 @@ function validatePropsForSingelFC(
         )
         isCheckFormalParamsPropPass = false
       }
-    }
-    else {
-      vineCompilerHooks.onError(
-        vineErr(
-          { vineFileCtx },
-          {
-            msg: 'Vine component function\'s props type annotation must be an object literal',
-            location: theOnlyFormalParamTypeAnnotation?.loc,
-          },
-        ),
-      )
-      isCheckFormalParamsPropPass = false
-    }
-
-    if (vinePropMacroCallCount > 0) {
-      vineCompilerHooks.onError(
-        vineErr(
-          { vineFileCtx },
-          {
-            msg: 'Vine component function\'s props can only be defined with formal parameter or `vineProp` macro calls, not both',
-            location: theOnlyFormalParam.loc,
-          },
-        ),
-      )
-      isCheckFormalParamsPropPass = false
     }
 
     // Still check if there're maybe some invalid `vineProp` macro call

--- a/packages/compiler/tests/__snapshots__/analyze.spec.ts.snap
+++ b/packages/compiler/tests/__snapshots__/analyze.spec.ts.snap
@@ -249,7 +249,10 @@ Node {
 exports[`test Vine compiler analyze > analyze vine component props by macro calls 1`] = `
 {
   "disabled": {
-    "declaredIdentifier": Node {
+    "isBool": true,
+    "isFromMacroDefine": true,
+    "isRequired": false,
+    "macroDeclaredIdentifier": Node {
       "end": 74,
       "loc": SourceLocation {
         "end": Position {
@@ -269,14 +272,14 @@ exports[`test Vine compiler analyze > analyze vine component props by macro call
       "start": 66,
       "type": "Identifier",
     },
-    "isBool": true,
-    "isFromMacroDefine": true,
-    "isRequired": false,
     "typeAnnotationRaw": "boolean",
     "validator": undefined,
   },
   "name": {
-    "declaredIdentifier": Node {
+    "isBool": false,
+    "isFromMacroDefine": true,
+    "isRequired": true,
+    "macroDeclaredIdentifier": Node {
       "end": 36,
       "loc": SourceLocation {
         "end": Position {
@@ -296,33 +299,10 @@ exports[`test Vine compiler analyze > analyze vine component props by macro call
       "start": 32,
       "type": "Identifier",
     },
-    "isBool": false,
-    "isFromMacroDefine": true,
-    "isRequired": true,
     "typeAnnotationRaw": "string",
     "validator": undefined,
   },
   "title": {
-    "declaredIdentifier": Node {
-      "end": 119,
-      "loc": SourceLocation {
-        "end": Position {
-          "column": 13,
-          "index": 119,
-          "line": 5,
-        },
-        "filename": undefined,
-        "identifierName": "title",
-        "start": Position {
-          "column": 8,
-          "index": 114,
-          "line": 5,
-        },
-      },
-      "name": "title",
-      "start": 114,
-      "type": "Identifier",
-    },
     "default": Node {
       "end": 152,
       "extra": {
@@ -350,6 +330,26 @@ exports[`test Vine compiler analyze > analyze vine component props by macro call
     "isBool": false,
     "isFromMacroDefine": true,
     "isRequired": false,
+    "macroDeclaredIdentifier": Node {
+      "end": 119,
+      "loc": SourceLocation {
+        "end": Position {
+          "column": 13,
+          "index": 119,
+          "line": 5,
+        },
+        "filename": undefined,
+        "identifierName": "title",
+        "start": Position {
+          "column": 8,
+          "index": 114,
+          "line": 5,
+        },
+      },
+      "name": "title",
+      "start": 114,
+      "type": "Identifier",
+    },
     "typeAnnotationRaw": "string",
     "validator": Node {
       "async": false,

--- a/packages/compiler/tests/analyze.spec.ts
+++ b/packages/compiler/tests/analyze.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { VineBindingTypes } from '../src/constants'
 import { compileVineTypeScriptFile } from '../src/index'
 import { sortStyleImport } from '../src/style/order'
-import { createMockTransformCtx } from './shared-utils'
+import { createMockTransformCtx } from './test-utils'
 
 // implement a function for excluding fields of an object
 function excludeFields<T extends Record<string, any>, K extends keyof T>(

--- a/packages/compiler/tests/test-utils.ts
+++ b/packages/compiler/tests/test-utils.ts
@@ -1,10 +1,11 @@
 import type { VineCompilerHooks, VineCompilerOptions } from '../src/types'
-import { createCompilerCtx } from '../src/index'
+import { createCompilerCtx, createTsMorph } from '../src/index'
 
 export function createMockTransformCtx(option: VineCompilerOptions = {}) {
   const mockCompilerCtx = createCompilerCtx(option)
   const mockCompilerHooks = {
     getCompilerCtx: () => mockCompilerCtx,
+    getTsMorph: () => createTsMorph(),
     onError: (err) => { mockCompilerCtx.vineCompileErrors.push(err) },
     onWarn: (warn) => { mockCompilerCtx.vineCompileWarnings.push(warn) },
     onBindFileCtx: (fileId, fileCtx) => mockCompilerCtx.fileCtxMap.set(fileId, fileCtx),

--- a/packages/compiler/tests/transform.spec.ts
+++ b/packages/compiler/tests/transform.spec.ts
@@ -1,7 +1,7 @@
 import { format } from 'prettier'
 import { describe, expect, it } from 'vitest'
 import { compileVineTypeScriptFile } from '../src/index'
-import { createMockTransformCtx } from './shared-utils'
+import { createMockTransformCtx } from './test-utils'
 
 const testContent = `
 import { ref } from 'vue'

--- a/packages/compiler/tests/validate.spec.ts
+++ b/packages/compiler/tests/validate.spec.ts
@@ -226,7 +226,7 @@ function App() {
 }`
     const { mockCompilerCtx, mockCompilerHooks } = createMockTransformCtx()
     compileVineTypeScriptFile(content, 'testVineComponentFunctionProps', { compilerHooks: mockCompilerHooks })
-    expect(mockCompilerCtx.vineCompileErrors.length).toMatchInlineSnapshot(`8`)
+    expect(mockCompilerCtx.vineCompileErrors.length).toMatchInlineSnapshot(`10`)
     expect(mockCompilerCtx.vineCompileErrors.map(err => err.msg))
       .toMatchInlineSnapshot(`
         [
@@ -238,6 +238,8 @@ function App() {
           "\`vineProp\` macro calls is not allowed when props with props formal parameter defined",
           "\`vineProp\` macro calls is not allowed when props with props formal parameter defined",
           "\`vineProp\` macro calls is not allowed when props with props formal parameter defined",
+          "Failed to resolve props type 'SomeExternalType1'. Error: Error: Could not find source file in project with the provided file name: testVineComponentFunctionProps",
+          "Failed to resolve props type 'SomeExternalType2'. Error: Error: Could not find source file in project with the provided file name: testVineComponentFunctionProps",
         ]
       `)
   })

--- a/packages/compiler/tests/validate.spec.ts
+++ b/packages/compiler/tests/validate.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { compileVineTypeScriptFile } from '../src/index'
-import { createMockTransformCtx } from './shared-utils'
+import { createMockTransformCtx } from './test-utils'
 
 describe('test Vine compiler validate', () => {
   it('validate no outside macro calls', () => {
@@ -226,7 +226,7 @@ function App() {
 }`
     const { mockCompilerCtx, mockCompilerHooks } = createMockTransformCtx()
     compileVineTypeScriptFile(content, 'testVineComponentFunctionProps', { compilerHooks: mockCompilerHooks })
-    expect(mockCompilerCtx.vineCompileErrors.length).toMatchInlineSnapshot(`10`)
+    expect(mockCompilerCtx.vineCompileErrors.length).toMatchInlineSnapshot(`8`)
     expect(mockCompilerCtx.vineCompileErrors.map(err => err.msg))
       .toMatchInlineSnapshot(`
         [
@@ -235,8 +235,6 @@ function App() {
           "\`vineProp\` macro call must be inside a \`const\` declaration",
           "\`vineProp\` macro call must be inside a \`const\` variable declaration",
           "If you're defining a Vine component function's props with formal parameter, it must be one and only identifier",
-          "Vine component function's props type annotation must be an object literal",
-          "Vine component function's props type annotation must be an object literal",
           "\`vineProp\` macro calls is not allowed when props with props formal parameter defined",
           "\`vineProp\` macro calls is not allowed when props with props formal parameter defined",
           "\`vineProp\` macro calls is not allowed when props with props formal parameter defined",

--- a/packages/language-service/src/vine-ctx.ts
+++ b/packages/language-service/src/vine-ctx.ts
@@ -2,10 +2,12 @@ import type { VineCompilerHooks, VineDiagnostic } from '@vue-vine/compiler'
 import {
   compileVineTypeScriptFile,
   createCompilerCtx,
+  createTsMorph,
 } from '@vue-vine/compiler'
 
-export function compileVineForVirtualCode(sourceFileName: string, source: string) {
+export function compileVineForVirtualCode(fileId: string, source: string) {
   const compilerCtx = createCompilerCtx({
+    disableTsMorph: true, // No need ts-morph to analyze props
     envMode: 'module',
     vueCompilerOptions: {
       // 'module' will break Volar virtual code's mapping
@@ -23,10 +25,11 @@ export function compileVineForVirtualCode(sourceFileName: string, source: string
     onError: err => vineCompileErrs.push(err),
     onWarn: warn => vineCompileWarns.push(warn),
     getCompilerCtx: () => compilerCtx,
+    getTsMorph: () => createTsMorph(fileId),
   }
   const vineFileCtx = compileVineTypeScriptFile(
     source,
-    sourceFileName,
+    fileId,
     {
       compilerHooks,
       babelParseOptions: {

--- a/packages/language-service/src/virtual-code.ts
+++ b/packages/language-service/src/virtual-code.ts
@@ -146,7 +146,7 @@ function buildMappings(chunks: Segment<VineCodeInformation>[]) {
 
 export function createVueVineCode(
   ts: typeof import('typescript'),
-  sourceFileName: string,
+  fileId: string,
   snapshotContent: string,
   compilerOptions: ts.CompilerOptions,
   vueCompilerOptions: VueCompilerOptions,
@@ -159,7 +159,7 @@ export function createVueVineCode(
     vineCompileErrs,
     vineCompileWarns,
     vineFileCtx,
-  } = compileVineForVirtualCode(sourceFileName, snapshotContent)
+  } = compileVineForVirtualCode(fileId, snapshotContent)
   const compileTime = (performance.now() - compileStartTime).toFixed(2)
 
   const tsCodeSegments: Segment<VineCodeInformation>[] = []
@@ -336,7 +336,7 @@ export function createVueVineCode(
     },
 
     get fileName() {
-      return sourceFileName
+      return fileId
     },
     get compileTime() {
       return compileTime
@@ -537,7 +537,7 @@ export function createVueVineCode(
     if (vineCompFn.propsDefinitionBy !== 'macro') {
       return
     }
-    const propsVarIdAstNode = vinePropMeta.declaredIdentifier
+    const propsVarIdAstNode = vinePropMeta.macroDeclaredIdentifier
     if (!propsVarIdAstNode) {
       return
     }

--- a/packages/language-service/src/virtual-code.ts
+++ b/packages/language-service/src/virtual-code.ts
@@ -482,8 +482,8 @@ export function createVueVineCode(
     else {
       // User provide a `props` formal parameter in the component function,
       // we should keep it in virtual code, and generate `context: ...` after it,
-      const formalParamNode = vineCompFn.propsFormalParam!
-      generateScriptUntil(formalParamNode.end!)
+      const formalParamTypeNode = vineCompFn.propsFormalParamType!
+      generateScriptUntil(formalParamTypeNode.end!)
 
       // Generate `context: { ... }` after `props: ...`
       tsCodeSegments.push(` & ${

--- a/packages/playground/src/components/page-header.vine.ts
+++ b/packages/playground/src/components/page-header.vine.ts
@@ -5,7 +5,7 @@ export function PageHeader() {
   const router = useRouter()
 
   const handleNavBtnClick = (
-    target: '/about' | '/style-order' | '/todolist',
+    target: string,
   ) => {
     router.push(
       route.path === target
@@ -41,6 +41,12 @@ export function PageHeader() {
         @click="handleNavBtnClick('/todolist')"
       >
         <span> TodoList </span>
+      </div>
+      <div
+        class="ml-2 px-4 py-2 rounded bg-teal-700:20 dark:bg-coolgray-100:20 cursor-pointer"
+        @click="handleNavBtnClick('/test-ts-morph')"
+      >
+        <span> ts morph </span>
       </div>
     </div>
   `

--- a/packages/playground/src/pages/test-ts-morph.vine.ts
+++ b/packages/playground/src/pages/test-ts-morph.vine.ts
@@ -1,0 +1,29 @@
+import type { TestProps } from '../types';
+
+export function TestTsMorphChild(props: TestProps) {
+  return vine`
+    <div class="p-2 bg-black text-white rounded-lg my-2">
+      <h3>Title: {{ title }}</h3>
+      <h4>Variant: {{ variant }}</h4>
+      <p>message: {{ message }}</p>
+      <p>err code: {{ errorCode }}</p>
+    </div>
+  `
+}
+
+export function TestTsMorph() {
+  return vine`
+    <div>
+      <h3>Test Ts Morph</h3>
+      <div class="flex-row">
+        <TestTsMorphChild
+          variant="success"
+          title="hello"
+          message="Hello, world!"
+        />
+
+        <TestTsMorphChild variant="error" title="error" errorCode="404" />
+      </div>
+    </div>
+`
+}

--- a/packages/playground/src/router.ts
+++ b/packages/playground/src/router.ts
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import { AboutPage } from './pages/about.vine'
 import { HomePage } from './pages/home.vine'
 import { StyleOrder } from './pages/style-order.vine'
+import { TestTsMorph } from './pages/test-ts-morph.vine'
 import TodoList from './pages/todolist.vine'
 
 const routes = [
@@ -9,6 +10,7 @@ const routes = [
   { path: '/about', component: AboutPage },
   { path: '/style-order', component: StyleOrder },
   { path: '/todolist', component: TodoList },
+  { path: '/test-ts-morph', component: TestTsMorph },
 ]
 
 const router = createRouter({

--- a/packages/playground/src/types.ts
+++ b/packages/playground/src/types.ts
@@ -1,0 +1,20 @@
+// Define base props
+interface BaseProps {
+  title: string
+}
+
+// Success variant prevents error props
+type SuccessProps = BaseProps & {
+  variant: 'success'
+  message: string
+  errorCode?: never // Prevents mixing
+}
+
+// Error variant prevents success props
+type ErrorProps = BaseProps & {
+  variant: 'error'
+  errorCode: string
+  message?: never // Prevents mixing
+}
+
+export type TestProps = SuccessProps | ErrorProps

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -28,7 +28,9 @@
     "prepublish": "pnpm run build"
   },
   "dependencies": {
-    "@vue-vine/compiler": "workspace:*"
+    "@vue-vine/compiler": "workspace:*",
+    "ts-morph": "^25.0.0",
+    "typescript": "^5.6.3"
   },
   "devDependencies": {
     "@types/hash-sum": "^1.0.2",

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -13,11 +13,14 @@ import {
   compileVineStyle,
   compileVineTypeScriptFile,
   createCompilerCtx,
+  createTsMorph,
 } from '@vue-vine/compiler'
 import { createLogger } from 'vite'
 import { QUERY_TYPE_STYLE, QUERY_TYPE_STYLE_EXTERNAL } from './constants'
 import { vineHMR } from './hot-update'
 import { parseQuery } from './parse-query'
+
+type TsMorphCache = ReturnType<Required<VineCompilerHooks>['getTsMorph']>
 
 function createVinePlugin(options: VineCompilerOptions = {}): PluginOption {
   const compilerCtx = createCompilerCtx({
@@ -37,9 +40,11 @@ function createVinePlugin(options: VineCompilerOptions = {}): PluginOption {
   }
 
   let transformPluginContext: TransformPluginContext
+  let tsMorphCache: TsMorphCache
 
   const compilerHooks: VineCompilerHooks = {
     getCompilerCtx: () => compilerCtx,
+    getTsMorph: () => tsMorphCache,
     onError: errMsg => compilerCtx.vineCompileErrors.push(errMsg),
     onWarn: warnMsg => compilerCtx.vineCompileWarnings.push(warnMsg),
     onBindFileCtx: (fileId, fileCtx) => compilerCtx.fileCtxMap.set(fileId, fileCtx),
@@ -154,6 +159,10 @@ function createVinePlugin(options: VineCompilerOptions = {}): PluginOption {
 
       // eslint-disable-next-line ts/no-this-alias
       transformPluginContext = this
+
+      if (!tsMorphCache) {
+        tsMorphCache = createTsMorph(id)
+      }
 
       return runCompileScript(code, id, ssr)
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,12 @@ importers:
       source-map-js:
         specifier: ^1.0.2
         version: 1.2.1
+      ts-morph:
+        specifier: ^25.0.0
+        version: 25.0.0
+      typescript:
+        specifier: ^5.6.3
+        version: 5.6.3
     devDependencies:
       '@types/hash-sum':
         specifier: ^1.0.0
@@ -524,6 +530,12 @@ importers:
       '@vue-vine/compiler':
         specifier: workspace:*
         version: link:../compiler
+      ts-morph:
+        specifier: ^25.0.0
+        version: 25.0.0
+      typescript:
+        specifier: ^5.6.3
+        version: 5.6.3
     devDependencies:
       '@types/hash-sum':
         specifier: ^1.0.2
@@ -2365,6 +2377,9 @@ packages:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
 
+  '@ts-morph/common@0.26.0':
+    resolution: {integrity: sha512-/RmKAtctStXqM5nECMQ46duT74Hoig/DBzhWXGHcodlDNrgRbsbwwHqSKFNbca6z9Xt/CUWMeXOsC9QEN1+rqw==}
+
   '@tsconfig/node18@18.2.4':
     resolution: {integrity: sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==}
 
@@ -3481,6 +3496,9 @@ packages:
   cockatiel@3.2.1:
     resolution: {integrity: sha512-gfrHV6ZPkquExvMh9IOkKsBzNDk6sDuZ6DdBGUBkvFnTCqCxzpuq48RySgP0AnaqQkw2zynOFj9yly6T1Q2G5Q==}
     engines: {node: '>=16'}
+
+  code-block-writer@13.0.3:
+    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -6871,6 +6889,9 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  ts-morph@25.0.0:
+    resolution: {integrity: sha512-ERPTUVO5qF8cEGJgAejGOsCVlbk8d0SDyiJsucKQT5XgqoZslv0Qml+gnui6Yy6o+uQqw5SestyW2HvlVtT/Sg==}
+
   tsconfck@3.1.4:
     resolution: {integrity: sha512-kdqWFGVJqe+KGYvlSO9NIaWn9jT1Ny4oKVzAJsKii5eoE9snzTJzL4+MMVOMn+fikWGFmKEylcXL710V/kIPJQ==}
     engines: {node: ^18 || >=20}
@@ -9616,6 +9637,12 @@ snapshots:
 
   '@trysound/sax@0.2.0': {}
 
+  '@ts-morph/common@0.26.0':
+    dependencies:
+      fast-glob: 3.3.2
+      minimatch: 9.0.5
+      path-browserify: 1.0.1
+
   '@tsconfig/node18@18.2.4': {}
 
   '@types/debug@4.1.12':
@@ -11192,6 +11219,8 @@ snapshots:
   cluster-key-slot@1.1.2: {}
 
   cockatiel@3.2.1: {}
+
+  code-block-writer@13.0.3: {}
 
   color-convert@1.9.3:
     dependencies:
@@ -15139,6 +15168,11 @@ snapshots:
       typescript: 5.6.3
 
   ts-interface-checker@0.1.13: {}
+
+  ts-morph@25.0.0:
+    dependencies:
+      '@ts-morph/common': 0.26.0
+      code-block-writer: 13.0.3
 
   tsconfck@3.1.4(typescript@5.6.3):
     optionalDependencies:


### PR DESCRIPTION
## Preview

<image alt="types" src="https://github.com/user-attachments/assets/80a7bc90-a72d-42b9-bb83-51aad9fce913" width="400px" />
<image alt="component" src="https://github.com/user-attachments/assets/2947684d-8312-4641-95da-199e7992a58e" width="400px" />

As you can see, we can even leverage fields intellisense from external type.

## Perfomance

It seems that compiling `.vine.ts` with ts-morph is still very fast
![image](https://github.com/user-attachments/assets/1cd715e0-1add-45b5-b122-0ce35267be95)
