### PR TITLE
fix(lang-service): type check for passing props on slots element

### DIFF
--- a/packages/language-service/src/injectTypes.ts
+++ b/packages/language-service/src/injectTypes.ts
@@ -133,7 +133,7 @@ ${notPropsBindings.map(([name]) => {
   ${
     vineCompFn.propsDefinitionBy === 'annotaion'
       ? '...props,'
-      : '...{ /* No need append `props` due to vineProp */ }'
+      : '/* No props formal params */'
   }
 });
 const __VLS_localComponents = __VLS_ctx;

--- a/packages/language-service/src/virtual-code.ts
+++ b/packages/language-service/src/virtual-code.ts
@@ -257,6 +257,10 @@ export function createVueVineCode(
         inheritAttrs: false,
         templateRefNames: new Set(),
         destructuredPropNames: new Set(),
+
+        // Slots type virtual code helper
+        hasDefineSlots: Object.keys(vineCompFn.slots).length > 0,
+        slotsAssignName: 'context.slots',
       })
 
       for (const segment of generatedTemplate) {


### PR DESCRIPTION
## Description

### Before

There're no type checking while passing props on `<slots />` element

![image](https://github.com/user-attachments/assets/32331636-c11b-45ab-adac-68e87f62e79d)


### After

Type check is working!

![image](https://github.com/user-attachments/assets/202dbe95-31c1-47cb-a30e-2562e835f593)
