### PR TITLE
docs(specification/props): optimize title and fix wrong words

### DIFF
--- a/packages/docs/src/zh/specification/props.md
+++ b/packages/docs/src/zh/specification/props.md
@@ -32,9 +32,9 @@ function MyComponent(props: {
 }) { ... }
 ```
 
-### 使用更复杂类型 <code version>v0.2.0+</code> {#using-complex-type-v0-2-0}
+### 使用更复杂的类型 <code version>v0.2.0+</code> {#using-complex-type-v0-2-0}
 
-从 Vu Vine v0.2.0 版本开始，我们引入了 ts-morph 来解析 props 类型注解，因此您可以使用任何类型，而不仅仅是 `TSTypeLiteral`。
+从 Vue Vine v0.2.0 版本开始，我们引入了 ts-morph 来解析 props 类型注解，因此您可以使用任何类型，而不仅仅是 `TSTypeLiteral`。
 
 ```vue-vine
 import type { SomeExternalType } from '../path/to/somewhere'


### PR DESCRIPTION
optimize title and fix wrong words in  zh/specification/props.md

Chinese:
<img width="1070" alt="image" src="https://github.com/user-attachments/assets/913bab98-7649-425a-b66a-3c9d5c7181a9" />

English:
<img width="1068" alt="image" src="https://github.com/user-attachments/assets/08f1662f-d412-404c-85f5-189873d86f3e" />