### PR TITLE
feat(lang-service): intellisense and navigation for useTemplateRef

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "bump": "pnpm changeset add",
     "changeset:core": "pnpm changeset version --ignore \"vue-vine-extension\" --ignore \"vue-vine-tsc\" --ignore \"@vue-vine/nuxt\" && git add ./packages/*/package.json",
     "changeset:main": "pnpm changeset version --ignore \"vue-vine-tsc\" --ignore \"@vue-vine/nuxt\" && git add ./packages/*/package.json",
-    "pkg-new:publish": "pnpx pkg-pr-new publish --pnpm './packages/compiler' './packages/language-service' './packages/language-server' './packages/vite-plugin' './packages/eslint-parser' './packages/eslint-plugin' './packages/eslint-config' './packages/nuxt-module' './packages/vscode-ext' './packages/tsc' './packages/vue-vine' './packages/create-vue-vine'",
+    "pkg-new:publish": "pnpx pkg-pr-new publish --pnpm './packages/compiler' './packages/language-service' './packages/language-server' './packages/vite-plugin' './packages/eslint-parser' './packages/eslint-plugin' './packages/eslint-config' './packages/nuxt-module' './packages/tsc' './packages/vue-vine' './packages/create-vue-vine'",
     "typecheck": "pnpm --parallel -r typecheck",
     "upgrade-deps": "node scripts/upgrade-deps.js"
   },

--- a/packages/compiler/src/analyze.ts
+++ b/packages/compiler/src/analyze.ts
@@ -1094,6 +1094,7 @@ function buildVineCompFnCtx(
     templateReturn,
     templateSource,
     templateComponentNames: new Set<string>(),
+    templateRefNames: new Set<string>(),
     linkedMacroCalls: [],
     propsDestructuredNames: {},
     propsDefinitionBy: 'annotaion',

--- a/packages/compiler/src/template/compose.ts
+++ b/packages/compiler/src/template/compose.ts
@@ -226,6 +226,18 @@ function setVineTemplateAst(
         return
       }
 
+      // Collect all template ref literal names
+      const maybeRef = node.props.find(
+        prop => (
+          prop.type === NodeTypes.ATTRIBUTE
+          && prop.name === 'ref'
+          && prop.value?.type === NodeTypes.TEXT
+        ),
+      ) as (AttributeNode | undefined)
+      if (maybeRef?.value) {
+        vineCompFnCtx.templateRefNames.add(maybeRef.value.content)
+      }
+
       if (node.tagType === ElementTypes.COMPONENT) {
         vineCompFnCtx.templateComponentNames.add(node.tag)
       }

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -190,6 +190,7 @@ export interface VineCompFnCtx {
   templateAst?: RootNode
   templateParsedAst?: RootNode
   templateComponentNames: Set<string>
+  templateRefNames: Set<string>
   isExportDefault: boolean
   isAsync: boolean
   /** is web component (customElement) */

--- a/packages/nuxt-module/playground/app.vue
+++ b/packages/nuxt-module/playground/app.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
+import { useTemplateRef } from 'vue';
 import Welcome from './welcome.vine'
+const divRef = useTemplateRef('foo')
 </script>
 
 <template>
-  <div style="text-align: center;">
+  <div ref="foo" style="text-align: center;">
     <Welcome content="Nuxt module playground!" />
   </div>
 </template>

--- a/packages/playground/src/components/debug.vine.ts
+++ b/packages/playground/src/components/debug.vine.ts
@@ -1,3 +1,10 @@
+/**
+ * This is a placeholder for debugging virutal code.
+ * 
+ * So please revert any changes made in this file before you commit,
+ * in order to remain a clean environment for testing.
+ */
+
 function DebugTest() {
   return vine`
     <div>...</div>

--- a/scripts/pre-commit.js
+++ b/scripts/pre-commit.js
@@ -24,8 +24,8 @@ async function runCommitMsgHook() {
 Error: Commit message format does not meet the requirements.
 
 Please follow the commitlint format, for example:
-  feat(module): add new feature
-  fix: fix a bug
+  feat(module): message less than 50 characters
+  fix: message less than 50 characters
 `)
     process.exit(1)
   }


### PR DESCRIPTION
## Preview

Now after you add a `ref="..."` on a HTML element or a component, you'll able to get intellisense when referencing it in params of `useTemplateRef( ... )`

![Kapture 2025-04-23 at 15 04 17](https://github.com/user-attachments/assets/9315f17d-8bb7-44f6-b58f-6f1468326b53)
