### PR TITLE
fix(vue-vine): resolve `@vueuse/core` version abnormal

### DIFF
--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@iconify-json/mdi": "^1.2.1",
-    "@vueuse/core": "catalog:",
+    "@vueuse/core": "^12.3.0",
     "pinia": "^2.2.4",
     "sass": "^1.66.1",
     "vue": "catalog:",

--- a/packages/vue-vine/package.json
+++ b/packages/vue-vine/package.json
@@ -30,9 +30,14 @@
     "build": "tsup",
     "prepublish": "pnpm run build"
   },
+  "peerDependencies": {
+    "vue": ">=3"
+  },
   "dependencies": {
-    "@vue-vine/vite-plugin": "workspace:*",
-    "@vueuse/core": "catalog:"
+    "@vue-vine/vite-plugin": "workspace:^"
+  },
+  "devDependencies": {
+    "vue": "^3"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/vue-vine/src/index.ts
+++ b/packages/vue-vine/src/index.ts
@@ -1,4 +1,4 @@
-import { reactiveComputed } from '@vueuse/core'
+import { reactiveComputed } from './utils/reactive'
 
 export function useDefaults<P extends Record<string, any>>(props: P, defaults: Partial<P>) {
   return reactiveComputed(() => {

--- a/packages/vue-vine/src/utils/reactive.ts
+++ b/packages/vue-vine/src/utils/reactive.ts
@@ -1,0 +1,54 @@
+// copy from https://github.com/vueuse/vueuse/blob/main/packages/shared/toReactive/index.ts#L12
+
+import type { MaybeRef, UnwrapNestedRefs } from 'vue'
+import { computed, isRef, reactive, unref } from 'vue'
+
+/**
+ * Converts ref to reactive.
+ *
+ * @see https://vueuse.org/toReactive
+ * @param objectRef A ref of object
+ */
+export function toReactive<T extends object>(
+  objectRef: MaybeRef<T>,
+): UnwrapNestedRefs<T> {
+  if (!isRef(objectRef))
+    return reactive(objectRef)
+
+  const proxy = new Proxy({}, {
+    get(_, p, receiver) {
+      return unref(Reflect.get(objectRef.value, p, receiver))
+    },
+    set(_, p, value) {
+      if (isRef((objectRef.value as any)[p]) && !isRef(value))
+        (objectRef.value as any)[p].value = value
+      else
+        (objectRef.value as any)[p] = value
+      return true
+    },
+    deleteProperty(_, p) {
+      return Reflect.deleteProperty(objectRef.value, p)
+    },
+    has(_, p) {
+      return Reflect.has(objectRef.value, p)
+    },
+    ownKeys() {
+      return Object.keys(objectRef.value)
+    },
+    getOwnPropertyDescriptor() {
+      return {
+        enumerable: true,
+        configurable: true,
+      }
+    },
+  })
+
+  return reactive(proxy) as UnwrapNestedRefs<T>
+}
+
+/**
+ * Computed reactive object.
+ */
+export function reactiveComputed<T extends object>(fn: () => T): UnwrapNestedRefs<T> {
+  return toReactive(computed(fn))
+}

--- a/packages/vue-vine/tsup.config.ts
+++ b/packages/vue-vine/tsup.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
   },
   external: [
     '@vue-vine/vite-plugin',
-    '@vueuse/core',
+    'vue',
   ],
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,9 +57,6 @@ catalogs:
     '@vue/shared':
       specifier: ^3.5.13
       version: 3.5.13
-    '@vueuse/core':
-      specifier: ^10.4.1
-      version: 10.11.1
     eslint:
       specifier: ~9.10.0
       version: 9.10.0
@@ -258,7 +255,7 @@ importers:
         version: 0.64.1(postcss@8.4.49)(rollup@4.27.3)(vite@5.4.11(@types/node@20.17.6)(less@4.2.0)(sass@1.81.0)(terser@5.36.0))(vue@3.5.13(typescript@5.6.3))
       unplugin-auto-import:
         specifier: 'catalog:'
-        version: 0.18.5(@nuxt/kit@3.14.1592(magicast@0.3.5)(rollup@4.27.3))(@vueuse/core@11.3.0(vue@3.5.13(typescript@5.6.3)))(rollup@4.27.3)
+        version: 0.18.5(@nuxt/kit@3.14.1592(magicast@0.3.5)(rollup@4.27.3))(@vueuse/core@12.3.0(typescript@5.6.3))(rollup@4.27.3)
       vite:
         specifier: 'catalog:'
         version: 5.4.11(@types/node@20.17.6)(less@4.2.0)(sass@1.81.0)(terser@5.36.0)
@@ -557,8 +554,8 @@ importers:
         specifier: ^1.2.1
         version: 1.2.1
       '@vueuse/core':
-        specifier: 'catalog:'
-        version: 10.11.1(vue@3.5.13(typescript@5.6.3))
+        specifier: ^12.3.0
+        version: 12.3.0(typescript@5.6.3)
       pinia:
         specifier: ^2.2.4
         version: 2.2.6(typescript@5.6.3)(vue@3.5.13(typescript@5.6.3))
@@ -595,7 +592,7 @@ importers:
         version: 0.64.1(postcss@8.4.49)(rollup@4.27.3)(vite@5.4.11(@types/node@20.17.6)(less@4.2.0)(sass@1.81.0)(terser@5.36.0))(vue@3.5.13(typescript@5.6.3))
       unplugin-auto-import:
         specifier: 'catalog:'
-        version: 0.18.5(@nuxt/kit@3.14.1592(magicast@0.3.5)(rollup@4.27.3))(@vueuse/core@10.11.1(vue@3.5.13(typescript@5.6.3)))(rollup@4.27.3)
+        version: 0.18.5(@nuxt/kit@3.14.1592(magicast@0.3.5)(rollup@4.27.3))(@vueuse/core@12.3.0(typescript@5.6.3))(rollup@4.27.3)
       vite:
         specifier: 'catalog:'
         version: 5.4.11(@types/node@20.17.6)(less@4.2.0)(sass@1.81.0)(terser@5.36.0)
@@ -673,11 +670,12 @@ importers:
   packages/vue-vine:
     dependencies:
       '@vue-vine/vite-plugin':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../vite-plugin
-      '@vueuse/core':
-        specifier: 'catalog:'
-        version: 10.11.1(vue@3.5.13(typescript@5.6.3))
+    devDependencies:
+      vue:
+        specifier: ^3
+        version: 3.5.13(typescript@5.6.3)
 
 packages:
 
@@ -2815,11 +2813,11 @@ packages:
   '@vue/typescript-plugin@2.1.10':
     resolution: {integrity: sha512-NrS3BB3l5vuZHU4Vp8l9TbT5pC7VjBfwZKqc24dAXF3Z+dJyGs4mcC3zo59gUggLMQSah8mdXj8xqEfMkrps8w==}
 
-  '@vueuse/core@10.11.1':
-    resolution: {integrity: sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==}
-
   '@vueuse/core@11.3.0':
     resolution: {integrity: sha512-7OC4Rl1f9G8IT6rUfi9JrKiXy4bfmHhZ5x2Ceojy0jnd3mHNEvV4JaRygH362ror6/NZ+Nl+n13LPzGiPN8cKA==}
+
+  '@vueuse/core@12.3.0':
+    resolution: {integrity: sha512-cnV8QDKZrsyKC7tWjPbeEUz2cD9sa9faxF2YkR8QqNwfofgbOhmfIgvSYmkp+ttSvfOw4E6hLcQx15mRPr0yBA==}
 
   '@vueuse/integrations@11.3.0':
     resolution: {integrity: sha512-5fzRl0apQWrDezmobchoiGTkGw238VWESxZHazfhP3RM7pDSiyXy18QbfYkILoYNTd23HPAfQTJpkUc5QbkwTw==}
@@ -2862,17 +2860,17 @@ packages:
       universal-cookie:
         optional: true
 
-  '@vueuse/metadata@10.11.1':
-    resolution: {integrity: sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==}
-
   '@vueuse/metadata@11.3.0':
     resolution: {integrity: sha512-pwDnDspTqtTo2HwfLw4Rp6yywuuBdYnPYDq+mO38ZYKGebCUQC/nVj/PXSiK9HX5otxLz8Fn7ECPbjiRz2CC3g==}
 
-  '@vueuse/shared@10.11.1':
-    resolution: {integrity: sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==}
+  '@vueuse/metadata@12.3.0':
+    resolution: {integrity: sha512-M/iQHHjMffOv2npsw2ihlUx1CTiBwPEgb7DzByLq7zpg1+Ke8r7s9p5ybUWc5OIeGewtpY4Xy0R2cKqFqM8hFg==}
 
   '@vueuse/shared@11.3.0':
     resolution: {integrity: sha512-P8gSSWQeucH5821ek2mn/ciCk+MS/zoRKqdQIM3bHq6p7GXDAJLmnRRKmF5F65sAVJIfzQlwR3aDzwCn10s8hA==}
+
+  '@vueuse/shared@12.3.0':
+    resolution: {integrity: sha512-X3YD35GUeW0d5Gajcwv9jdLAJTV2Jdb/Ll6Ii2JIYcKLYZqv5wxyLeKtiQkqWmHg3v0J0ZWjDUMVOw2E7RCXfA==}
 
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -9983,16 +9981,6 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/core@10.11.1(vue@3.5.13(typescript@5.6.3))':
-    dependencies:
-      '@types/web-bluetooth': 0.0.20
-      '@vueuse/metadata': 10.11.1
-      '@vueuse/shared': 10.11.1(vue@3.5.13(typescript@5.6.3))
-      vue-demi: 0.14.10(vue@3.5.13(typescript@5.6.3))
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-      - vue
-
   '@vueuse/core@11.3.0(vue@3.5.13(typescript@5.6.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
@@ -10002,6 +9990,15 @@ snapshots:
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
+
+  '@vueuse/core@12.3.0(typescript@5.6.3)':
+    dependencies:
+      '@types/web-bluetooth': 0.0.20
+      '@vueuse/metadata': 12.3.0
+      '@vueuse/shared': 12.3.0(typescript@5.6.3)
+      vue: 3.5.13(typescript@5.6.3)
+    transitivePeerDependencies:
+      - typescript
 
   '@vueuse/integrations@11.3.0(change-case@5.4.4)(focus-trap@7.6.2)(vue@3.5.13(typescript@5.6.3))':
     dependencies:
@@ -10015,16 +10012,9 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/metadata@10.11.1': {}
-
   '@vueuse/metadata@11.3.0': {}
 
-  '@vueuse/shared@10.11.1(vue@3.5.13(typescript@5.6.3))':
-    dependencies:
-      vue-demi: 0.14.10(vue@3.5.13(typescript@5.6.3))
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-      - vue
+  '@vueuse/metadata@12.3.0': {}
 
   '@vueuse/shared@11.3.0(vue@3.5.13(typescript@5.6.3))':
     dependencies:
@@ -10032,6 +10022,12 @@ snapshots:
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
+
+  '@vueuse/shared@12.3.0(typescript@5.6.3)':
+    dependencies:
+      vue: 3.5.13(typescript@5.6.3)
+    transitivePeerDependencies:
+      - typescript
 
   abbrev@1.1.1: {}
 
@@ -14640,7 +14636,7 @@ snapshots:
       - supports-color
       - vue
 
-  unplugin-auto-import@0.18.5(@nuxt/kit@3.14.1592(magicast@0.3.5)(rollup@4.27.3))(@vueuse/core@10.11.1(vue@3.5.13(typescript@5.6.3)))(rollup@4.27.3):
+  unplugin-auto-import@0.18.5(@nuxt/kit@3.14.1592(magicast@0.3.5)(rollup@4.27.3))(@vueuse/core@12.3.0(typescript@5.6.3))(rollup@4.27.3):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.1.3(rollup@4.27.3)
@@ -14652,23 +14648,7 @@ snapshots:
       unplugin: 1.16.0
     optionalDependencies:
       '@nuxt/kit': 3.14.1592(magicast@0.3.5)(rollup@4.27.3)
-      '@vueuse/core': 10.11.1(vue@3.5.13(typescript@5.6.3))
-    transitivePeerDependencies:
-      - rollup
-
-  unplugin-auto-import@0.18.5(@nuxt/kit@3.14.1592(magicast@0.3.5)(rollup@4.27.3))(@vueuse/core@11.3.0(vue@3.5.13(typescript@5.6.3)))(rollup@4.27.3):
-    dependencies:
-      '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.1.3(rollup@4.27.3)
-      fast-glob: 3.3.2
-      local-pkg: 0.5.1
-      magic-string: 0.30.13
-      minimatch: 9.0.5
-      unimport: 3.13.2(rollup@4.27.3)
-      unplugin: 1.16.0
-    optionalDependencies:
-      '@nuxt/kit': 3.14.1592(magicast@0.3.5)(rollup@4.27.3)
-      '@vueuse/core': 11.3.0(vue@3.5.13(typescript@5.6.3))
+      '@vueuse/core': 12.3.0(typescript@5.6.3)
     transitivePeerDependencies:
       - rollup
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,6 @@ catalog:
   '@vue/compiler-ssr': ^3.4.38
   '@vue/language-core': ~2.1.10
   '@vue/language-service': ~2.1.10
-  '@vueuse/core': ^10.4.1
   '@volar/language-core': ~2.4.8
   '@volar/language-server': ~2.4.8
   '@volar/language-service': ~2.4.8


### PR DESCRIPTION
<img width="1343" alt="image" src="https://github.com/user-attachments/assets/2bc9c004-3dba-4705-825a-2966c5757102" />

This first fixes the above problems. Secondly, I think that' vue-vine' is a dependency of dev, and it should not be mandatory to install' @vueuse/core' in the installed project. Therefore, I localized the functions I used, which has the advantage of reducing a direct dependency.
> 这首先修复了以上问题，其次我认为 `vue-vine` 作为dev 的依赖，不应该强制要求安装的项目中也同步安装 `@vueuse/core` 所以我将使用到的功能本地化了，这么做的好处是减少了一个直接依赖