### PR TITLE
feat(language-service): implement pipe server for component info

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build:ls": "pnpm --filter @vue-vine/compiler --filter @vue-vine/language-service --filter @vue-vine/language-server --filter vue-vine-tsc run build",
     "build:eslint": "pnpm --filter @vue-vine/eslint-parser --filter @vue-vine/eslint-plugin --filter @vue-vine/eslint-config run build",
     "build:ext": "pnpm run build:ls && pnpm --filter vue-vine-extension run build",
+    "debug:ext": "pnpm run build:ls && pnpm --filter vue-vine-extension run build:debug",
     "test": "NODE_ENV=test pnpm --parallel --filter @vue-vine/compiler --filter @vue-vine/e2e-test --filter @vue-vine/eslint-parser --filter @vue-vine/nuxt --filter vue-vine run test --run",
     "test:compiler": "pnpm --filter @vue-vine/compiler run test --run",
     "test:e2e": "pnpm --filter @vue-vine/e2e-test run test --run",

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -49,10 +49,12 @@
     "volar-service-html": "0.0.62",
     "volar-service-typescript": "0.0.62",
     "vscode-languageserver-protocol": "^3.17.5",
-    "vscode-languageserver-textdocument": "^1.0.12"
+    "vscode-languageserver-textdocument": "^1.0.12",
+    "ws": "^8.18.1"
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "@types/ws": "^8.5.14",
     "@vue/shared": "catalog:",
     "vscode-html-languageservice": "^5.3.0",
     "vscode-uri": "catalog:"

--- a/packages/language-server/src/pipeline/get-component-props.ts
+++ b/packages/language-server/src/pipeline/get-component-props.ts
@@ -1,0 +1,67 @@
+import type { VueVineCode } from '@vue-vine/language-service'
+import type * as ts from 'typescript'
+import type { HtmlTagInfo, PipelineStatus } from '../types'
+import { pipelineRequest, tryParsePipelineResponse } from '@vue-vine/language-service'
+import { WebSocket } from 'ws'
+import { getPipelineServerPort } from './get-pipeline-server-port'
+
+interface GetComponentPropsContext {
+  vineVirtualCode: VueVineCode
+  tagInfos: Map<string, HtmlTagInfo>
+  pipelineStatus: PipelineStatus
+  tsConfigFileName: string
+  tsHost: ts.System
+}
+
+export function getComponentPropsFromPipeline(
+  tag: string,
+  {
+    tagInfos,
+    vineVirtualCode,
+    pipelineStatus,
+    tsConfigFileName,
+    tsHost,
+  }: GetComponentPropsContext,
+) {
+  const port = getPipelineServerPort(tsConfigFileName, tsHost)
+  const pipelineClient = new WebSocket(`ws://localhost:${port}`)
+  const requestPromise = new Promise<void>((resolve, reject) => {
+    pipelineClient.on('open', () => {
+      pipelineClient.on('message', (msgData) => {
+        const resp = tryParsePipelineResponse(msgData.toString(), (err) => {
+          reject(err)
+        })
+        if (!resp) {
+          const err = new Error(
+            '[Vue Vine Pipeline] Invalid pipeline response data',
+            { cause: msgData.toString() },
+          )
+          reject(err)
+          return
+        }
+
+        console.log(`Pipeline: Got message`, JSON.stringify(resp, null, 2))
+        if (resp.type === 'getComponentPropsResponse') {
+          tagInfos.set(tag, {
+            props: [...resp.props],
+            events: [],
+          })
+          resolve()
+        }
+      })
+
+      console.log(`Pipeline: Fetching component '${tag}' props`)
+      pipelineClient.send(
+        pipelineRequest({
+          type: 'getComponentPropsRequest',
+          componentName: tag,
+          fileName: vineVirtualCode.fileName,
+        }),
+      )
+    })
+  }).finally(() => {
+    pipelineClient.close()
+    pipelineStatus.pendingRequest.delete('getComponentPropsRequest')
+  })
+  pipelineStatus.pendingRequest.set('getComponentPropsRequest', requestPromise)
+}

--- a/packages/language-server/src/pipeline/get-pipeline-server-port.ts
+++ b/packages/language-server/src/pipeline/get-pipeline-server-port.ts
@@ -1,0 +1,34 @@
+import type * as ts from 'typescript'
+import { dirname, join } from 'node:path'
+
+const DEFAULT_PIPELINE_SERVER_PORT = 15193
+
+export function getPipelineServerPort(
+  tsConfigFileName: string,
+  tsHost: ts.System,
+): number {
+  // Find `node_modules/.vine-pipeline-port` file
+  // and read the port number from it
+  let dir = dirname(tsConfigFileName)
+  while (!tsHost.fileExists(join(dir, 'node_modules', '.vine-pipeline-port'))) {
+    const parentDir = dirname(dir)
+    if (parentDir === dir) {
+      // Failed to find `node_modules` directory
+      return DEFAULT_PIPELINE_SERVER_PORT
+    }
+    dir = parentDir
+  }
+
+  const portFilePath = join(dir, 'node_modules', '.vine-pipeline-port')
+  if (tsHost.fileExists(portFilePath)) {
+    const portStr = tsHost.readFile(portFilePath, 'utf-8')
+    const portNum = Number(portStr)
+    return (
+      Number.isNaN(portNum)
+        ? DEFAULT_PIPELINE_SERVER_PORT
+        : portNum
+    )
+  }
+
+  return DEFAULT_PIPELINE_SERVER_PORT
+}

--- a/packages/language-server/src/plugins/vine-template.ts
+++ b/packages/language-server/src/plugins/vine-template.ts
@@ -7,14 +7,17 @@ import type {
 import type { VineDiagnostic, VineFnCompCtx } from '@vue-vine/compiler'
 import type { VueVineCode } from '@vue-vine/language-service'
 import type { IAttributeData, IHTMLDataProvider, ITagData, TextDocument } from 'vscode-html-languageservice'
-import { isVueVineVirtualCode } from '@vue-vine/language-service'
+import type { PipelineStatus } from '../types'
+import { isVueVineVirtualCode, pipelineRequest, tryParsePipelineResponse, VINE_PIPELINE_PORT } from '@vue-vine/language-service'
 import { hyphenateAttr } from '@vue/language-core'
 import { create as createHtmlService } from 'volar-service-html'
 import { newHTMLDataProvider } from 'vscode-html-languageservice'
 import { URI } from 'vscode-uri'
+import { WebSocket } from 'ws'
 import { vueTemplateBuiltinData } from '../data/vue-template-built-in'
 
 const EMBEDDED_TEMPLATE_SUFFIX = /_template$/
+const CAMEL_CASE_EVENT_PREFIX = /on[A-Z]/
 
 interface HtmlTagInfo {
   events: string[]
@@ -66,6 +69,7 @@ export function isTemplateDiagnosticOfVineCompName(vineDiag: VineDiagnostic, vin
 
 export function createVineTemplatePlugin(): LanguageServicePlugin {
   let customData: IHTMLDataProvider[] = []
+  const tagInfosMap = new Map<string, Map<string, HtmlTagInfo>>()
 
   const onDidChangeCustomDataListeners = new Set<() => void>()
   const onDidChangeCustomData = (listener: () => void): Disposable => {
@@ -114,8 +118,8 @@ export function createVineTemplatePlugin(): LanguageServicePlugin {
           if (document.languageId !== 'html') {
             return
           }
-          const { docUri, vineVirtualCode } = getVueVineVirtualCode(document, context)
-          if (!vineVirtualCode || !isVueVineVirtualCode(vineVirtualCode)) {
+          const { docUri, sourceScriptId, vineVirtualCode } = getVueVineVirtualCode(document, context)
+          if (!sourceScriptId || !vineVirtualCode || !isVueVineVirtualCode(vineVirtualCode)) {
             return
           }
           const htmlEmbeddedId = docUri.authority.replace(EMBEDDED_TEMPLATE_SUFFIX, '')
@@ -126,14 +130,29 @@ export function createVineTemplatePlugin(): LanguageServicePlugin {
             return
           }
 
+          let tagInfos: Map<string, HtmlTagInfo>
+          if (!tagInfosMap.has(vineVirtualCode.fileName)) {
+            tagInfos = new Map()
+            tagInfosMap.set(vineVirtualCode.fileName, tagInfos)
+          }
+          else {
+            tagInfos = tagInfosMap.get(vineVirtualCode.fileName)!
+          }
+
           // Precompute HTMLDocument before provideHtmlData to avoid parseHTMLDocument requesting component names from tsserver
           baseServiceInstance.provideCompletionItems?.(document, position, completionContext, triggerCharToken)
-          provideHtmlData(
+          const { sync } = provideHtmlData(
+            tagInfos,
             vineVirtualCode,
             triggerAtVineCompFn,
           )
+          let isDataReady = await sync()
+          let htmlComplete = await baseServiceInstance.provideCompletionItems?.(document, position, completionContext, triggerCharToken)
+          // eslint-disable-next-line no-cond-assign, unused-imports/no-unused-vars
+          while (!(isDataReady = await sync())) {
+            htmlComplete = await baseServiceInstance.provideCompletionItems?.(document, position, completionContext, triggerCharToken)
+          }
 
-          const htmlComplete = await baseServiceInstance.provideCompletionItems?.(document, position, completionContext, triggerCharToken)
           return htmlComplete
         },
         async provideDiagnostics(document) {
@@ -171,104 +190,163 @@ export function createVineTemplatePlugin(): LanguageServicePlugin {
         },
       }
 
-      function createVineTemplateDataProvider(
-        vineVirtualCode: VueVineCode,
-        triggerAtVineCompFn: VineFnCompCtx,
-        tagInfos: Map<string, HtmlTagInfo>,
-      ): IHTMLDataProvider {
-        return {
-          getId: () => 'vine-vue-template',
-          isApplicable: () => true,
-          provideTags: () => {
-            const tags: ITagData[] = []
-
-            const { bindings } = triggerAtVineCompFn
-            Object.keys(bindings).forEach((bindingName) => {
-              tags.push({
-                name: bindingName,
-                attributes: [],
-              })
-            })
-
-            return tags
-          },
-          provideAttributes: (tag) => {
-            const tagAttrs: IAttributeData[] = []
-            let tagInfo = tagInfos.get(tag)
-
-            if (!tagInfo) {
-              const triggerAtVineCompFn = vineVirtualCode.vineMetaCtx.vineFileCtx.vineCompFns.find(
-                (compFn) => {
-                  return compFn.fnName === tag
-                },
-              )
-              if (!triggerAtVineCompFn) {
-                return tagAttrs
-              }
-
-              tagInfo = {
-                props: Object.keys(triggerAtVineCompFn.props).map(prop => hyphenateAttr(prop)),
-                events: triggerAtVineCompFn.emits.map(emit => hyphenateAttr(emit)),
-              }
-              tagInfos.set(tag, tagInfo)
-            }
-
-            const { props, events } = tagInfo
-            const attributes: IAttributeData[] = []
-
-            for (const prop of props) {
-              const isEvent = prop.startsWith('on-')
-
-              if (isEvent) {
-                const propNameBase = prop.startsWith('on-')
-                  ? prop.slice('on-'.length)
-                  : (prop['on'.length].toLowerCase() + prop.slice('onX'.length))
-
-                attributes.push(
-                  { name: `v-on:${propNameBase}` },
-                  { name: `@${propNameBase}` },
-                )
-              }
-              else {
-                attributes.push(
-                  { name: prop },
-                  { name: `:${prop}` },
-                  { name: `v-bind:${prop}` },
-                )
-              }
-            }
-            for (const event of events) {
-              const name = hyphenateAttr(event)
-
-              attributes.push(
-                { name: `v-on:${name}` },
-                { name: `@${name}` },
-              )
-            }
-
-            return attributes
-          },
-          provideValues: () => [],
-        }
-      }
-
       function provideHtmlData(
+        tagInfos: Map<string, HtmlTagInfo>,
         vineVirtualCode: VueVineCode,
         triggerAtVineCompFn: VineFnCompCtx,
       ) {
-        const tagInfos = new Map<string, HtmlTagInfo>()
+        const templateBuiltIn = newHTMLDataProvider(
+          'vine-vue-template-built-in',
+          vueTemplateBuiltinData,
+        )
+        const vineVolarContextProvider = createVineTemplateDataProvider()
+
+        let pipelineStatus: PipelineStatus = {
+          isFetchDone: false,
+          pendingRequest: new Map(),
+        }
 
         updateCustomData([
-          newHTMLDataProvider(
-            'vine-vue-template-built-in',
-            vueTemplateBuiltinData,
-          ),
-          createVineTemplateDataProvider(
-            vineVirtualCode,
-            triggerAtVineCompFn,
-            tagInfos,
-          ),
+          templateBuiltIn,
+          vineVolarContextProvider,
         ])
+
+        return {
+          async sync() {
+            const promises = Array.from(pipelineStatus.pendingRequest.values())
+            await Promise.all(promises).then(() => {
+              pipelineStatus.isFetchDone = true
+            })
+            return pipelineStatus.isFetchDone
+          },
+        }
+
+        function createVineTemplateDataProvider(): IHTMLDataProvider {
+          return {
+            getId: () => 'vine-vue-template',
+            isApplicable: () => true,
+            provideTags: () => {
+              const tags: ITagData[] = []
+
+              const { bindings } = triggerAtVineCompFn
+              Object.keys(bindings).forEach((bindingName) => {
+                tags.push({
+                  name: bindingName,
+                  attributes: [],
+                })
+              })
+
+              return tags
+            },
+            provideAttributes: (tag) => {
+              const tagAttrs: IAttributeData[] = []
+              let tagInfo = tagInfos.get(tag)
+
+              if (!tagInfo) {
+                const triggerAtVineCompFn = vineVirtualCode.vineMetaCtx.vineFileCtx.vineCompFns.find(
+                  (compFn) => {
+                    return compFn.fnName === tag
+                  },
+                )
+                if (!triggerAtVineCompFn) {
+                  // Can't find component info in current file,
+                  // try to fetch info from pipeline
+
+                  // Create request if there's no pending one
+                  if (!pipelineStatus.pendingRequest.has('getComponentPropsRequest')) {
+                    const pipelineClient = new WebSocket(`ws://localhost:${VINE_PIPELINE_PORT}`)
+                    const requestPromise = (async () => {
+                      return new Promise<void>((resolve, reject) => {
+                        pipelineClient.on('open', () => {
+                          pipelineClient.on('message', (msgData) => {
+                            console.log(`Pipeline: Got message`, msgData.toString())
+                            const resp = tryParsePipelineResponse(msgData.toString(), (err) => {
+                              reject(err)
+                            })
+                            if (!resp) {
+                              const err = new Error(
+                                '[Vue Vine Pipeline] Invalid pipeline response data',
+                                { cause: msgData.toString() },
+                              )
+                              reject(err)
+                              return
+                            }
+
+                            if (resp.type === 'getComponentPropsResponse') {
+                              tagInfo = {
+                                props: [...resp.props],
+                                events: [],
+                              }
+                              tagInfos.set(tag, tagInfo)
+                              resolve()
+                            }
+                          })
+
+                          console.log(`Pipeline: Fetching component '${tag}' props`)
+                          pipelineClient.send(
+                            pipelineRequest({
+                              type: 'getComponentPropsRequest',
+                              componentName: tag,
+                              fileName: vineVirtualCode.fileName,
+                            }),
+                          )
+                        })
+                      }).finally(() => {
+                        pipelineClient.close()
+                        pipelineStatus.pendingRequest.delete('getComponentPropsRequest')
+                      })
+                    })()
+                    pipelineStatus.pendingRequest.set('getComponentPropsRequest', requestPromise)
+                  }
+
+                  return tagAttrs
+                }
+
+                tagInfo = {
+                  props: Object.keys(triggerAtVineCompFn.props).map(prop => hyphenateAttr(prop)),
+                  events: triggerAtVineCompFn.emits.map(emit => hyphenateAttr(emit)),
+                }
+                tagInfos.set(tag, tagInfo)
+              }
+
+              const { props, events } = tagInfo
+              const attributes: IAttributeData[] = []
+
+              for (const prop of props) {
+                const isEvent = prop.startsWith('on-') || CAMEL_CASE_EVENT_PREFIX.test(prop)
+
+                if (isEvent) {
+                  const propNameBase = prop.startsWith('on-')
+                    ? prop.slice('on-'.length)
+                    : (prop['on'.length].toLowerCase() + prop.slice('onX'.length))
+
+                  attributes.push(
+                    { name: `v-on:${propNameBase}` },
+                    { name: `@${propNameBase}` },
+                  )
+                }
+                else {
+                  attributes.push(
+                    { name: prop },
+                    { name: `:${prop}` },
+                    { name: `v-bind:${prop}` },
+                  )
+                }
+              }
+              for (const event of events) {
+                const name = hyphenateAttr(event)
+
+                attributes.push(
+                  { name: `v-on:${name}` },
+                  { name: `@${name}` },
+                )
+              }
+
+              return attributes
+            },
+            provideValues: () => [],
+          }
+        }
       }
     },
   }

--- a/packages/language-server/src/types.ts
+++ b/packages/language-server/src/types.ts
@@ -13,3 +13,8 @@ export interface PipelineStatus {
   isFetchDone: boolean
   pendingRequest: Map<PipelineRequest['type'], Promise<void>>
 }
+
+export interface HtmlTagInfo {
+  events: string[]
+  props: string[]
+}

--- a/packages/language-server/src/types.ts
+++ b/packages/language-server/src/types.ts
@@ -1,3 +1,5 @@
+import type { PipelineRequest } from '@vue-vine/language-service'
+
 export type VineVirtualFileExtension =
   | 'ts'
   | 'css'
@@ -6,3 +8,8 @@ export type VineVirtualFileExtension =
   | 'less'
   | 'styl'
   | 'html'
+
+export interface PipelineStatus {
+  isFetchDone: boolean
+  pendingRequest: Map<PipelineRequest['type'], Promise<void>>
+}

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -53,11 +53,13 @@
     "@vue-vine/compiler": "workspace:*",
     "@vue/language-core": "catalog:",
     "@vue/shared": "catalog:",
-    "muggle-string": "^0.4.1"
+    "muggle-string": "^0.4.1",
+    "ws": "^8.18.1"
   },
   "devDependencies": {
     "@babel/types": "catalog:",
     "@types/node": "catalog:",
+    "@types/ws": "^8.5.14",
     "vscode-uri": "catalog:"
   }
 }

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -53,6 +53,7 @@
     "@vue-vine/compiler": "workspace:*",
     "@vue/language-core": "catalog:",
     "@vue/shared": "catalog:",
+    "detect-port": "^2.1.0",
     "muggle-string": "^0.4.1",
     "ws": "^8.18.1"
   },

--- a/packages/language-service/src/index.ts
+++ b/packages/language-service/src/index.ts
@@ -10,9 +10,6 @@ import { URI } from 'vscode-uri'
 import { VLS_ErrorLog } from './shared'
 import { createVueVineCode } from './virtual-code'
 
-export {
-  VINE_PIPELINE_PORT,
-} from '../typescript-plugin/pipeline'
 export type {
   PipelineRequest,
   PipelineResponse,
@@ -20,7 +17,7 @@ export type {
 export {
   pipelineRequest,
   tryParsePipelineResponse,
-} from '../typescript-plugin/visitors'
+} from '../typescript-plugin/utils'
 
 export {
   setupGlobalTypes,

--- a/packages/language-service/src/index.ts
+++ b/packages/language-service/src/index.ts
@@ -11,6 +11,18 @@ import { VLS_ErrorLog } from './shared'
 import { createVueVineCode } from './virtual-code'
 
 export {
+  VINE_PIPELINE_PORT,
+} from '../typescript-plugin/pipeline'
+export type {
+  PipelineRequest,
+  PipelineResponse,
+} from '../typescript-plugin/types'
+export {
+  pipelineRequest,
+  tryParsePipelineResponse,
+} from '../typescript-plugin/visitors'
+
+export {
   setupGlobalTypes,
 } from './injectTypes'
 export {
@@ -21,6 +33,7 @@ export {
 export type {
   VueVineCode,
 } from './shared'
+
 export {
   createVueVineCode,
 } from './virtual-code'

--- a/packages/language-service/src/injectTypes.ts
+++ b/packages/language-service/src/injectTypes.ts
@@ -1,5 +1,6 @@
 import type { VineFnCompCtx } from '@vue-vine/compiler'
 import type { VueCompilerOptions } from '@vue/language-core'
+import type * as ts from 'typescript'
 import { posix as path } from 'node:path'
 import { VineBindingTypes } from '@vue-vine/compiler'
 import { generateGlobalTypes as _generateGlobalTypes } from '@vue/language-core'
@@ -7,10 +8,7 @@ import { generateGlobalTypes as _generateGlobalTypes } from '@vue/language-core'
 export function setupGlobalTypes(
   rootDir: string,
   vueOptions: VueCompilerOptions,
-  host: {
-    fileExists: (path: string) => boolean
-    writeFile?: (path: string, data: string) => void
-  },
+  host: ts.System,
 ) {
   if (!host.writeFile) {
     return ''

--- a/packages/language-service/src/virtual-code.ts
+++ b/packages/language-service/src/virtual-code.ts
@@ -278,6 +278,10 @@ export function createVueVineCode(
             if (!segment[3].completion.onlyImport) {
               segment[3].completion.onlyImport = true
             }
+            else {
+              // - fix https://github.com/vue-vine/vue-vine/issues/218
+              segment[3].completion = {}
+            }
           }
 
           tsCodeSegments.push([

--- a/packages/language-service/src/virtual-code.ts
+++ b/packages/language-service/src/virtual-code.ts
@@ -51,14 +51,12 @@ function getLinkedCodeMappings(tsCode: string): Mapping[] {
 
     const start = foundLeft.index + foundLeft.tagLength
     const end = foundRight.index + foundRight.tagLength
-    const length = foundLeft.tagLength
+    const length = foundLeft.itemLength
     linkedCodeMappings.push({
       sourceOffsets: [start],
       generatedOffsets: [end],
       lengths: [length],
-      data: {
-        navigation: true,
-      },
+      data: void 0,
     })
   }
 
@@ -309,6 +307,18 @@ export function createVueVineCode(
     generateScriptUntil(vineCompFn.fnDeclNode!.end!)
   }
   generateScriptUntil(snapshotContent.length)
+
+  // Generate all full collection of all used components in this file
+  const usedComponents = new Set<string>()
+  vineFileCtx.vineCompFns.forEach((vineCompFn) => {
+    usedComponents.add(vineCompFn.fnName)
+    vineCompFn.templateComponentNames.forEach((compName) => {
+      usedComponents.add(compName)
+    })
+  })
+  tsCodeSegments.push(`\nconst __VLS_ComponentsReferenceMap = {\n${
+    [...usedComponents].map(compName => `  ${compName}: ${compName}`).join(',\n')
+  }\n};\n`)
 
   // Add a 'VINE' prefix to all '__VLS_'
   replaceAll(

--- a/packages/language-service/typescript-plugin/index.ts
+++ b/packages/language-service/typescript-plugin/index.ts
@@ -1,7 +1,10 @@
 import type { VueCompilerOptions } from '@vue/language-core'
+import type * as ts from 'typescript'
 import type { WebSocketServer } from 'ws'
+import { dirname, posix as path } from 'node:path'
 import { createLanguageServicePlugin } from '@volar/typescript/lib/quickstart/createLanguageServicePlugin'
 import { createParsedCommandLine, getDefaultCompilerOptions } from '@vue/language-core'
+import { detect } from 'detect-port'
 import { createVueVineLanguagePlugin, setupGlobalTypes } from '../src/index'
 import { createVueVinePipelineServer } from './pipeline'
 
@@ -12,6 +15,7 @@ function ensureStrictTemplatesCheck(vueOptions: VueCompilerOptions) {
   vueOptions.checkUnknownProps = true
 }
 
+const DEFAULT_PIPELINE_PORT = 15193
 const logger = {
   info: (...msg: any[]) => {
     console.log(`${new Date().toLocaleString()}: [INFO]`, ...msg)
@@ -20,6 +24,7 @@ const logger = {
     console.error(`${new Date().toLocaleString()}: [ERROR]`, ...msg)
   },
 }
+
 let pipelineServer: WebSocketServer | undefined
 
 export function createVueVineTypeScriptPlugin() {
@@ -40,7 +45,7 @@ export function createVueVineTypeScriptPlugin() {
 
     if (isConfiguredTsProject) {
       const globalTypesFilePath = setupGlobalTypes(
-        info.project.getProjectName(),
+        configFileName,
         vueOptions,
         ts.sys,
       )
@@ -64,17 +69,59 @@ export function createVueVineTypeScriptPlugin() {
       languagePlugins: [vueVinePlugin],
       setup: (language) => {
         if (isConfiguredTsProject && !pipelineServer) {
-          pipelineServer = createVueVinePipelineServer({
-            ts,
-            language,
-            tsPluginInfo: info,
-            tsPluginLogger: logger,
-          })
-          logger?.info(`Pipeline: WebSocket server created`)
+          detect(DEFAULT_PIPELINE_PORT)
+            .then((availablePort) => {
+              if (pipelineServer) {
+                return
+              }
+
+              pipelineServer = createVueVinePipelineServer(availablePort, {
+                ts,
+                language,
+                tsPluginInfo: info,
+                tsPluginLogger: logger,
+              })
+              logger?.info(`Pipeline: WebSocket server created`)
+
+              writePipelineServerPortToFile(
+                ts.sys,
+                configFileName,
+                availablePort,
+              )
+            })
+            .catch((err) => {
+              logger?.error(
+                `Pipeline: Failed to detect available port for pipeline server`,
+                err,
+              )
+            })
         }
       },
     }
   })
 
   return plugin
+}
+
+function writePipelineServerPortToFile(
+  host: ts.System,
+  tsConfigFilePath: string,
+  port: number,
+) {
+  const rootDir = dirname(tsConfigFilePath)
+
+  // Find the `node_modules` directory that contains `vue-vine`
+  let dir = rootDir
+  while (!host.fileExists(path.join(dir, 'node_modules', 'vue-vine', 'package.json'))) {
+    const parentDir = dirname(dir)
+    if (parentDir === dir) {
+      throw new Error('Failed to find `node_modules` directory that contains \'vue-vine\'')
+    }
+    dir = parentDir
+  }
+
+  host.writeFile(
+    path.join(dir, 'node_modules', '.vine-pipeline-port'),
+    port.toString(),
+  )
 }

--- a/packages/language-service/typescript-plugin/pipeline.ts
+++ b/packages/language-service/typescript-plugin/pipeline.ts
@@ -2,9 +2,8 @@ import type { Language } from '@volar/language-server'
 import type { PipelineContext, PipelineLogger, PipelineRequest, TsPluginInfo, TypeScriptSdk } from './types'
 import { WebSocketServer } from 'ws'
 import { isVueVineVirtualCode } from '../src'
-import { getComponentProps, pipelineResponse } from './visitors'
-
-export const VINE_PIPELINE_PORT = 15193
+import { pipelineResponse } from './utils'
+import { getComponentProps } from './visitors'
 
 interface PipelineServerCreateParams {
   ts: TypeScriptSdk
@@ -12,13 +11,16 @@ interface PipelineServerCreateParams {
   language: Language
   tsPluginLogger: PipelineLogger
 }
-export function createVueVinePipelineServer({
-  ts,
-  tsPluginInfo,
-  language,
-  tsPluginLogger,
-}: PipelineServerCreateParams) {
-  const wss = new WebSocketServer({ port: VINE_PIPELINE_PORT })
+export function createVueVinePipelineServer(
+  port: number,
+  {
+    ts,
+    tsPluginInfo,
+    language,
+    tsPluginLogger,
+  }: PipelineServerCreateParams,
+) {
+  const wss = new WebSocketServer({ port })
 
   wss.on('error', (err) => {
     tsPluginLogger.error('Pipeline: Server error:', err)
@@ -51,7 +53,7 @@ export function createVueVinePipelineServer({
     })
   })
 
-  tsPluginLogger.info(`Pipeline: Server is running on port ${VINE_PIPELINE_PORT}`)
+  tsPluginLogger.info(`Pipeline: Server is running on port ${port}`)
   return wss
 }
 

--- a/packages/language-service/typescript-plugin/pipeline.ts
+++ b/packages/language-service/typescript-plugin/pipeline.ts
@@ -1,0 +1,99 @@
+import type { Language } from '@volar/language-server'
+import type { PipelineContext, PipelineLogger, PipelineRequest, TsPluginInfo, TypeScriptSdk } from './types'
+import { WebSocketServer } from 'ws'
+import { isVueVineVirtualCode } from '../src'
+import { getComponentProps, pipelineResponse } from './visitors'
+
+export const VINE_PIPELINE_PORT = 15193
+
+interface PipelineServerCreateParams {
+  ts: TypeScriptSdk
+  tsPluginInfo: TsPluginInfo
+  language: Language
+  tsPluginLogger: PipelineLogger
+}
+export function createVueVinePipelineServer({
+  ts,
+  tsPluginInfo,
+  language,
+  tsPluginLogger,
+}: PipelineServerCreateParams) {
+  const wss = new WebSocketServer({ port: VINE_PIPELINE_PORT })
+
+  wss.on('error', (err) => {
+    tsPluginLogger.error('Pipeline: Server error:', err)
+  })
+  wss.on('connection', (ws) => {
+    tsPluginLogger.info('Pipeline: Client connected')
+
+    ws.on('message', (message) => {
+      tsPluginLogger.info('Pipeline: Recieved message.')
+
+      let request: PipelineRequest | undefined
+      try {
+        request = JSON.parse(message.toString().trim()) as PipelineRequest
+      }
+      catch (err) {
+        tsPluginLogger.error('Pipeline: Error parsing message:', err)
+      }
+
+      if (request) {
+        const context = { ts, tsPluginInfo, ws, language, tsPluginLogger }
+        handlePipelineRequest(request, context)
+      }
+    })
+
+    ws.on('error', (err) => {
+      tsPluginLogger.error('Pipeline: Client error:', err)
+    })
+    ws.on('close', () => {
+      tsPluginLogger.info('Pipeline: Client disconnected')
+    })
+  })
+
+  tsPluginLogger.info(`Pipeline: Server is running on port ${VINE_PIPELINE_PORT}`)
+  return wss
+}
+
+function handlePipelineRequest(request: PipelineRequest, context: PipelineContext) {
+  try {
+    switch (request.type) {
+      case 'getComponentPropsRequest':
+        handleGetComponentProps(request, context)
+        break
+    }
+  }
+  catch (err) {
+    context.tsPluginLogger.error('Pipeline: Unhandled error during request:', err)
+  }
+}
+
+function handleGetComponentProps(request: PipelineRequest, context: PipelineContext) {
+  const { ws, language } = context
+  const { componentName, fileName } = request
+
+  const volarFile = language.scripts.get(fileName)
+  if (!(isVueVineVirtualCode(volarFile?.generated?.root))) {
+    return
+  }
+  const vineCode = volarFile.generated.root
+
+  try {
+    const props = getComponentProps(
+      context,
+      vineCode,
+      componentName,
+    )
+    context.tsPluginLogger.info('Pipeline: Got component props', props)
+
+    ws.send(
+      pipelineResponse({
+        type: 'getComponentPropsResponse',
+        props,
+      }),
+    )
+  }
+  catch (err) {
+    context.tsPluginLogger.error('Pipeline: Error on getComponentProps:', err)
+  }
+}

--- a/packages/language-service/typescript-plugin/types.ts
+++ b/packages/language-service/typescript-plugin/types.ts
@@ -1,0 +1,25 @@
+import type { Language } from '@volar/language-server'
+import type { createLanguageServicePlugin } from '@volar/typescript/lib/quickstart/createLanguageServicePlugin'
+import type { WebSocket } from 'ws'
+
+export type TypeScriptSdk = Parameters<Parameters<(typeof createLanguageServicePlugin)>[0]>[0]
+export type TsPluginInfo = Parameters<Parameters<(typeof createLanguageServicePlugin)>[0]>[1]
+
+export type PipelineRequest =
+  | { type: 'getComponentPropsRequest', componentName: string, fileName: string }
+
+export type PipelineResponse =
+  | { type: 'getComponentPropsResponse', props: string[] }
+
+export interface PipelineContext {
+  ts: TypeScriptSdk
+  tsPluginInfo: TsPluginInfo
+  ws: WebSocket
+  language: Language
+  tsPluginLogger: PipelineLogger
+}
+
+export interface PipelineLogger {
+  info: (...msg: any[]) => void
+  error: (...msg: any[]) => void
+}

--- a/packages/language-service/typescript-plugin/utils.ts
+++ b/packages/language-service/typescript-plugin/utils.ts
@@ -1,0 +1,22 @@
+import type { PipelineRequest, PipelineResponse } from './types'
+
+export function pipelineRequest<T extends PipelineRequest>(data: T) {
+  return JSON.stringify(data)
+}
+
+export function pipelineResponse<T extends PipelineResponse>(data: T) {
+  return JSON.stringify(data)
+}
+
+export function tryParsePipelineResponse(
+  data: string,
+  onError?: (e: unknown) => void,
+): PipelineResponse | undefined {
+  try {
+    return JSON.parse(data)
+  }
+  catch (err) {
+    onError?.(err)
+    return (void 0)
+  }
+}

--- a/packages/language-service/typescript-plugin/visitors.ts
+++ b/packages/language-service/typescript-plugin/visitors.ts
@@ -1,0 +1,123 @@
+import type * as ts from 'typescript'
+import type { VueVineCode } from '../src'
+import type { PipelineContext, PipelineRequest, PipelineResponse } from './types'
+
+export function searchFunctionDeclInRoot(
+  ts: typeof import('typescript'),
+  sourceFile: ts.SourceFile,
+  name: string,
+) {
+  let functionNode: ts.Node | undefined
+  walk(sourceFile)
+  return functionNode
+
+  function walk(node: ts.Node) {
+    if (functionNode) {
+      return
+    }
+
+    if (ts.isFunctionDeclaration(node) && node.name?.getText() === name) {
+      functionNode = node
+    }
+    else if (
+      ts.isVariableDeclaration(node)
+      && node.name.getText() === name
+      && node.initializer
+      && (
+        ts.isArrowFunction(node.initializer)
+        || ts.isFunctionExpression(node.initializer)
+      )
+    ) {
+      functionNode = node.initializer
+    }
+    else {
+      node.forEachChild(walk)
+    }
+  }
+}
+
+export function searchVarDeclInCompFn(
+  ts: typeof import('typescript'),
+  compFnNode: ts.Node,
+  name: string,
+) {
+  let componentsNode: ts.Node | undefined
+  walk(compFnNode)
+  return componentsNode
+
+  function walk(node: ts.Node) {
+    if (componentsNode) {
+      return
+    }
+
+    if (ts.isVariableDeclaration(node) && node.name.getText() === name) {
+      componentsNode = node
+    }
+    else {
+      node.forEachChild(walk)
+    }
+  }
+}
+
+export function getComponentProps(
+  context: PipelineContext,
+  vineCode: VueVineCode,
+  compName: string,
+): string[] {
+  const { ts, tsPluginInfo, tsPluginLogger } = context
+  const program = tsPluginInfo.languageService.getProgram()!
+  const tsSourceFile = program.getSourceFile(vineCode.fileName)
+  if (!tsSourceFile) {
+    return []
+  }
+
+  const vlsCompsMapNode = searchVarDeclInCompFn(ts, tsSourceFile, '__VINE_VLS_ComponentsReferenceMap')
+  const checker = program.getTypeChecker()
+  if (!vlsCompsMapNode) {
+    return []
+  }
+
+  const vlsCompsMapType = checker.getTypeAtLocation(vlsCompsMapNode)
+  tsPluginLogger.info('vlsCompsMapType', checker.typeToString(vlsCompsMapType))
+  const compSymbol = vlsCompsMapType.getProperty(compName)
+  if (!compSymbol) {
+    return []
+  }
+
+  const compFnType = checker.getTypeOfSymbolAtLocation(compSymbol, tsSourceFile)
+  if (!compFnType) {
+    return []
+  }
+  tsPluginLogger.info('compFnType', checker.typeToString(compFnType))
+
+  // `compFnType` is (props: ...) => { ... }
+  // we need to extract `props` type from it
+  const propsNode = compFnType.getCallSignatures()[0].getParameters()[0]!
+  const propsType = checker.getTypeOfSymbol(propsNode)
+  // Extract all properties
+  const propsNames = propsType
+    .getProperties()
+    .map(p => p.getName())
+
+  return propsNames
+}
+
+export function pipelineRequest<T extends PipelineRequest>(data: T) {
+  return JSON.stringify(data)
+}
+export function pipelineResponse<T extends PipelineResponse>(data: T) {
+  return JSON.stringify(data)
+}
+
+export function tryParsePipelineResponse(
+  data: string,
+  onError?: (e: unknown) => void,
+): PipelineResponse | undefined {
+  try {
+    return JSON.parse(data)
+  }
+  catch (err) {
+    onError?.(err)
+    return (void 0)
+  }
+}

--- a/packages/language-service/typescript-plugin/visitors.ts
+++ b/packages/language-service/typescript-plugin/visitors.ts
@@ -1,6 +1,6 @@
 import type * as ts from 'typescript'
 import type { VueVineCode } from '../src'
-import type { PipelineContext, PipelineRequest, PipelineResponse } from './types'
+import type { PipelineContext } from './types'
 
 export function searchFunctionDeclInRoot(
   ts: typeof import('typescript'),
@@ -100,24 +100,4 @@ export function getComponentProps(
     .map(p => p.getName())
 
   return propsNames
-}
-
-export function pipelineRequest<T extends PipelineRequest>(data: T) {
-  return JSON.stringify(data)
-}
-export function pipelineResponse<T extends PipelineResponse>(data: T) {
-  return JSON.stringify(data)
-}
-
-export function tryParsePipelineResponse(
-  data: string,
-  onError?: (e: unknown) => void,
-): PipelineResponse | undefined {
-  try {
-    return JSON.parse(data)
-  }
-  catch (err) {
-    onError?.(err)
-    return (void 0)
-  }
 }

--- a/packages/playground/src/components/fixtures.vine.ts
+++ b/packages/playground/src/components/fixtures.vine.ts
@@ -28,7 +28,7 @@ export function SampleOne() {
       }"
     >
       <p v-text="msg">Dida dida</p>
-      <comp foo="111" :foo="'222'" />
+      <Comp foo="111" :foo="'222'" />
     </div>
   `
 }

--- a/packages/playground/src/pages/home.vine.ts
+++ b/packages/playground/src/pages/home.vine.ts
@@ -34,7 +34,7 @@ function OutsideExample(props: { id: string }) {
     <div class="state-container">
       <InsideExample
         :title
-        author="ShenQingchuan"
+        author="Tom"
         @metaBgColorChange="(color: string) => console.log(color)"
       />
 

--- a/packages/playground/src/pages/home.vine.ts
+++ b/packages/playground/src/pages/home.vine.ts
@@ -3,7 +3,6 @@ import { generateRandomString } from '~/utils'
 // No need to manually import the following components,
 // they will be automatically imported
 // - import { InsideExample } from '../components/inside-example.vine'
-// - import { PageHeader } from '../components/page-header.vine'
 
 function OutsideExample(props: { id: string }) {
   const randomStr = ref('')

--- a/packages/vscode-ext/package.json
+++ b/packages/vscode-ext/package.json
@@ -99,6 +99,7 @@
     "vscode:prepublish": "pnpm run build",
     "dev": "NODE_ENV=development tsup --watch",
     "build": "NODE_ENV=production tsup",
+    "build:debug": "NODE_ENV=development tsup",
     "lint": "eslint src --ext ts",
     "pack:ext": "vsce pack",
     "prepack": "pnpm run build",

--- a/packages/vscode-ext/tsup.config.ts
+++ b/packages/vscode-ext/tsup.config.ts
@@ -1,4 +1,3 @@
-import type { PluginBuild } from 'esbuild'
 import { createRequire } from 'node:module'
 import process from 'node:process'
 import { defineConfig, type Options } from 'tsup'
@@ -6,10 +5,11 @@ import { defineConfig, type Options } from 'tsup'
 const require = createRequire(import.meta.url)
 const isDev = process.env.NODE_ENV === 'development'
 
+type SetupBuild = Parameters<Exclude<Options['esbuildPlugins'], undefined>[number]['setup']>[0]
 function mockDependency(name: string) {
   return {
     name: `mock-${name}`,
-    setup(build: PluginBuild) {
+    setup(build: SetupBuild) {
       build.onResolve({ filter: new RegExp(`^${name}$`) }, () => {
         return { path: name, namespace: `mock-${name}` }
       })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,16 +8,16 @@ catalogs:
   default:
     '@babel/parser':
       specifier: ^7.24.0
-      version: 7.26.7
+      version: 7.26.9
     '@babel/types':
       specifier: ^7.24.0
-      version: 7.26.7
+      version: 7.26.9
     '@changesets/cli':
       specifier: ^2.27.7
       version: 2.27.12
     '@nuxt/kit':
       specifier: ^3.15.0
-      version: 3.15.3
+      version: 3.15.4
     '@nuxt/module-builder':
       specifier: ^1.0.0-alpha.1
       version: 1.0.0-alpha.1
@@ -104,7 +104,7 @@ catalogs:
       version: 0.18.6
     vite:
       specifier: ^6.0.0
-      version: 6.0.11
+      version: 6.1.0
     vite-plugin-inspect:
       specifier: ^0.8.8
       version: 0.8.9
@@ -113,7 +113,7 @@ catalogs:
       version: 3.0.4
     vscode-uri:
       specifier: ^3.0.8
-      version: 3.0.8
+      version: 3.1.0
     vue:
       specifier: ^3.5.13
       version: 3.5.13
@@ -169,7 +169,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: 'catalog:'
-        version: 6.0.11(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
+        version: 6.1.0(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
       vitest:
         specifier: 'catalog:'
         version: 3.0.4(@types/debug@4.1.12)(@types/node@20.17.16)(jiti@2.4.2)(jsdom@25.0.1)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
@@ -181,10 +181,10 @@ importers:
     dependencies:
       '@babel/parser':
         specifier: 'catalog:'
-        version: 7.26.7
+        version: 7.26.9
       '@babel/types':
         specifier: 'catalog:'
-        version: 7.26.7
+        version: 7.26.9
       '@vue/compiler-dom':
         specifier: 'catalog:'
         version: 3.5.13
@@ -261,16 +261,16 @@ importers:
         version: 20.17.16
       unocss:
         specifier: 'catalog:'
-        version: 0.64.1(postcss@8.5.2)(rollup@4.34.7)(vite@6.0.11(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))
+        version: 0.64.1(postcss@8.5.2)(rollup@4.34.7)(vite@6.1.0(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))
       unplugin-auto-import:
         specifier: 'catalog:'
         version: 0.18.6(@nuxt/kit@3.15.4(magicast@0.3.5))(@vueuse/core@12.7.0(typescript@5.7.3))(rollup@4.34.7)
       vite:
         specifier: 'catalog:'
-        version: 6.0.11(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
+        version: 6.1.0(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
       vite-plugin-inspect:
         specifier: 'catalog:'
-        version: 0.8.9(@nuxt/kit@3.15.4(magicast@0.3.5))(rollup@4.34.7)(vite@6.0.11(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
+        version: 0.8.9(@nuxt/kit@3.15.4(magicast@0.3.5))(rollup@4.34.7)(vite@6.1.0(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       vue:
         specifier: 'catalog:'
         version: 3.5.13(typescript@5.7.3)
@@ -468,10 +468,16 @@ importers:
       vscode-languageserver-textdocument:
         specifier: ^1.0.12
         version: 1.0.12
+      ws:
+        specifier: ^8.18.1
+        version: 8.18.1
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
         version: 20.17.16
+      '@types/ws':
+        specifier: ^8.5.14
+        version: 8.5.14
       '@vue/shared':
         specifier: 'catalog:'
         version: 3.5.13
@@ -480,7 +486,7 @@ importers:
         version: 5.3.1
       vscode-uri:
         specifier: 'catalog:'
-        version: 3.0.8
+        version: 3.1.0
 
   packages/language-service:
     dependencies:
@@ -502,22 +508,28 @@ importers:
       muggle-string:
         specifier: ^0.4.1
         version: 0.4.1
+      ws:
+        specifier: ^8.18.1
+        version: 8.18.1
     devDependencies:
       '@babel/types':
         specifier: 'catalog:'
-        version: 7.26.7
+        version: 7.26.9
       '@types/node':
         specifier: 'catalog:'
         version: 20.17.16
+      '@types/ws':
+        specifier: ^8.5.14
+        version: 8.5.14
       vscode-uri:
         specifier: 'catalog:'
-        version: 3.0.8
+        version: 3.1.0
 
   packages/nuxt-module:
     dependencies:
       '@nuxt/kit':
         specifier: 'catalog:'
-        version: 3.15.3(magicast@0.3.5)
+        version: 3.15.4(magicast@0.3.5)
       consola:
         specifier: ^3.4.0
         version: 3.4.0
@@ -932,11 +944,6 @@ packages:
     resolution: {integrity: sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==, tarball: https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.9.tgz}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.26.7':
-    resolution: {integrity: sha512-kEvgGGgEjRUutvdVvZhbn/BxVt+5VSpwXz1j3WYXQbXDo8KzFOPNG2GQbdAiNq8g6wn1yKk7C/qrke03a84V+w==, tarball: https://registry.npmjs.org/@babel/parser/-/parser-7.26.7.tgz}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/parser@7.26.9':
     resolution: {integrity: sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==, tarball: https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz}
     engines: {node: '>=6.0.0'}
@@ -997,10 +1004,6 @@ packages:
 
   '@babel/traverse@7.26.9':
     resolution: {integrity: sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==, tarball: https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.9.tgz}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.26.7':
-    resolution: {integrity: sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==, tarball: https://registry.npmjs.org/@babel/types/-/types-7.26.7.tgz}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.26.9':
@@ -2348,6 +2351,9 @@ packages:
 
   '@types/web-bluetooth@0.0.20':
     resolution: {integrity: sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==, tarball: https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz}
+
+  '@types/ws@8.5.14':
+    resolution: {integrity: sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw==, tarball: https://registry.npmjs.org/@types/ws/-/ws-8.5.14.tgz}
 
   '@typescript-eslint/eslint-plugin@8.24.0':
     resolution: {integrity: sha512-aFcXEJJCI4gUdXgoo/j9udUYIHgF23MFkg09LFz2dzEmU0+1Plk4rQWv/IYKvPHAtlkkGoB3m5e6oUp+JPsNaQ==, tarball: https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.24.0.tgz}
@@ -4262,8 +4268,8 @@ packages:
     resolution: {integrity: sha512-O1Ld7Dr+nqPnmGpdhzLmMTQ4vAsD+rHwMm1NLUmoUFFymBOMKxCCrtDxqdBRYXdeEPEi3SyoR4TizJLQrnKBNA==, tarball: https://registry.npmjs.org/gzip-size/-/gzip-size-7.0.0.tgz}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  h3@1.15.0:
-    resolution: {integrity: sha512-OsjX4JW8J4XGgCgEcad20pepFQWnuKH+OwkCJjogF3C+9AZ1iYdtB4hX6vAb5DskBiu5ljEXqApINjR8CqoCMQ==, tarball: https://registry.npmjs.org/h3/-/h3-1.15.0.tgz}
+  h3@1.15.1:
+    resolution: {integrity: sha512-+ORaOBttdUm1E2Uu/obAyCguiI7MbBvsLTndc3gyK3zU+SYLoZXlyCP9Xgy0gikkGufFLTZXCXD6+4BsufnmHA==, tarball: https://registry.npmjs.org/h3/-/h3-1.15.1.tgz}
 
   has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==, tarball: https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz}
@@ -6978,46 +6984,6 @@ packages:
       terser:
         optional: true
 
-  vite@6.0.11:
-    resolution: {integrity: sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==, tarball: https://registry.npmjs.org/vite/-/vite-6.0.11.tgz}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      jiti: '>=1.21.0'
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vite@6.1.0:
     resolution: {integrity: sha512-RjjMipCKVoR4hVfPY6GQTgveinjNuyLw+qruksLDvA5ktI1150VmcMBKmQaEWJhg/j6Uaf6dNCNA0AfdzUb/hQ==, tarball: https://registry.npmjs.org/vite/-/vite-6.1.0.tgz}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -7211,9 +7177,6 @@ packages:
   vscode-nls@5.2.0:
     resolution: {integrity: sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==, tarball: https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz}
 
-  vscode-uri@3.0.8:
-    resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==, tarball: https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz}
-
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==, tarball: https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz}
 
@@ -7332,8 +7295,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==, tarball: https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz}
 
-  ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==, tarball: https://registry.npmjs.org/ws/-/ws-8.18.0.tgz}
+  ws@8.18.1:
+    resolution: {integrity: sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==, tarball: https://registry.npmjs.org/ws/-/ws-8.18.1.tgz}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -7806,10 +7769,6 @@ snapshots:
       '@babel/template': 7.26.9
       '@babel/types': 7.26.9
 
-  '@babel/parser@7.26.7':
-    dependencies:
-      '@babel/types': 7.26.7
-
   '@babel/parser@7.26.9':
     dependencies:
       '@babel/types': 7.26.9
@@ -7882,11 +7841,6 @@ snapshots:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.26.7':
-    dependencies:
-      '@babel/helper-string-parser': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
 
   '@babel/types@7.26.9':
     dependencies:
@@ -8207,7 +8161,7 @@ snapshots:
     dependencies:
       '@types/eslint': 9.6.1
       '@types/estree': 1.0.6
-      '@typescript-eslint/types': 8.24.0
+      '@typescript-eslint/types': 8.15.0
       comment-parser: 1.4.1
       esquery: 1.6.0
       jsdoc-type-pratt-parser: 4.1.0
@@ -8644,7 +8598,7 @@ snapshots:
       defu: 6.1.4
       fuse.js: 7.1.0
       giget: 1.2.4
-      h3: 1.15.0
+      h3: 1.15.1
       httpxy: 0.1.7
       jiti: 2.4.2
       listhen: 1.9.0
@@ -8666,7 +8620,7 @@ snapshots:
 
   '@nuxt/devtools-kit@1.7.0(magicast@0.3.5)(vite@6.1.0(@types/node@22.13.4)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))':
     dependencies:
-      '@nuxt/kit': 3.15.3(magicast@0.3.5)
+      '@nuxt/kit': 3.15.4(magicast@0.3.5)
       '@nuxt/schema': 3.15.3
       execa: 7.2.0
       vite: 6.1.0(@types/node@22.13.4)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
@@ -8692,7 +8646,7 @@ snapshots:
       '@antfu/utils': 0.7.10
       '@nuxt/devtools-kit': 1.7.0(magicast@0.3.5)(vite@6.1.0(@types/node@22.13.4)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       '@nuxt/devtools-wizard': 1.7.0
-      '@nuxt/kit': 3.15.3(magicast@0.3.5)
+      '@nuxt/kit': 3.15.4(magicast@0.3.5)
       '@vue/devtools-core': 7.6.8(vite@6.1.0(@types/node@22.13.4)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))
       '@vue/devtools-kit': 7.6.8
       birpc: 0.2.19
@@ -8723,10 +8677,10 @@ snapshots:
       tinyglobby: 0.2.10
       unimport: 3.14.6(rollup@4.34.7)
       vite: 6.1.0(@types/node@22.13.4)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
-      vite-plugin-inspect: 0.8.9(@nuxt/kit@3.15.3(magicast@0.3.5))(rollup@4.34.7)(vite@6.1.0(@types/node@22.13.4)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
+      vite-plugin-inspect: 0.8.9(@nuxt/kit@3.15.4(magicast@0.3.5))(rollup@4.34.7)(vite@6.1.0(@types/node@22.13.4)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       vite-plugin-vue-inspector: 5.3.1(vite@6.1.0(@types/node@22.13.4)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       which: 3.0.1
-      ws: 8.18.0
+      ws: 8.18.1
     transitivePeerDependencies:
       - bufferutil
       - rollup
@@ -8872,7 +8826,7 @@ snapshots:
 
   '@nuxt/test-utils@3.15.4(@types/node@22.13.4)(@vue/test-utils@2.4.6)(jiti@2.4.2)(jsdom@25.0.1)(less@4.2.2)(magicast@0.3.5)(playwright-core@1.50.1)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(typescript@5.7.3)(vitest@3.0.4(@types/debug@4.1.12)(@types/node@22.13.4)(jiti@2.4.2)(jsdom@25.0.1)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(yaml@2.7.0)':
     dependencies:
-      '@nuxt/kit': 3.15.3(magicast@0.3.5)
+      '@nuxt/kit': 3.15.4(magicast@0.3.5)
       '@nuxt/schema': 3.15.3
       c12: 2.0.2(magicast@0.3.5)
       consola: 3.4.0
@@ -8881,7 +8835,7 @@ snapshots:
       estree-walker: 3.0.3
       fake-indexeddb: 6.0.0
       get-port-please: 3.1.2
-      h3: 1.15.0
+      h3: 1.15.1
       local-pkg: 1.0.0
       magic-string: 0.30.17
       node-fetch-native: 1.6.6
@@ -8933,7 +8887,7 @@ snapshots:
       escape-string-regexp: 5.0.0
       externality: 1.0.2
       get-port-please: 3.1.2
-      h3: 1.15.0
+      h3: 1.15.1
       jiti: 2.4.2
       knitwork: 1.2.0
       magic-string: 0.30.17
@@ -9317,7 +9271,7 @@ snapshots:
 
   '@types/jsdom@21.1.7':
     dependencies:
-      '@types/node': 20.17.16
+      '@types/node': 22.13.4
       '@types/tough-cookie': 4.0.5
       parse5: 7.2.1
 
@@ -9371,6 +9325,10 @@ snapshots:
   '@types/vscode@1.84.0': {}
 
   '@types/web-bluetooth@0.0.20': {}
+
+  '@types/ws@8.5.14':
+    dependencies:
+      '@types/node': 22.13.4
 
   '@typescript-eslint/eslint-plugin@8.24.0(@typescript-eslint/parser@8.24.0(eslint@9.10.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.10.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
@@ -9543,18 +9501,6 @@ snapshots:
       - supports-color
       - vue
 
-  '@unocss/astro@0.64.1(rollup@4.34.7)(vite@6.0.11(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))':
-    dependencies:
-      '@unocss/core': 0.64.1
-      '@unocss/reset': 0.64.1
-      '@unocss/vite': 0.64.1(rollup@4.34.7)(vite@6.0.11(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))
-    optionalDependencies:
-      vite: 6.0.11(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-      - vue
-
   '@unocss/astro@0.64.1(rollup@4.34.7)(vite@6.1.0(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))':
     dependencies:
       '@unocss/core': 0.64.1
@@ -9706,22 +9652,6 @@ snapshots:
       - supports-color
       - vue
 
-  '@unocss/vite@0.64.1(rollup@4.34.7)(vite@6.0.11(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@rollup/pluginutils': 5.1.4(rollup@4.34.7)
-      '@unocss/config': 0.64.1
-      '@unocss/core': 0.64.1
-      '@unocss/inspector': 0.64.1(vue@3.5.13(typescript@5.7.3))
-      chokidar: 3.6.0
-      magic-string: 0.30.17
-      tinyglobby: 0.2.10
-      vite: 6.0.11(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-      - vue
-
   '@unocss/vite@0.64.1(rollup@4.34.7)(vite@6.1.0(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -9797,13 +9727,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.4(vite@6.0.11(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))':
+  '@vitest/mocker@3.0.4(vite@6.1.0(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 3.0.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.0.11(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
+      vite: 6.1.0(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
 
   '@vitest/pretty-format@3.0.4':
     dependencies:
@@ -9848,14 +9778,14 @@ snapshots:
       vscode-languageserver: 9.0.1
       vscode-languageserver-protocol: 3.17.5
       vscode-languageserver-textdocument: 1.0.12
-      vscode-uri: 3.0.8
+      vscode-uri: 3.1.0
 
   '@volar/language-service@2.4.11':
     dependencies:
       '@volar/language-core': 2.4.11
       vscode-languageserver-protocol: 3.17.5
       vscode-languageserver-textdocument: 1.0.12
-      vscode-uri: 3.0.8
+      vscode-uri: 3.1.0
 
   '@volar/source-map@2.4.11': {}
 
@@ -9863,7 +9793,7 @@ snapshots:
     dependencies:
       '@volar/language-core': 2.4.11
       path-browserify: 1.0.1
-      vscode-uri: 3.0.8
+      vscode-uri: 3.1.0
 
   '@volar/vscode@2.4.11':
     dependencies:
@@ -9878,7 +9808,7 @@ snapshots:
       jsonc-parser: 2.3.1
       vscode-languageserver-textdocument: 1.0.12
       vscode-languageserver-types: 3.17.5
-      vscode-uri: 3.0.8
+      vscode-uri: 3.1.0
 
   '@vscode/l10n@0.0.18': {}
 
@@ -9995,7 +9925,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.13':
     dependencies:
-      '@babel/parser': 7.26.7
+      '@babel/parser': 7.26.9
       '@vue/shared': 3.5.13
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -11403,7 +11333,7 @@ snapshots:
     dependencies:
       '@antfu/utils': 0.7.10
       '@types/eslint': 9.6.1
-      '@typescript-eslint/utils': 8.15.0(eslint@9.10.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@9.10.0(jiti@2.4.2))(typescript@5.7.3)
       eslint: 9.10.0(jiti@2.4.2)
       vitest: 3.0.4(@types/debug@4.1.12)(@types/node@22.13.4)(jiti@2.4.2)(jsdom@25.0.1)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
     transitivePeerDependencies:
@@ -11835,7 +11765,7 @@ snapshots:
     dependencies:
       duplexer: 0.1.2
 
-  h3@1.15.0:
+  h3@1.15.1:
     dependencies:
       cookie-es: 1.2.2
       crossws: 0.3.4
@@ -11843,7 +11773,6 @@ snapshots:
       destr: 2.0.3
       iron-webcrypto: 1.2.1
       node-mock-http: 1.0.0
-      ohash: 1.1.4
       radix3: 1.1.2
       ufo: 1.5.4
       uncrypto: 0.1.3
@@ -12207,7 +12136,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.1.1
-      ws: 8.18.0
+      ws: 8.18.1
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -12380,7 +12309,7 @@ snapshots:
       crossws: 0.3.4
       defu: 6.1.4
       get-port-please: 3.1.2
-      h3: 1.15.0
+      h3: 1.15.1
       http-shutdown: 1.2.2
       jiti: 2.4.2
       mlly: 1.7.4
@@ -13030,7 +12959,7 @@ snapshots:
       fs-extra: 11.3.0
       globby: 14.1.0
       gzip-size: 7.0.0
-      h3: 1.15.0
+      h3: 1.15.1
       hookable: 5.5.3
       httpxy: 0.1.7
       ioredis: 5.5.0
@@ -13180,7 +13109,7 @@ snapshots:
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
       globby: 14.1.0
-      h3: 1.15.0
+      h3: 1.15.1
       hookable: 5.5.3
       ignore: 7.0.3
       impound: 0.2.0(rollup@4.34.7)
@@ -14770,33 +14699,6 @@ snapshots:
       - supports-color
       - vue
 
-  unocss@0.64.1(postcss@8.5.2)(rollup@4.34.7)(vite@6.0.11(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3)):
-    dependencies:
-      '@unocss/astro': 0.64.1(rollup@4.34.7)(vite@6.0.11(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))
-      '@unocss/cli': 0.64.1(rollup@4.34.7)
-      '@unocss/core': 0.64.1
-      '@unocss/postcss': 0.64.1(postcss@8.5.2)
-      '@unocss/preset-attributify': 0.64.1
-      '@unocss/preset-icons': 0.64.1
-      '@unocss/preset-mini': 0.64.1
-      '@unocss/preset-tagify': 0.64.1
-      '@unocss/preset-typography': 0.64.1
-      '@unocss/preset-uno': 0.64.1
-      '@unocss/preset-web-fonts': 0.64.1
-      '@unocss/preset-wind': 0.64.1
-      '@unocss/transformer-attributify-jsx': 0.64.1
-      '@unocss/transformer-compile-class': 0.64.1
-      '@unocss/transformer-directives': 0.64.1
-      '@unocss/transformer-variant-group': 0.64.1
-      '@unocss/vite': 0.64.1(rollup@4.34.7)(vite@6.0.11(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))
-    optionalDependencies:
-      vite: 6.0.11(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
-    transitivePeerDependencies:
-      - postcss
-      - rollup
-      - supports-color
-      - vue
-
   unocss@0.64.1(postcss@8.5.2)(rollup@4.34.7)(vite@6.1.0(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3)):
     dependencies:
       '@unocss/astro': 0.64.1(rollup@4.34.7)(vite@6.1.0(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))
@@ -14887,7 +14789,7 @@ snapshots:
       anymatch: 3.1.3
       chokidar: 3.6.0
       destr: 2.0.3
-      h3: 1.15.0
+      h3: 1.15.1
       lru-cache: 10.4.3
       node-fetch-native: 1.6.6
       ofetch: 1.4.1
@@ -14972,7 +14874,7 @@ snapshots:
       debug: 4.4.0(supports-color@9.4.0)
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.0.11(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
+      vite: 6.1.0(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -14993,7 +14895,7 @@ snapshots:
       debug: 4.4.0(supports-color@9.4.0)
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.0.11(@types/node@22.13.4)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
+      vite: 6.1.0(@types/node@22.13.4)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -15052,42 +14954,6 @@ snapshots:
       typescript: 5.7.3
       vue-tsc: 2.1.10(typescript@5.7.3)
 
-  vite-plugin-inspect@0.8.9(@nuxt/kit@3.15.3(magicast@0.3.5))(rollup@4.34.7)(vite@6.1.0(@types/node@22.13.4)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)):
-    dependencies:
-      '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.1.4(rollup@4.34.7)
-      debug: 4.4.0(supports-color@9.4.0)
-      error-stack-parser-es: 0.1.5
-      fs-extra: 11.3.0
-      open: 10.1.0
-      perfect-debounce: 1.0.0
-      picocolors: 1.1.1
-      sirv: 3.0.0
-      vite: 6.1.0(@types/node@22.13.4)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
-    optionalDependencies:
-      '@nuxt/kit': 3.15.3(magicast@0.3.5)
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-
-  vite-plugin-inspect@0.8.9(@nuxt/kit@3.15.4(magicast@0.3.5))(rollup@4.34.7)(vite@6.0.11(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)):
-    dependencies:
-      '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.1.4(rollup@4.34.7)
-      debug: 4.4.0(supports-color@9.4.0)
-      error-stack-parser-es: 0.1.5
-      fs-extra: 11.3.0
-      open: 10.1.0
-      perfect-debounce: 1.0.0
-      picocolors: 1.1.1
-      sirv: 3.0.0
-      vite: 6.0.11(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
-    optionalDependencies:
-      '@nuxt/kit': 3.15.4(magicast@0.3.5)
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-
   vite-plugin-inspect@0.8.9(@nuxt/kit@3.15.4(magicast@0.3.5))(rollup@4.34.7)(vite@6.1.0(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)):
     dependencies:
       '@antfu/utils': 0.7.10
@@ -15100,6 +14966,24 @@ snapshots:
       picocolors: 1.1.1
       sirv: 3.0.0
       vite: 6.1.0(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
+    optionalDependencies:
+      '@nuxt/kit': 3.15.4(magicast@0.3.5)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+
+  vite-plugin-inspect@0.8.9(@nuxt/kit@3.15.4(magicast@0.3.5))(rollup@4.34.7)(vite@6.1.0(@types/node@22.13.4)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)):
+    dependencies:
+      '@antfu/utils': 0.7.10
+      '@rollup/pluginutils': 5.1.4(rollup@4.34.7)
+      debug: 4.4.0(supports-color@9.4.0)
+      error-stack-parser-es: 0.1.5
+      fs-extra: 11.3.0
+      open: 10.1.0
+      perfect-debounce: 1.0.0
+      picocolors: 1.1.1
+      sirv: 3.0.0
+      vite: 6.1.0(@types/node@22.13.4)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
     optionalDependencies:
       '@nuxt/kit': 3.15.4(magicast@0.3.5)
     transitivePeerDependencies:
@@ -15132,36 +15016,6 @@ snapshots:
       less: 4.2.2
       sass: 1.85.0
       terser: 5.39.0
-
-  vite@6.0.11(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0):
-    dependencies:
-      esbuild: 0.24.2
-      postcss: 8.5.2
-      rollup: 4.34.7
-    optionalDependencies:
-      '@types/node': 20.17.16
-      fsevents: 2.3.3
-      jiti: 2.4.2
-      less: 4.2.2
-      sass: 1.85.0
-      terser: 5.39.0
-      tsx: 4.19.2
-      yaml: 2.7.0
-
-  vite@6.0.11(@types/node@22.13.4)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0):
-    dependencies:
-      esbuild: 0.24.2
-      postcss: 8.5.2
-      rollup: 4.34.7
-    optionalDependencies:
-      '@types/node': 22.13.4
-      fsevents: 2.3.3
-      jiti: 2.4.2
-      less: 4.2.2
-      sass: 1.85.0
-      terser: 5.39.0
-      tsx: 4.19.2
-      yaml: 2.7.0
 
   vite@6.1.0(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0):
     dependencies:
@@ -15274,7 +15128,7 @@ snapshots:
   vitest@3.0.4(@types/debug@4.1.12)(@types/node@20.17.16)(jiti@2.4.2)(jsdom@25.0.1)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0):
     dependencies:
       '@vitest/expect': 3.0.4
-      '@vitest/mocker': 3.0.4(vite@6.0.11(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
+      '@vitest/mocker': 3.0.4(vite@6.1.0(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       '@vitest/pretty-format': 3.0.5
       '@vitest/runner': 3.0.4
       '@vitest/snapshot': 3.0.4
@@ -15290,7 +15144,7 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.0.11(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
+      vite: 6.1.0(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
       vite-node: 3.0.4(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -15314,7 +15168,7 @@ snapshots:
   vitest@3.0.4(@types/debug@4.1.12)(@types/node@22.13.4)(jiti@2.4.2)(jsdom@25.0.1)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0):
     dependencies:
       '@vitest/expect': 3.0.4
-      '@vitest/mocker': 3.0.4(vite@6.0.11(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
+      '@vitest/mocker': 3.0.4(vite@6.1.0(@types/node@20.17.16)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       '@vitest/pretty-format': 3.0.5
       '@vitest/runner': 3.0.4
       '@vitest/snapshot': 3.0.4
@@ -15330,7 +15184,7 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.0.11(@types/node@22.13.4)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
+      vite: 6.1.0(@types/node@22.13.4)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
       vite-node: 3.0.4(@types/node@22.13.4)(jiti@2.4.2)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -15355,7 +15209,7 @@ snapshots:
     dependencies:
       vscode-css-languageservice: 6.3.2
       vscode-languageserver-textdocument: 1.0.12
-      vscode-uri: 3.0.8
+      vscode-uri: 3.1.0
     optionalDependencies:
       '@volar/language-service': 2.4.11
 
@@ -15364,7 +15218,7 @@ snapshots:
       '@emmetio/css-parser': 0.4.0
       '@emmetio/html-matcher': 1.3.0
       '@vscode/emmet-helper': 2.11.0
-      vscode-uri: 3.0.8
+      vscode-uri: 3.1.0
     optionalDependencies:
       '@volar/language-service': 2.4.11
 
@@ -15372,7 +15226,7 @@ snapshots:
     dependencies:
       vscode-html-languageservice: 5.3.1
       vscode-languageserver-textdocument: 1.0.12
-      vscode-uri: 3.0.8
+      vscode-uri: 3.1.0
     optionalDependencies:
       '@volar/language-service': 2.4.11
 
@@ -15412,7 +15266,7 @@ snapshots:
       typescript-auto-import-cache: 0.3.5
       vscode-languageserver-textdocument: 1.0.12
       vscode-nls: 5.2.0
-      vscode-uri: 3.0.8
+      vscode-uri: 3.1.0
     optionalDependencies:
       '@volar/language-service': 2.4.11
 
@@ -15421,14 +15275,14 @@ snapshots:
       '@vscode/l10n': 0.0.18
       vscode-languageserver-textdocument: 1.0.12
       vscode-languageserver-types: 3.17.5
-      vscode-uri: 3.0.8
+      vscode-uri: 3.1.0
 
   vscode-html-languageservice@5.3.1:
     dependencies:
       '@vscode/l10n': 0.0.18
       vscode-languageserver-textdocument: 1.0.12
       vscode-languageserver-types: 3.17.5
-      vscode-uri: 3.0.8
+      vscode-uri: 3.1.0
 
   vscode-json-languageservice@5.4.3:
     dependencies:
@@ -15479,8 +15333,6 @@ snapshots:
       vscode-languageserver-protocol: 3.17.5
 
   vscode-nls@5.2.0: {}
-
-  vscode-uri@3.0.8: {}
 
   vscode-uri@3.1.0: {}
 
@@ -15598,7 +15450,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.18.0: {}
+  ws@8.18.1: {}
 
   xml-name-validator@4.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -505,6 +505,9 @@ importers:
       '@vue/shared':
         specifier: 'catalog:'
         version: 3.5.13
+      detect-port:
+        specifier: ^2.1.0
+        version: 2.1.0
       muggle-string:
         specifier: ^0.4.1
         version: 0.4.1
@@ -2864,6 +2867,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  address@2.0.3:
+    resolution: {integrity: sha512-XNAb/a6TCqou+TufU8/u11HCu9x1gYvOoxLwtlXgIqmkrYQADVv6ljyW2zwiPhHz9R1gItAWpuDrdJMmrOBFEA==, tarball: https://registry.npmjs.org/address/-/address-2.0.3.tgz}
+    engines: {node: '>= 16.0.0'}
+
   agent-base@7.1.3:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==, tarball: https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz}
     engines: {node: '>= 14'}
@@ -3568,6 +3575,11 @@ packages:
   detect-libc@2.0.3:
     resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==, tarball: https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz}
     engines: {node: '>=8'}
+
+  detect-port@2.1.0:
+    resolution: {integrity: sha512-epZuWb/6Q62L+nDHJc/hQAqf8pylsqgk3BpZXVBx1CDnr3nkrVNn73Uu1rXcFzkNcc+hkP3whuOg7JZYaQB65Q==, tarball: https://registry.npmjs.org/detect-port/-/detect-port-2.1.0.tgz}
+    engines: {node: '>= 16.0.0'}
+    hasBin: true
 
   devalue@5.1.1:
     resolution: {integrity: sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==, tarball: https://registry.npmjs.org/devalue/-/devalue-5.1.1.tgz}
@@ -10136,6 +10148,8 @@ snapshots:
 
   acorn@8.14.0: {}
 
+  address@2.0.3: {}
+
   agent-base@7.1.3: {}
 
   aggregate-error@4.0.1:
@@ -10864,6 +10878,10 @@ snapshots:
   detect-libc@1.0.3: {}
 
   detect-libc@2.0.3: {}
+
+  detect-port@2.1.0:
+    dependencies:
+      address: 2.0.3
 
   devalue@5.1.1: {}
 


### PR DESCRIPTION
Close #221 

## Description

We established a C/S architecture named "Pipeline server" on TS plugin initialization, (just like [vuejs/language-tools](https://github.com/vuejs/language-tools))
use the context of TS language service to communicate with VSCode extension.

## ~Currently not resolved problems~

- [x] Multiple VSCode windows will conflict on creating WebSocket server.
