### PR TITLE
fix(compiler): move hmr inject code to vite plugin

### DIFF
--- a/packages/compiler/src/transform.ts
+++ b/packages/compiler/src/transform.ts
@@ -834,28 +834,6 @@ export function transformFile(
     }
   }
 
-  // HMR helper code
-  if (isDev) {
-    ms.appendRight(
-      ms.length(),
-      /* js */`export const _rerender_only = ${vineFileCtx.renderOnly}
-export const _rerender_vcf_fn_name = "${vineFileCtx.hmrCompFnsName ?? ''}"
-if (import.meta.hot) {
-  import.meta.hot.accept((mod) => {
-    if (!mod) { return; }
-    const { _rerender_only, _rerender_vcf_fn_name } = mod;
-    if (!_rerender_vcf_fn_name) { return; }
-    const component = mod[_rerender_vcf_fn_name];
-    if (_rerender_only) {
-      __VUE_HMR_RUNTIME__.rerender(component.__hmrId, component.render);
-    } else {
-      __VUE_HMR_RUNTIME__.reload(component.__hmrId, component);
-    }
-  });
-}`,
-    )
-  }
-
   // Prepend all style import statements
   ms.prepend(`\n${styleImportStmts.join('\n')}\n`)
   // Prepend all imports

--- a/packages/compiler/tests/__snapshots__/transform.spec.ts.snap
+++ b/packages/compiler/tests/__snapshots__/transform.spec.ts.snap
@@ -187,25 +187,6 @@ export default MyApp;
 
 typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
   __VUE_HMR_RUNTIME__.createRecord(MyApp.__hmrId, MyApp);
-export const _rerender_only = false;
-export const _rerender_vcf_fn_name = "";
-if (import.meta.hot) {
-  import.meta.hot.accept((mod) => {
-    if (!mod) {
-      return;
-    }
-    const { _rerender_only, _rerender_vcf_fn_name } = mod;
-    if (!_rerender_vcf_fn_name) {
-      return;
-    }
-    const component = mod[_rerender_vcf_fn_name];
-    if (_rerender_only) {
-      __VUE_HMR_RUNTIME__.rerender(component.__hmrId, component.render);
-    } else {
-      __VUE_HMR_RUNTIME__.reload(component.__hmrId, component);
-    }
-  });
-}
 "
 `;
 
@@ -592,25 +573,6 @@ export default MyApp;
 
 typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
   __VUE_HMR_RUNTIME__.createRecord(MyApp.__hmrId, MyApp);
-export const _rerender_only = false;
-export const _rerender_vcf_fn_name = "";
-if (import.meta.hot) {
-  import.meta.hot.accept((mod) => {
-    if (!mod) {
-      return;
-    }
-    const { _rerender_only, _rerender_vcf_fn_name } = mod;
-    if (!_rerender_vcf_fn_name) {
-      return;
-    }
-    const component = mod[_rerender_vcf_fn_name];
-    if (_rerender_only) {
-      __VUE_HMR_RUNTIME__.rerender(component.__hmrId, component.render);
-    } else {
-      __VUE_HMR_RUNTIME__.reload(component.__hmrId, component);
-    }
-  });
-}
 "
 `;
 
@@ -814,25 +776,6 @@ export default MyApp;
 
 typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
   __VUE_HMR_RUNTIME__.createRecord(MyApp.__hmrId, MyApp);
-export const _rerender_only = false;
-export const _rerender_vcf_fn_name = "";
-if (import.meta.hot) {
-  import.meta.hot.accept((mod) => {
-    if (!mod) {
-      return;
-    }
-    const { _rerender_only, _rerender_vcf_fn_name } = mod;
-    if (!_rerender_vcf_fn_name) {
-      return;
-    }
-    const component = mod[_rerender_vcf_fn_name];
-    if (_rerender_only) {
-      __VUE_HMR_RUNTIME__.rerender(component.__hmrId, component.render);
-    } else {
-      __VUE_HMR_RUNTIME__.reload(component.__hmrId, component);
-    }
-  });
-}
 "
 `;
 
@@ -869,25 +812,6 @@ export default MyComp;
 
 typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
   __VUE_HMR_RUNTIME__.createRecord(MyComp.__hmrId, MyComp);
-export const _rerender_only = false;
-export const _rerender_vcf_fn_name = "";
-if (import.meta.hot) {
-  import.meta.hot.accept((mod) => {
-    if (!mod) {
-      return;
-    }
-    const { _rerender_only, _rerender_vcf_fn_name } = mod;
-    if (!_rerender_vcf_fn_name) {
-      return;
-    }
-    const component = mod[_rerender_vcf_fn_name];
-    if (_rerender_only) {
-      __VUE_HMR_RUNTIME__.rerender(component.__hmrId, component.render);
-    } else {
-      __VUE_HMR_RUNTIME__.reload(component.__hmrId, component);
-    }
-  });
-}
 "
 `;
 
@@ -933,25 +857,6 @@ export const About = (() => {
 
 typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
   __VUE_HMR_RUNTIME__.createRecord(About.__hmrId, About);
-export const _rerender_only = false;
-export const _rerender_vcf_fn_name = "";
-if (import.meta.hot) {
-  import.meta.hot.accept((mod) => {
-    if (!mod) {
-      return;
-    }
-    const { _rerender_only, _rerender_vcf_fn_name } = mod;
-    if (!_rerender_vcf_fn_name) {
-      return;
-    }
-    const component = mod[_rerender_vcf_fn_name];
-    if (_rerender_only) {
-      __VUE_HMR_RUNTIME__.rerender(component.__hmrId, component.render);
-    } else {
-      __VUE_HMR_RUNTIME__.reload(component.__hmrId, component);
-    }
-  });
-}
 "
 `;
 
@@ -1024,25 +929,6 @@ export const MyComp = (() => {
 
 typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
   __VUE_HMR_RUNTIME__.createRecord(MyComp.__hmrId, MyComp);
-export const _rerender_only = false;
-export const _rerender_vcf_fn_name = "";
-if (import.meta.hot) {
-  import.meta.hot.accept((mod) => {
-    if (!mod) {
-      return;
-    }
-    const { _rerender_only, _rerender_vcf_fn_name } = mod;
-    if (!_rerender_vcf_fn_name) {
-      return;
-    }
-    const component = mod[_rerender_vcf_fn_name];
-    if (_rerender_only) {
-      __VUE_HMR_RUNTIME__.rerender(component.__hmrId, component.render);
-    } else {
-      __VUE_HMR_RUNTIME__.reload(component.__hmrId, component);
-    }
-  });
-}
 "
 `;
 
@@ -1099,24 +985,5 @@ export const MyComp = (() => {
 
 typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
   __VUE_HMR_RUNTIME__.createRecord(MyComp.__hmrId, MyComp);
-export const _rerender_only = false;
-export const _rerender_vcf_fn_name = "";
-if (import.meta.hot) {
-  import.meta.hot.accept((mod) => {
-    if (!mod) {
-      return;
-    }
-    const { _rerender_only, _rerender_vcf_fn_name } = mod;
-    if (!_rerender_vcf_fn_name) {
-      return;
-    }
-    const component = mod[_rerender_vcf_fn_name];
-    if (_rerender_only) {
-      __VUE_HMR_RUNTIME__.rerender(component.__hmrId, component.render);
-    } else {
-      __VUE_HMR_RUNTIME__.reload(component.__hmrId, component);
-    }
-  });
-}
 "
 `;

--- a/packages/compiler/tests/transform.spec.ts
+++ b/packages/compiler/tests/transform.spec.ts
@@ -250,25 +250,6 @@ export function MyComp() {
 
       typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
         __VUE_HMR_RUNTIME__.createRecord(MyComp.__hmrId, MyComp);
-      export const _rerender_only = false;
-      export const _rerender_vcf_fn_name = "";
-      if (import.meta.hot) {
-        import.meta.hot.accept((mod) => {
-          if (!mod) {
-            return;
-          }
-          const { _rerender_only, _rerender_vcf_fn_name } = mod;
-          if (!_rerender_vcf_fn_name) {
-            return;
-          }
-          const component = mod[_rerender_vcf_fn_name];
-          if (_rerender_only) {
-            __VUE_HMR_RUNTIME__.rerender(component.__hmrId, component.render);
-          } else {
-            __VUE_HMR_RUNTIME__.reload(component.__hmrId, component);
-          }
-        });
-      }
       "
     `)
   })

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -17,7 +17,7 @@ import {
 } from '@vue-vine/compiler'
 import { createLogger } from 'vite'
 import { QUERY_TYPE_STYLE, QUERY_TYPE_STYLE_EXTERNAL } from './constants'
-import { vineHMR } from './hot-update'
+import { addHMRHelperCode, vineHMR } from './hot-update'
 import { parseQuery } from './parse-query'
 
 type TsMorphCache = ReturnType<Required<VineCompilerHooks>['getTsMorph']>
@@ -74,6 +74,9 @@ function createVinePlugin(options: VineCompilerOptions = {}): PluginOption {
       }
     }
     compilerCtx.vineCompileWarnings.length = 0
+
+    // Inject `import.meta.hot.accept`
+    addHMRHelperCode(vineFileCtx)
 
     return {
       code: vineFileCtx.fileMagicCode.toString(),


### PR DESCRIPTION
Currently, we're injecting some HMR helper code in compiler's transform phase, which is not correct, compiler should be a bundler-framework agnostic package.

`import.meta.hot` is only available in Vite, and we're planning to integrate with Rspack in the future.