### PR TITLE
fix(vite-plugin): hot-updated module which are not `.vine.ts` should trigger Vine importer module updates

### DIFF
--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -31,12 +31,12 @@ export {
 
 export type {
   HMRCompFnsName,
+  VineCompFnCtx as VineFnCompCtx,
   VineCompilerCtx,
   VineCompilerHooks,
   VineCompilerOptions,
   VineDiagnostic,
   VineFileCtx,
-  VineCompFnCtx as VineFnCompCtx,
   VineProcessorLang,
   VinePropMeta,
 } from './types'
@@ -45,6 +45,14 @@ export {
   _breakableTraverse,
   exitTraverse,
 } from './utils'
+
+export {
+  topoSort,
+} from './utils/topo-sort'
+
+export type {
+  ComponentRelationsMap,
+} from './utils/topo-sort'
 
 export function createCompilerCtx(
   options: VineCompilerOptions = {},

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -31,12 +31,12 @@ export {
 
 export type {
   HMRCompFnsName,
-  VineCompFnCtx as VineFnCompCtx,
   VineCompilerCtx,
   VineCompilerHooks,
   VineCompilerOptions,
   VineDiagnostic,
   VineFileCtx,
+  VineCompFnCtx as VineFnCompCtx,
   VineProcessorLang,
   VinePropMeta,
 } from './types'

--- a/packages/compiler/src/style/order.ts
+++ b/packages/compiler/src/style/order.ts
@@ -1,52 +1,10 @@
 import type { ElementNode } from '@vue/compiler-dom'
 import type { VineFileCtx } from '../types'
+import type { ComponentRelationsMap } from '../utils/topo-sort'
 import { traverseTemplate } from '../template/traverse'
 import { isComponentNode, isTemplateElementNode } from '../template/type-predicate'
+import { topoSort } from '../utils/topo-sort'
 import { createStyleImportStmt } from './create-import-statement'
-
-type ComponentRelationsMap = Record<string, Set<string>>
-
-function topoSort(
-  relationsMap: Record<string, Set<string>>,
-): string[] | null {
-  const visited: Record<string, boolean> = {}
-  const sorted: string[] = []
-
-  function dfs(node: string, stack: Record<string, boolean>) {
-    if (stack[node]) {
-      // circle dependency detected
-      return null
-    }
-
-    if (visited[node])
-      return
-
-    visited[node] = true
-    stack[node] = true
-
-    for (const depNode of relationsMap[node]) {
-      const result = dfs(depNode, stack)
-      if (result === null) {
-        // sub-tree detected circle dependency, so just quit
-        return null
-      }
-    }
-
-    stack[node] = false
-    sorted.push(node)
-  }
-
-  for (const node of Object.keys(relationsMap)) {
-    dfs(node, {})
-  }
-
-  // If there're still some nodes not visited, it means there's a circle dependency.
-  if (sorted.length !== Object.keys(visited).length) {
-    return null
-  }
-
-  return sorted
-}
 
 /**
  * Sort the style import statements.

--- a/packages/compiler/src/transform.ts
+++ b/packages/compiler/src/transform.ts
@@ -558,7 +558,7 @@ export function transformFile(
     ms.appendRight(
       ms.length(),
       /* js */`export const _rerender_only = ${vineFileCtx.renderOnly}
-export const _rerender_vcf_fn_name = ${vineFileCtx.hmrCompFnsName ? `"${vineFileCtx.hmrCompFnsName!}"` : '""'}
+export const _rerender_vcf_fn_name = "${vineFileCtx.hmrCompFnsName ?? ""}"
 import.meta.hot?.accept((mod) => {
 if (!mod){return;}
 const { _rerender_only, _rerender_vcf_fn_name } = mod;

--- a/packages/compiler/src/transform.ts
+++ b/packages/compiler/src/transform.ts
@@ -558,7 +558,7 @@ export function transformFile(
     ms.appendRight(
       ms.length(),
       /* js */`export const _rerender_only = ${vineFileCtx.renderOnly}
-export const _rerender_vcf_fn_name = "${vineFileCtx.hmrCompFnsName ?? ""}"
+export const _rerender_vcf_fn_name = "${vineFileCtx.hmrCompFnsName ?? ''}"
 import.meta.hot?.accept((mod) => {
 if (!mod){return;}
 const { _rerender_only, _rerender_vcf_fn_name } = mod;

--- a/packages/compiler/src/utils/topo-sort.ts
+++ b/packages/compiler/src/utils/topo-sort.ts
@@ -1,0 +1,43 @@
+export type ComponentRelationsMap = Record<string, Set<string>>
+
+export function topoSort(
+  relationsMap: Record<string, Set<string>>,
+): string[] | null {
+  const visited: Record<string, boolean> = {}
+  const sorted: string[] = []
+
+  function dfs(node: string, stack: Record<string, boolean>) {
+    if (stack[node]) {
+      // circle dependency detected
+      return null
+    }
+
+    if (visited[node])
+      return
+
+    visited[node] = true
+    stack[node] = true
+
+    for (const depNode of relationsMap[node]) {
+      const result = dfs(depNode, stack)
+      if (result === null) {
+        // sub-tree detected circle dependency, so just quit
+        return null
+      }
+    }
+
+    stack[node] = false
+    sorted.push(node)
+  }
+
+  for (const node of Object.keys(relationsMap)) {
+    dfs(node, {})
+  }
+
+  // If there're still some nodes not visited, it means there's a circle dependency.
+  if (sorted.length !== Object.keys(visited).length) {
+    return null
+  }
+
+  return sorted
+}

--- a/packages/docs/src/zh/specification/macros.md
+++ b/packages/docs/src/zh/specification/macros.md
@@ -29,7 +29,6 @@ const myEmit = vineEmits(['update', 'delete'])
 ```
 
 Vue Vine 将会默认将所有事件视为 **必需** 的，但如果您在类型中使用 `?` 后缀或使用事件名称数组定义，它将被视为可选。
-
 ## `vineExpose` {#vineexpose}
 
 这个宏的使用方法与官方 `defineExpose` 宏完全一致。

--- a/packages/vite-plugin/src/hot-update.ts
+++ b/packages/vite-plugin/src/hot-update.ts
@@ -60,65 +60,65 @@ function patchModule(
   const nOriginCode = normalizeLineEndings(newVFCtx.originCode)
   const oOriginCode = normalizeLineEndings(oldVFCtx.originCode)
   for (let i = 0; i < nVineCompFns.length; i++) {
-    const nCompFns = nVineCompFns[i]
-    const oCompFns = oVineCompFns[i]
+    const nCompFn = nVineCompFns[i]
+    const oCompFn = oVineCompFns[i]
     if (
-      (!oCompFns || !nCompFns)
-      || (!oCompFns.fnItselfNode || !nCompFns.fnItselfNode)
+      (!oCompFn || !nCompFn)
+      || (!oCompFn.fnItselfNode || !nCompFn.fnItselfNode)
     ) {
       continue
     }
 
-    const nCompFnsTemplate = normalizeLineEndings(nCompFns.templateSource)
-    const oCompFnsTemplate = normalizeLineEndings(oCompFns.templateSource)
-    const nCompFnsStyles = nStyleDefine[nCompFns.scopeId]?.map(style => style.source ?? '')
-    const oCompFnsStyles = oStyleDefine[oCompFns.scopeId]?.map(style => style.source ?? '')
+    const nCompFnTemplate = normalizeLineEndings(nCompFn.templateSource)
+    const oCompFnTemplate = normalizeLineEndings(oCompFn.templateSource)
+    const nCompFnStyles = nStyleDefine[nCompFn.scopeId]?.map(style => style.source ?? '')
+    const oCompFnStyles = oStyleDefine[oCompFn.scopeId]?.map(style => style.source ?? '')
     // 1. Get component function AST Node range for its code content
-    const nCompFnCode = nOriginCode.substring(Number(nCompFns.fnItselfNode.start), Number((nCompFns.fnItselfNode!.end)))
-    const oCompFnCode = oOriginCode.substring(Number(oCompFns.fnItselfNode.start), Number((oCompFns.fnItselfNode!.end)))
+    const nCompFnCode = nOriginCode.substring(Number(nCompFn.fnItselfNode.start), Number((nCompFn.fnItselfNode!.end)))
+    const oCompFnCode = oOriginCode.substring(Number(oCompFn.fnItselfNode.start), Number((oCompFn.fnItselfNode!.end)))
     // 2. Clean template content
-    const nCompFnCodeNonTemplate = nCompFnCode.replace(nCompFnsTemplate, '')
-    const oCompFnCodeNonTemplate = oCompFnCode.replace(oCompFnsTemplate, '')
+    const nCompFnCodeNonTemplate = nCompFnCode.replace(nCompFnTemplate, '')
+    const oCompFnCodeNonTemplate = oCompFnCode.replace(oCompFnTemplate, '')
     // 3. Clean style content
     let nCompFnCodePure = nCompFnCodeNonTemplate
-    nCompFnsStyles?.forEach((style) => {
+    nCompFnStyles?.forEach((style) => {
       nCompFnCodePure = nCompFnCodePure.replace(style, '')
     })
     let oCompFnCodePure = oCompFnCodeNonTemplate
-    oCompFnsStyles?.forEach((style) => {
+    oCompFnStyles?.forEach((style) => {
       oCompFnCodePure = oCompFnCodePure.replace(style, '')
     })
 
     // Compare with the remaining characters without style and template interference
     // 4. If not equal, it means that the script has changed
     if (nCompFnCodePure !== oCompFnCodePure) {
-      patchRes.hmrCompFnsName = nCompFns.fnName
+      patchRes.hmrCompFnsName = nCompFn.fnName
       newVFCtx.renderOnly = false
     }
-    else if (nCompFnsTemplate !== oCompFnsTemplate) {
+    else if (nCompFnTemplate !== oCompFnTemplate) {
       // script equal, then compare template
-      patchRes.hmrCompFnsName = nCompFns.fnName
+      patchRes.hmrCompFnsName = nCompFn.fnName
       newVFCtx.renderOnly = true
     }
-    else if (!areStrArraysEqual(nCompFnsStyles, oCompFnsStyles)) {
+    else if (!areStrArraysEqual(nCompFnStyles, oCompFnStyles)) {
       // script and template equal, then compare style
-      const oCssBindingsVariables = Object.keys(oCompFns.cssBindings)
-      const nCssBindingsVariables = Object.keys(nCompFns.cssBindings)
+      const oCssBindingsVariables = Object.keys(oCompFn.cssBindings)
+      const nCssBindingsVariables = Object.keys(nCompFn.cssBindings)
       // No v-bind() before and after the change
       if (oCssBindingsVariables.length === 0 && nCssBindingsVariables.length === 0) {
         patchRes.type = 'style'
-        patchRes.scopeId = nCompFns.scopeId
+        patchRes.scopeId = nCompFn.scopeId
       }
       // The variables of v-bind() before and after the change are equal
       else if (areStrArraysEqual(oCssBindingsVariables, nCssBindingsVariables)) {
         patchRes.type = 'style'
-        patchRes.scopeId = nCompFns.scopeId
+        patchRes.scopeId = nCompFn.scopeId
       }
       else {
         patchRes.type = 'module'
       }
-      patchRes.hmrCompFnsName = nCompFns.fnName
-      patchRes.scopeId = nCompFns.scopeId
+      patchRes.hmrCompFnsName = nCompFn.fnName
+      patchRes.scopeId = nCompFn.scopeId
       newVFCtx.renderOnly = false
     }
   }
@@ -141,7 +141,7 @@ function patchVineFile(
   fileId: string,
   fileContent: string,
 ) {
-  // file changed !
+  // Nothing changed!
   if (fileContent === originVineFileCtx.originCode) {
     return
   }
@@ -230,5 +230,14 @@ export async function vineHMR(
       fileId,
       fileContent,
     )
+  }
+  else {
+    // Maybe not .vine.ts module,
+    // find `.vine.ts` module in `modules`
+    for (const mod of modules) {
+      if (mod.id?.endsWith('.vine.ts')) {
+        // ...
+      }
+    }
   }
 }

--- a/packages/vscode-ext/CHANGELOG.md
+++ b/packages/vscode-ext/CHANGELOG.md
@@ -1,5 +1,11 @@
 # vue-vine-extension
 
+## 0.2.2
+
+### Patch Changes
+
+- Decrease extension package size by bundling strategy.
+
 ## 0.2.1
 
 ### Patch Changes

--- a/packages/vscode-ext/package.json
+++ b/packages/vscode-ext/package.json
@@ -2,7 +2,7 @@
   "publisher": "ShenQingchuan",
   "name": "vue-vine-extension",
   "displayName": "Vue Vine",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "Vue Vine extension for syntax highlight and language features",
   "repository": {


### PR DESCRIPTION
Close #175 

## Summary

When a non-Vine module (like #175 `.mdx` file) is hot-updated, it should trigger its importers' update.

If the importer is a `.vine.ts`, we should topo sort all components' name to analyze their dependency relationship, and get the last item to call `__VUE_HMR_RUNTIME.rerender()`, it means re-render all the related Vine components.

Thanks demo from @libondev  https://github.com/libondev/vue-vine-with-mdx