### PR TITLE
fix(compiler): auto-import components're broken in prod mode

### DIFF
--- a/packages/compiler/src/template/compose.ts
+++ b/packages/compiler/src/template/compose.ts
@@ -23,7 +23,7 @@ export function postProcessForRenderCodegen(codegen: string) {
       /=\s*_resolveComponent\(['"](.+?)['"]\)/g,
       (match, componentName) => {
         const pascalComponentName = toPascalCase(componentName)
-        return `= (typeof ${pascalComponentName} === 'undefined' ? _resolveComponent('${componentName}') : ${pascalComponentName})`
+        return `= (typeof ${pascalComponentName} === 'undefined' ? _resolveComponent('${componentName}') : ${pascalComponentName});`
       },
     )
 }

--- a/packages/compiler/src/template/compose.ts
+++ b/packages/compiler/src/template/compose.ts
@@ -11,6 +11,23 @@ import { vineErr, vineWarn } from '../diagnostics'
 import { appendToMapArray } from '../utils'
 import { walkVueTemplateAst } from './walk'
 
+function toPascalCase(str: string) {
+  return str.replace(/(?:^|-)(\w)/g, (_, c) => c.toUpperCase())
+}
+export function postProcessForRenderCodegen(codegen: string) {
+  return codegen
+    // https://github.com/vue-vine/vue-vine/issues/171
+    // Replace all `= _resolveComponent('...')`, '...' is the component name,
+    // to `= (typeof <toPascalCase('...')> === 'undefined' ? _resolveComponent('...') : <toPascalCase('...')>)`
+    .replace(
+      /=\s*_resolveComponent\(['"](.+?)['"]\)/g,
+      (match, componentName) => {
+        const pascalComponentName = toPascalCase(componentName)
+        return `= (typeof ${pascalComponentName} === 'undefined' ? _resolveComponent('${componentName}') : ${pascalComponentName})`
+      },
+    )
+}
+
 export function compileVineTemplate(
   source: string,
   params: Partial<CompilerOptions>,
@@ -335,12 +352,14 @@ export function createSeparatedTemplateComposer(
       }
       templateCompileResults.set(
         vineCompFnCtx,
-        code.slice(
-          exportRenderFnNode.start!,
-          exportRenderFnNode.end!,
-        ).replace(
-          ssr ? 'export function ssrRender' : 'export function render',
-          ssr ? 'function __sfc_ssr_render' : 'function __sfc_render',
+        postProcessForRenderCodegen(
+          code.slice(
+            exportRenderFnNode.start!,
+            exportRenderFnNode.end!,
+          ).replace(
+            ssr ? 'export function ssrRender' : 'export function render',
+            ssr ? 'function __sfc_ssr_render' : 'function __sfc_render',
+          ),
         ),
       )
 
@@ -488,10 +507,11 @@ export function createInlineTemplateComposer(
 
       // For inline mode, we can directly store the generated code,
       // it's an inline render function
-      templateCompileResults.set(vineCompFnCtx, code)
+      const finalCode = postProcessForRenderCodegen(code)
+      templateCompileResults.set(vineCompFnCtx, finalCode)
 
       // For inline mode, the setup function's return expression is the render function
-      return code
+      return finalCode
     },
   }
 }

--- a/packages/compiler/src/transform.ts
+++ b/packages/compiler/src/transform.ts
@@ -185,24 +185,6 @@ function propsOptionsCodeGeneration(
   ]
 }
 
-function toPascalCase(str: string) {
-  return str.replace(/(?:^|-)(\w)/g, (_, c) => c.toUpperCase())
-}
-
-function postProcessForRenderCodegen(codegen: string) {
-  return codegen
-    // https://github.com/vue-vine/vue-vine/issues/171
-    // Replace all `= _resolveComponent('...')`, '...' is the component name,
-    // to `= (typeof <toPascalCase('...')> === 'undefined' ? _resolveComponent('...') : <toPascalCase('...')>)`
-    .replace(
-      /=\s*_resolveComponent\(['"](.+?)['"]\)/g,
-      (match, componentName) => {
-        const pascalComponentName = toPascalCase(componentName)
-        return `= (typeof ${pascalComponentName} === 'undefined' ? _resolveComponent('${componentName}') : ${pascalComponentName})`
-      },
-    )
-}
-
 function rewriteDestructuredPropAccess(
   compilerHooks: VineCompilerHooks,
   vineFileCtx: VineFileCtx,
@@ -805,7 +787,7 @@ export function transformFile(
       // Not-inline mode, we need manually add the
       // render function to the component object.
         : `${
-          postProcessForRenderCodegen(templateCompileResults.get(vineCompFnCtx) ?? '')
+          templateCompileResults.get(vineCompFnCtx) ?? ''
         }\n__vine.${ssr ? 'ssrRender' : 'render'} = ${ssr ? '__sfc_ssr_render' : '__sfc_render'}`
     }\n${
       showIf(

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -14,6 +14,9 @@ const configForSassAndScss = {
 }
 
 export default defineConfig({
+  build: {
+    minify: false,
+  },
   css: {
     preprocessorOptions: {
       sass: configForSassAndScss as SassPreprocessorOptions,


### PR DESCRIPTION
in Vue compiler's generated render code, there will be something like the following example 
when you're using `unplugin-auto-import`, because you didn't write any import statement explicitly in source code.

```ts
const _component_PageHeader = _resolveComponent("PageHeader")
```

But before `unplugin-auto-import` (this is a Vite plugin) handles your code in Vite transform pipeline, the code must contain that identifier `PageHeader` as reference, so that it can be recognized.

so we transform this in Vine plugin phase:

```ts
const _component_PageHeader = (typeof PageHeader === 'undefined' ? _resolveComponent("PageHeader") : PageHeader);
```