### PR TITLE
enhance(vsc-ext): decrease extension bundle size

### DIFF
--- a/packages/compiler/src/analyze.ts
+++ b/packages/compiler/src/analyze.ts
@@ -413,6 +413,9 @@ const analyzeVineProps: AnalyzeRunner = (
       if (vineCompilerHooks.getCompilerCtx().options.disableTsMorph) {
         return
       }
+      if (!vineCompilerHooks.getTsMorph) {
+        throw new Error('ts-morph is not initialized')
+      }
 
       try {
         // Use ts-morph to analyze props info

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -62,7 +62,7 @@ export interface TsMorphCache {
 
 export interface VineCompilerHooks {
   getCompilerCtx: () => VineCompilerCtx
-  getTsMorph: () => TsMorphCache
+  getTsMorph?: () => TsMorphCache
   onError: (err: VineDiagnostic) => void
   onWarn: (warn: VineDiagnostic) => void
   onBindFileCtx?: (fileId: string, fileCtx: VineFileCtx) => void

--- a/packages/compiler/tests/test-utils.ts
+++ b/packages/compiler/tests/test-utils.ts
@@ -1,11 +1,10 @@
 import type { VineCompilerHooks, VineCompilerOptions } from '../src/types'
-import { createCompilerCtx, createTsMorph } from '../src/index'
+import { createCompilerCtx } from '../src/index'
 
 export function createMockTransformCtx(option: VineCompilerOptions = {}) {
   const mockCompilerCtx = createCompilerCtx(option)
   const mockCompilerHooks = {
     getCompilerCtx: () => mockCompilerCtx,
-    getTsMorph: () => createTsMorph(),
     onError: (err) => { mockCompilerCtx.vineCompileErrors.push(err) },
     onWarn: (warn) => { mockCompilerCtx.vineCompileWarnings.push(warn) },
     onBindFileCtx: (fileId, fileCtx) => mockCompilerCtx.fileCtxMap.set(fileId, fileCtx),

--- a/packages/language-service/src/vine-ctx.ts
+++ b/packages/language-service/src/vine-ctx.ts
@@ -2,7 +2,6 @@ import type { VineCompilerHooks, VineDiagnostic } from '@vue-vine/compiler'
 import {
   compileVineTypeScriptFile,
   createCompilerCtx,
-  createTsMorph,
 } from '@vue-vine/compiler'
 
 export function compileVineForVirtualCode(fileId: string, source: string) {
@@ -25,7 +24,6 @@ export function compileVineForVirtualCode(fileId: string, source: string) {
     onError: err => vineCompileErrs.push(err),
     onWarn: warn => vineCompileWarns.push(warn),
     getCompilerCtx: () => compilerCtx,
-    getTsMorph: () => createTsMorph(fileId),
   }
   const vineFileCtx = compileVineTypeScriptFile(
     source,

--- a/packages/vscode-ext/tsup.config.ts
+++ b/packages/vscode-ext/tsup.config.ts
@@ -26,14 +26,37 @@ const esbuildPlugins: Options['esbuildPlugins'] = [
       })
     },
   },
+
+  // Mock ts-morph dependency for '@vue-vine/compiler',
+  // in order to decrease the bundle size, because VSCode extension
+  // doesn't need ts-morph to analyze props
+  {
+    name: 'mock-ts-morph',
+    setup(build) {
+      build.onResolve({ filter: /^ts-morph$/ }, () => {
+        return {
+          path: 'ts-morph',
+          namespace: 'mock-ts-morph',
+        }
+      })
+      build.onLoad({ filter: /.*/, namespace: 'mock-ts-morph' }, () => {
+        return {
+          contents: 'export default {}',
+          loader: 'js',
+        }
+      })
+    },
+  },
 ]
 const sharedConfig: Partial<Options> = {
   format: 'cjs',
-  external: ['vscode'],
+  external: ['vscode', 'typescript'],
   minify: !isDev,
   bundle: true,
   sourcemap: isDev,
-  define: { 'process.env.NODE_ENV': '"production"' },
+  define: {
+    'process.env.NODE_ENV': '"production"',
+  },
   esbuildPlugins,
 }
 


### PR DESCRIPTION
## Before
```
> vue-vine-extension@0.2.3 build /home/shenqingchuan/vue-vine/packages/vscode-ext
> NODE_ENV=production tsup

CLI Building entry: {"client":"./src/index.ts","server":"./node_modules/@vue-vine/language-server/bin/vue-vine-language-server.js"}
CLI Using tsconfig: tsconfig.json
CLI Building entry: {"index":"src/typescript-plugin.ts"}
CLI Using tsconfig: tsconfig.json
CLI tsup v8.3.5
CLI Using tsup config: /home/shenqingchuan/vue-vine/packages/vscode-ext/tsup.config.ts
CLI tsup v8.3.5
CLI Using tsup config: /home/shenqingchuan/vue-vine/packages/vscode-ext/tsup.config.ts
CLI Target: esnext
CLI Target: esnext
CJS Build start
CLI Cleaning output folder
CJS Build start
CJS node_modules/@vue-vine/typescript-plugin/index.js 10.70 MB
CJS ⚡️ Build success in 787ms
CJS dist/client.js 373.18 KB
CJS dist/server.js 12.57 MB
CJS ⚡️ Build success in 786ms
```

## After
```
> vue-vine-extension@0.2.3 build /home/shenqingchuan/vue-vine/packages/vscode-ext
> NODE_ENV=production tsup

CLI Building entry: {"client":"./src/index.ts","server":"./node_modules/@vue-vine/language-server/bin/vue-vine-language-server.js"}
CLI Using tsconfig: tsconfig.json
CLI Building entry: {"index":"src/typescript-plugin.ts"}
CLI Using tsconfig: tsconfig.json
CLI tsup v8.3.5
CLI Using tsup config: /home/shenqingchuan/vue-vine/packages/vscode-ext/tsup.config.ts
CLI tsup v8.3.5
CLI Using tsup config: /home/shenqingchuan/vue-vine/packages/vscode-ext/tsup.config.ts
CLI Target: esnext
CLI Target: esnext
CJS Build start
CLI Cleaning output folder
CJS Build start
CJS node_modules/@vue-vine/typescript-plugin/index.js 1.62 MB
CJS ⚡️ Build success in 221ms
CJS dist/client.js 370.78 KB
CJS dist/server.js 3.46 MB
CJS ⚡️ Build success in 220ms
```