### PR TITLE
fix(compiler): emits defined by names should be optional

### DIFF
--- a/packages/compiler/src/analyze.ts
+++ b/packages/compiler/src/analyze.ts
@@ -546,6 +546,7 @@ const analyzeVineEmits: AnalyzeRunner = (
   else if (isArrayExpression(callArg)) {
     // Save all the string elements of the array expression
     // as `vineCompFn.emits`
+    vineCompFnCtx.emitsDefinitionByNames = true
     callArg.elements.forEach((el) => {
       if (isStringLiteral(el)) {
         vineCompFnCtx.emits.push((el as StringLiteral).value)

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -195,6 +195,7 @@ export interface VineCompFnCtx {
   emitsAlias: string
   emits: string[]
   emitsTypeParam?: TSTypeLiteral
+  emitsDefinitionByNames?: boolean
   /** Store the `defineExpose`'s argument in source code */
   expose?: Node
   /** Store the `defineOptions`'s argument in source code */

--- a/packages/compiler/tests/analyze.spec.ts
+++ b/packages/compiler/tests/analyze.spec.ts
@@ -172,6 +172,7 @@ function MyComp() {
     const vineFnComp = fileCtx?.vineCompFns[0]
     expect(vineFnComp?.emitsAlias).toBe('myEmits')
     expect(vineFnComp?.emits).toEqual(['foo', 'bar'])
+    expect(vineFnComp?.emitsDefinitionByNames).toBe(true)
   })
 
   it('analyze vine slots definition', () => {

--- a/packages/language-service/src/virtual-code.ts
+++ b/packages/language-service/src/virtual-code.ts
@@ -395,7 +395,10 @@ export function createVueVineCode(
         // Convert `emit` to a camelCase Name
         const camelCaseEmit = emit.replace(/-([a-z])/g, (_, c) => c.toUpperCase())
         const onEmit = `on${camelCaseEmit.charAt(0).toUpperCase()}${camelCaseEmit.slice(1)}`
-        const isOptional = emitsOptionalKeys.length && emitsOptionalKeys.includes(emit)
+        const isOptional = (
+          vineCompFn.emitsDefinitionByNames
+          || (emitsOptionalKeys.length && emitsOptionalKeys.includes(emit))
+        )
 
         return `\n${' '.repeat(tabNum + 2)}${
           // '/* left linkCodeTag here ... */'

--- a/packages/playground/src/pages/test-ts-morph.vine.ts
+++ b/packages/playground/src/pages/test-ts-morph.vine.ts
@@ -5,8 +5,8 @@ export function TestTsMorphChild(props: TestProps) {
     <div class="p-2 bg-black text-white rounded-lg my-2">
       <h3>Title: {{ title }}</h3>
       <h4>Variant: {{ variant }}</h4>
-      <p>message: {{ message }}</p>
-      <p>err code: {{ errorCode }}</p>
+      <p v-if="message">message: {{ message }}</p>
+      <p v-if="errorCode">err code: {{ errorCode }}</p>
     </div>
   `
 }
@@ -25,5 +25,5 @@ export function TestTsMorph() {
         <TestTsMorphChild variant="error" title="error" errorCode="404" />
       </div>
     </div>
-`
+  `
 }


### PR DESCRIPTION
## Motivation

```ts
vineEmits(['foo', 'bar'])
```

`emits`'s definition like this should generate Volar virtual code as the following code:

```ts
emits: {
  foo?: __VINE_VLS_MyComp_emits__["foo"]
  bar?: __VINE_VLS_MyComp_emits__["bar"]
}
```