### PR TITLE
fix(lang-service): conflicts with implicit any

### DIFF
--- a/packages/language-service/src/injectTypes.ts
+++ b/packages/language-service/src/injectTypes.ts
@@ -49,11 +49,14 @@ export function generateGlobalTypes(vueOptions: VueCompilerOptions) {
     /declare global\s*\{/,
     `declare global {
   const VUE_VINE_COMPONENT: unique symbol;
-  type StrictIsAny<T> = [unknown] extends [T]
+  type __StrictIsAny<T> = [unknown] extends [T]
     ? ([T] extends [unknown] ? true : false)
     : false;
+  type __OmitAny<T> = {
+    [K in keyof T as __StrictIsAny<T[K]> extends true ? never : K]: T[K]
+  }
   type MakeVLSCtx<T extends object> = {
-    [K in keyof T as StrictIsAny<T[K]> extends true ? never : K]: T[K]
+    [K in keyof T]: T[K]
   }
   const __createVineVLSCtx: <T>(ctx: T) => MakeVLSCtx<import('vue').UnwrapRef<T>>;
   type VueVineComponent = __VLS_Element;
@@ -149,11 +152,11 @@ ${notPropsBindings.map(([name]) => {
   }
 });
 const __VLS_localComponents = __VLS_ctx;
+type __VLS_LocalComponents = __OmitAny<typeof __VLS_localComponents>;
 const __VLS_components = {
   ...{} as __VLS_GlobalComponents,
-  ...__VLS_localComponents,
+  ...__VLS_localComponents as __VLS_LocalComponents,
 };
-type __VLS_LocalComponents = typeof __VLS_localComponents;
 `
 
   return __VINE_CONTEXT_TYPES

--- a/packages/playground/src/pages/about.vine.ts
+++ b/packages/playground/src/pages/about.vine.ts
@@ -1,4 +1,5 @@
-import { ref, Ref } from 'vue'
+import type { Ref } from 'vue';
+import { ref } from 'vue'
 //           ^^^^ Deliberately import an extra useless type item here
 //                - For ESLint rules to catch it
 //                - Test if it broke compilation in JS runtime
@@ -35,11 +36,14 @@ function TestSlotContainer({ fizz, bar = 1 }: {
   `
 }
 
+declare const useRequest: <T = any>(url: string) => { data: Ref<T> }
+
 export function AboutPage() {
   const handleEmitCamel = (bar: string) => {
     console.log(bar)
   }
   const testSlotContainerText = ref('')
+  const { data: testDataRef } = useRequest('...')
 
   return vine`
     <PageHeader />
@@ -49,6 +53,7 @@ export function AboutPage() {
     <p class="my-4">
       TestSlotContainer text: {{ testSlotContainerText ?? "__Empty__" }}
     </p>
+    {{ testDataRef }}
     <TestSlotContainer
       fizz="bass"
       :bar="10"
@@ -56,8 +61,8 @@ export function AboutPage() {
       v-model="testSlotContainerText"
     >
       <template #slotCamel="{ foo }">
-      <p>in slot: {{ foo }}</p>
-    </template>
-  </TestSlotContainer>
-`
+        <p>in slot: {{ foo }}</p>
+      </template>
+    </TestSlotContainer>
+  `
 }

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -1,3 +1,4 @@
+import type { SassPreprocessorOptions } from 'vite'
 import path from 'node:path'
 import UnoCSS from 'unocss/vite'
 import AutoImport from 'unplugin-auto-import/vite'
@@ -15,8 +16,8 @@ const configForSassAndScss = {
 export default defineConfig({
   css: {
     preprocessorOptions: {
-      sass: configForSassAndScss,
-      scss: configForSassAndScss,
+      sass: configForSassAndScss as SassPreprocessorOptions,
+      scss: configForSassAndScss as SassPreprocessorOptions,
     },
   },
   resolve: {


### PR DESCRIPTION
Mentioned by @Soya-xy 

Some `any` type bindings that exported to template is omitted.
![image](https://github.com/user-attachments/assets/c1a70b23-1f2f-4a5d-9ffd-7b7d3c2334ee)

It's a mistake while fixing #171 , now we omit any in correct position.
