### PR TITLE
fix: props page title has a typo

### DIFF
--- a/packages/docs/src/specification/props.md
+++ b/packages/docs/src/specification/props.md
@@ -1,4 +1,4 @@
-# Propss
+# Props
 
 Maybe you started to learn how to define props type in Vue by using type constructors like `String`, `Number`, `Boolean`, etc, this is used for Vue's runtime type checking. In fact, Vue only cares about what the props' name is, to better distinguish from normal attributes. Even you provide types for runtime to check, it will only report a warning instead of throwing an exception to interrupt the program.
 


### PR DESCRIPTION
Propss -> Props

Not much, but honest work 🫡