### PR TITLE
fix(lang-service): virtual code generation should be sorted

### DIFF
--- a/packages/compiler/src/babel-helpers/ast.ts
+++ b/packages/compiler/src/babel-helpers/ast.ts
@@ -211,6 +211,10 @@ export const isVineStyle = isVineMacroOf('vineStyle')
 export const isVineCustomElement = isVineMacroOf('vineCustomElement')
 export const isVineValidators = isVineMacroOf('vineValidators')
 
+export function isUseTemplateRefCall(node: Node) {
+  return isCallOf(node, 'useTemplateRef')
+}
+
 interface VineImportScopedCallee extends MemberExpression {
   object: CallExpression
   property: Identifier

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -39,10 +39,13 @@ export type CountingMacros = Exclude<
   | 'vineProp.withDefault'
   | 'vineModel'
 >
-export type LinkedMacroInfo =
+export type MacrosInfoForVolar =
   | { macroType: 'vineProp', macroCall: CallExpression, macroMeta: VinePropMeta }
   | { macroType: 'vineEmits', macroCall: CallExpression }
   | { macroType: 'vineSlots', macroCall: CallExpression }
+  | { macroType: 'vineExpose', macroCall: CallExpression }
+  | { macroType: 'vineValidators', macroCall: CallExpression }
+  | { macroType: 'useTemplateRef', macroCall: CallExpression }
 export type VineStyleValidArg = StringLiteral | TemplateLiteral | TaggedTemplateExpression
 
 export type VineProcessorLang = 'scss' | 'sass' | 'less' | 'stylus'
@@ -204,7 +207,7 @@ export interface VineCompFnCtx {
   fnName: string
   scopeId: string
   bindings: VineTemplateBindings
-  linkedMacroCalls: LinkedMacroInfo[]
+  macrosInfoForVolar: MacrosInfoForVolar[]
   propsAlias: string
   props: Record<string, VinePropMeta>
   propsDestructuredNames: Record<string, VineDestructuredProp>
@@ -233,7 +236,6 @@ export interface VineCompFnCtx {
     modelModifiersName: string
     modelOptions: Node | null
   }>
-  vineValidatorsMacroCall?: CallExpression
   slotsAlias: string
   hoistSetupStmts: Node[]
   cssBindings: Record<string, string | null>

--- a/packages/compiler/tests/analyze.spec.ts
+++ b/packages/compiler/tests/analyze.spec.ts
@@ -349,7 +349,7 @@ function ErrComp() {
     const fileCtx = mockCompilerCtx.fileCtxMap.get('testAnalyzeVineValidators')
     expect(fileCtx?.vineCompFns.length).toMatchInlineSnapshot(`2`)
     const MyComp = fileCtx?.vineCompFns[0]
-    expect(Boolean(MyComp?.vineValidatorsMacroCall)).toBe(true)
+    expect(Boolean(MyComp?.macrosInfoForVolar.some(info => info.macroType === 'vineValidators'))).toBe(true)
     expect(Boolean(MyComp?.props.foo.validator)).toBe(true)
     expect(Boolean(MyComp?.props.bar.validator)).toBe(true)
   })


### PR DESCRIPTION
## Issue description

The current code generation process is completely sequential. However, the order in which users write vine macros within the function body is uncertain. Therefore, it is necessary to make each execution unit of the code generation correspond to the content of the source code.  