### PR TITLE
fix(compiler): disable component props resolving by ts-morph in ext

### DIFF
--- a/packages/compiler/src/analyze.ts
+++ b/packages/compiler/src/analyze.ts
@@ -453,10 +453,13 @@ const analyzeVineProps: AnalyzeRunner = (
     // Should initialize ts-morph when props is a type alias
     // or that type literal contains generic type parameters
     if (
-      (!isTypeLiteralProps || isContainsGenericTypeParams)
-      && !isTsMorphDisabled
-      && vineCompilerHooks.getTsMorph
+      !isTsMorphDisabled
+      && (!isTypeLiteralProps || isContainsGenericTypeParams)
     ) {
+      if (!vineCompilerHooks.getTsMorph) {
+        throw new Error('ts-morph is not initialized')
+      }
+
       try {
         tsMorphCache = vineCompilerHooks.getTsMorph()
         // Use ts-morph to analyze props info
@@ -518,14 +521,7 @@ const analyzeVineProps: AnalyzeRunner = (
         }
       })
     }
-    else {
-      if (!vineCompilerHooks.getTsMorph) {
-        throw new Error('ts-morph is not initialized')
-      }
-      if (!tsMorphCache || !tsMorphAnalyzedPropsInfo) {
-        return
-      }
-
+    else if (tsMorphCache && tsMorphAnalyzedPropsInfo) {
       vineCompFnCtx.props = tsMorphAnalyzedPropsInfo
     }
   }

--- a/packages/language-service/src/virtual-code.ts
+++ b/packages/language-service/src/virtual-code.ts
@@ -587,8 +587,10 @@ export function createVueVineCode(
     else {
       // User provide a `props` formal parameter in the component function,
       // we should keep it in virtual code, and generate `context: ...` after it,
-      const formalParamTypeNode = vineCompFn.propsFormalParamType!
-      generateScriptUntil(formalParamTypeNode.end!)
+      const formalParamTypeNode = vineCompFn.propsFormalParamType
+      if (formalParamTypeNode) {
+        generateScriptUntil(formalParamTypeNode.end!)
+      }
 
       // Generate `context: { ... }` after `props: ...`
       tsCodeSegments.push(`${


### PR DESCRIPTION
Fix VSCode extension broken:
`Error: ts-morph is not initialized.`