### PR TITLE
feat(compiler): analyze type generics in props literal

### DIFF
--- a/packages/compiler/src/ts-morph/resolve-props-type.ts
+++ b/packages/compiler/src/ts-morph/resolve-props-type.ts
@@ -24,6 +24,14 @@ function isBooleanType(
     return type.getIntersectionTypes().some(t => t.isBoolean())
   }
 
+  // Generic types, need to get the actual type
+  if (type.isTypeParameter()) {
+    const actualType = type.getConstraint()
+    if (actualType) {
+      return isBooleanType(typeChecker, actualType)
+    }
+  }
+
   // Alias types, need to get the actual type
   const aliasSymbol = type.getAliasSymbol()
   if (aliasSymbol) {

--- a/packages/compiler/src/utils/index.ts
+++ b/packages/compiler/src/utils/index.ts
@@ -87,3 +87,12 @@ export const _breakableTraverse: typeof traverse = (node, handlers) => {
     throw e
   }
 }
+
+export function isBasicBoolTypeNames(type: string) {
+  return [
+    'boolean',
+    'Boolean',
+    'true',
+    'false',
+  ].includes(type)
+}

--- a/packages/compiler/tests/ts-morph.spec.ts
+++ b/packages/compiler/tests/ts-morph.spec.ts
@@ -198,4 +198,33 @@ export function TestTsMorph(props: P) {
       }
     `)
   })
+
+  it('can resolve generics in props type literal', () => {
+    const { vineFile, project, typeChecker } = prepareTsMorphProject(`
+export function TestGenerics<T extends boolean>(props: {
+  foo: T
+}) {
+  return vine\`
+    <div>TestGenerics foo: {{ foo }}</div>
+  \`
+}
+    `)
+    const { mockCompilerCtx, mockCompilerHooks } = createMockTransformCtx(vineFile.fileId, project, typeChecker)
+    compileVineTypeScriptFile(vineFile.content, vineFile.fileId, { compilerHooks: mockCompilerHooks })
+    expect(mockCompilerCtx.vineCompileErrors.length).toMatchInlineSnapshot(`0`)
+    expect(mockCompilerCtx.vineCompileWarnings.length).toMatchInlineSnapshot(`0`)
+    const fileCtx = mockCompilerCtx.fileCtxMap.get(vineFile.fileId)
+    const vineCompFnCtx = fileCtx?.vineCompFns?.find(fn => fn.fnName === 'TestGenerics')
+    expect(vineCompFnCtx).not.toBeUndefined()
+    expect(vineCompFnCtx?.props).toMatchInlineSnapshot(`
+      {
+        "foo": {
+          "isBool": true,
+          "isFromMacroDefine": false,
+          "isRequired": true,
+          "typeAnnotationRaw": "T",
+        },
+      }
+    `)
+  })
 })

--- a/packages/playground/src/pages/about.vine.ts
+++ b/packages/playground/src/pages/about.vine.ts
@@ -35,10 +35,21 @@ function TestSlotContainer({ fizz, bar = 1 }: {
   `
 }
 
+function TestGenerics<T extends boolean>(props: {
+  foo: T
+}) {
+  return vine`
+    <div>
+      <p>foo: {{ foo }}</p>
+    </div>
+  `
+}
+
 export function AboutPage() {
   const handleEmitCamel = (bar: string) => {
     console.log(bar)
   }
+  const testBool = ref(true)
   const testSlotContainerText = ref('')
   const slotContainerRef = useTemplateRef('slotContainerRef')
 
@@ -47,6 +58,7 @@ export function AboutPage() {
     <div>
       <h2>About page</h2>
     </div>
+    <TestGenerics :foo="testBool" />
     <p class="my-4">
       TestSlotContainer text: {{ testSlotContainerText ?? "__Empty__" }}
     </p>

--- a/packages/playground/src/pages/home.vine.ts
+++ b/packages/playground/src/pages/home.vine.ts
@@ -97,6 +97,7 @@ export function HomePage() {
   console.log('%c VINE %c Click the link to explore source code ->', 'background: green;', '')
 
   return vine`
+    <PageHeader />
     <OutsideExample :id="id" />
     <div class="flex flex-row items-center justify-center my-4">
       <div


### PR DESCRIPTION
## This problem comes from ...
<img width="436" alt="image" src="https://github.com/user-attachments/assets/14795813-1650-408b-8b52-484b27a04e67" />

## Solution
Use ts-morph to resolve generic type parameters' constraint, check whether it is a boolean type