### PR TITLE
refactor: transform code logic improving

### DIFF
--- a/packages/compiler/src/analyze.ts
+++ b/packages/compiler/src/analyze.ts
@@ -19,6 +19,8 @@ import type {
 } from '@babel/types'
 import type { BindingTypes } from '@vue/compiler-dom'
 import type {
+  VineAnalyzeCtx as AnalyzeCtx,
+  VineAnalyzeRunner as AnalyzeRunner,
   BabelFunctionNodeTypes,
   MacrosInfoForVolar,
   Nil,
@@ -99,18 +101,7 @@ import { parseCssVars } from './style/analyze-css-vars'
 import { isImportUsed } from './template/import-usage-check'
 import { resolveVineCompFnProps } from './ts-morph/resolve-props-type'
 import { VinePropsDefinitionBy } from './types'
-import { _breakableTraverse, exitTraverse, isBasicBoolTypeNames } from './utils'
-
-interface AnalyzeCtx {
-  vineCompilerHooks: VineCompilerHooks
-  vineFileCtx: VineFileCtx
-  vineCompFnCtx: VineCompFnCtx
-}
-
-type AnalyzeRunner = (
-  analyzeCtx: AnalyzeCtx,
-  fnItselfNode: BabelFunctionNodeTypes,
-) => void
+import { _breakableTraverse, createLinkedCodeTag, exitTraverse, isBasicBoolTypeNames } from './utils'
 
 function storeTheOnlyMacroCallArg(
   macroName: VINE_MACRO_NAMES,
@@ -1160,13 +1151,6 @@ function analyzeFileImportStmts(
   }
   const lastImportStmt = fileImportStmts[fileImportStmts.length - 1]
   vineFileCtx.importsLastLine = lastImportStmt.loc
-}
-
-export function createLinkedCodeTag(
-  side: 'left' | 'right',
-  itemLength: number,
-) {
-  return `/* __LINKED_CODE_${side.toUpperCase()}__#${itemLength} */`
 }
 
 function buildVineCompFnCtx(

--- a/packages/compiler/src/babel-helpers/ast.ts
+++ b/packages/compiler/src/babel-helpers/ast.ts
@@ -38,9 +38,9 @@ import {
   isVariableDeclarator,
   traverse,
 } from '@babel/types'
+import { TS_NODE_TYPES } from '@vue/compiler-dom'
 import {
   EXPECTED_ERROR,
-  TS_NODE_TYPES,
   VINE_MACROS,
   VUE_REACTIVITY_APIS,
 } from '../constants'

--- a/packages/compiler/src/constants.ts
+++ b/packages/compiler/src/constants.ts
@@ -88,13 +88,6 @@ export const VUE_LIFECYCLE_HOOK_APIS = [
   'onDeactivated',
   'onServerPrefetch',
 ] as const
-export const TS_NODE_TYPES = [
-  'TSAsExpression', // foo as number
-  'TSTypeAssertion', // (<number>foo)
-  'TSNonNullExpression', // foo!
-  'TSInstantiationExpression', // foo<string>
-  'TSSatisfiesExpression', // foo satisfies T
-]
 /** This is derived from `@vue/compiler-core` */
 export const VineBindingTypes = {
   /**

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1,10 +1,11 @@
 import type { Node } from '@babel/types'
 import type { VineCompileCtx, VineCompilerCtx, VineCompilerHooks, VineCompilerOptions, VineFileCtx } from './types'
 import MagicString from 'magic-string'
-import { analyzeVine, createLinkedCodeTag } from './analyze'
+import { analyzeVine } from './analyze'
 import { findAllExportNamedDeclarations, findVineCompFnDecls } from './babel-helpers/ast'
 import { babelParse } from './babel-helpers/parse'
 import { transformFile } from './transform'
+import { createLinkedCodeTag } from './utils'
 import { validateVine } from './validate'
 
 export {

--- a/packages/compiler/src/style/order.ts
+++ b/packages/compiler/src/style/order.ts
@@ -38,30 +38,26 @@ export function sortStyleImport(
     })
   }
 
-  const sortedStyleImportStmts = (
-    topoSort(relationsMap)?.map(
-      compName => vineCompFns.find(
-        compFn => compFn.fnName === compName,
-      )!,
-    ) ?? []
+  const sortedCompFns = topoSort(relationsMap)?.map(
+    compName => vineCompFns.find(
+      compFn => compFn.fnName === compName,
+    )!,
+  ) ?? []
+  const hasStyleDefineCompFns = sortedCompFns.filter(
+    compFn => Boolean(styleDefine[compFn.scopeId]),
   )
-    .filter(
-      fnCompCtx => Boolean(styleDefine[fnCompCtx.scopeId]),
-    )
-    .map(
-      fnCompCtx => [fnCompCtx, styleDefine[fnCompCtx.scopeId]] as const,
-    )
-    .map(
-      ([fnCompCtx, styleMetas]) => styleMetas.map(
-        (styleMeta, i) => createStyleImportStmt(
-          vineFileCtx,
-          fnCompCtx,
-          styleMeta,
-          i,
-        ),
+  const sortedStyleImportStmts = hasStyleDefineCompFns.map(
+    compFn => [compFn, styleDefine[compFn.scopeId]] as const,
+  ).map(
+    ([compFn, styleMetas]) => styleMetas.map(
+      (styleMeta, i) => createStyleImportStmt(
+        vineFileCtx,
+        compFn,
+        styleMeta,
+        i,
       ),
-    )
-    .flat()
+    ),
+  ).flat()
 
   return sortedStyleImportStmts
 }

--- a/packages/compiler/src/transform.ts
+++ b/packages/compiler/src/transform.ts
@@ -1,406 +1,35 @@
-import type { AwaitExpression, BlockStatement, Identifier, Node, VariableDeclaration } from '@babel/types'
-import type { MergedImportsMap, NamedImportSpecifierMeta } from './template/compose'
-import type { VineCompFnCtx, VineCompilerHooks, VineFileCtx } from './types'
+import type { SingleFnCompTransformCtx, TransformContext } from './transform/steps'
+import type { VineCompilerHooks, VineFileCtx } from './types'
+import { isBlockStatement } from '@babel/types'
 import {
-  isAwaitExpression,
-  isBlockStatement,
-  isExpressionStatement,
-  isReturnStatement,
-  isVariableDeclaration,
-  traverse,
-} from '@babel/types'
-import { extractIdentifiers, isFunctionType, isInDestructureAssignment, isReferencedIdentifier, isStaticProperty, TS_NODE_TYPES, unwrapTSNode, walkFunctionParams } from '@vue/compiler-dom'
-import { walk } from 'estree-walker'
-import { fineAllExplicitExports, isCallOf, isStatementContainsVineMacroCall } from './babel-helpers/ast'
-import {
-  CREATE_PROPS_REST_PROXY_HELPER,
-  CSS_VARS_HELPER,
-  DEFINE_COMPONENT_HELPER,
-  EXPECTED_ERROR,
-  TO_REFS_HELPER,
-  UN_REF_HELPER,
-  USE_DEFAULTS_HELPER,
-  USE_MODEL_HELPER,
-  USE_SLOT_HELPER,
-  WITH_ASYNC_CONTEXT_HELPER,
 } from './constants'
-import { vineErr } from './diagnostics'
-import { sortStyleImport } from './style/order'
-import { compileCSSVars } from './style/transform-css-var'
-import { createInlineTemplateComposer, createSeparatedTemplateComposer } from './template/compose'
-import { filterJoin, showIf } from './utils'
-
-const identRE = /^[_$a-z\xA0-\uFFFF][\w$\xA0-\uFFFF]*$/i
-
-function wrapWithAsyncContext(
-  isNeedResult: boolean,
-  exprSourceCode: string,
-) {
-  return isNeedResult
-    ? `(
-    ([__temp,__restore] = _withAsyncContext(() => ${exprSourceCode})),
-    __temp = await __temp,
-    __restore(),
-    __temp
-    )`
-    : `;(
-    ([__temp,__restore] = _withAsyncContext(() => ${exprSourceCode})),
-    await __temp,
-    __restore()
-  );`
-}
-
-function mayContainAwaitExpr(vineFnBodyStmt: Node) {
-  let awaitExpr: AwaitExpression | undefined
-  const isExprStmt = isExpressionStatement(vineFnBodyStmt)
-  const isVarDeclStmt = isVariableDeclaration(vineFnBodyStmt)
-
-  if (!(
-    isVarDeclStmt
-    || isExprStmt
-  )) {
-    return null
-  }
-
-  const isNeedResult = (
-    isVarDeclStmt
-    || vineFnBodyStmt.expression.type === 'AssignmentExpression'
-  )
-
-  try {
-    traverse(vineFnBodyStmt, (descendant) => {
-      if (isBlockStatement(descendant)) {
-        throw new Error(EXPECTED_ERROR)
-      }
-      else if (isAwaitExpression(descendant)) {
-        awaitExpr = descendant
-        throw new Error(EXPECTED_ERROR)
-      }
-    })
-  }
-  catch (error: any) {
-    if (error.message === EXPECTED_ERROR) {
-      return {
-        isNeedResult,
-        awaitExpr,
-      }
-    }
-    throw error
-  }
-
-  return null
-}
-
-function registerImport(
-  mergedImportsMap: MergedImportsMap,
-  importSource: string,
-  specifier: string,
-  alias: string,
-) {
-  const vueVineImports = mergedImportsMap.get(importSource)
-  if (!vueVineImports) {
-    mergedImportsMap.set(importSource, {
-      type: 'namedSpecifier',
-      specs: new Map([[specifier, alias]]),
-    })
-  }
-  else {
-    const vueImportsSpecs = (vueVineImports as NamedImportSpecifierMeta).specs
-    vueImportsSpecs.set(specifier, alias)
-  }
-}
-
-function setupCodeGenerationForVineModel(
-  vineFnCompCtx: VineCompFnCtx,
-): string {
-  let modelCodeGen: string[] = []
-
-  for (const [modelName, modelDef] of Object.entries(vineFnCompCtx.vineModels)) {
-    const { varName } = modelDef
-    modelCodeGen.push(
-      `const ${varName} = _${USE_MODEL_HELPER}(__props, '${modelName}')`,
-    )
-  }
-
-  return `\n${modelCodeGen.join('\n')}\n`
-}
-
-function propsOptionsCodeGeneration(
-  vineFileCtx: VineFileCtx,
-  vineCompFnCtx: VineCompFnCtx,
-) {
-  const segementsFromProps = Object.entries(vineCompFnCtx.props).map(([propName, propMeta]) => {
-    const metaFields = []
-    if (propMeta.isRequired) {
-      metaFields.push('required: true')
-    }
-    if (propMeta.isBool) {
-      metaFields.push('type: Boolean')
-    }
-    if (propMeta.validator) {
-      metaFields.push(`validator: ${
-        vineFileCtx.originCode.slice(
-          propMeta.validator.start!,
-          propMeta.validator.end!,
-        )
-      }`)
-    }
-    return `${
-      propMeta.nameNeedQuoted
-        ? `'${propName}'`
-        : propName
-    }: { ${
-      showIf(
-        metaFields.filter(Boolean).length > 0,
-        filterJoin(metaFields, ', '),
-        '/* Simple prop */',
-      )
-    } },`
-  })
-
-  const segmentsFromVineModel = Object
-    .entries(vineCompFnCtx.vineModels)
-    .reduce<string[]>((segments, [modelName, modelDef]) => {
-      const { modelModifiersName, modelOptions } = modelDef
-      segments.push(
-        `${modelName}: ${
-          modelOptions
-            ? vineFileCtx.originCode.slice(
-                modelOptions.start!,
-                modelOptions.end!,
-              )
-            : '{}'
-        },`,
-      )
-      segments.push(
-        `${modelModifiersName}: {},`,
-      )
-
-      return segments
-    }, [])
-
-  return [
-    ...segementsFromProps,
-    ...segmentsFromVineModel,
-  ]
-}
-
-function rewriteDestructuredPropAccess(
-  compilerHooks: VineCompilerHooks,
-  vineFileCtx: VineFileCtx,
-  vineCompFnCtx: VineCompFnCtx,
-  vineCompFnBody: BlockStatement,
-) {
-  type Scope = Record<string, boolean>
-  const rootScope: Scope = Object.create(null)
-  const scopeStack: Scope[] = [rootScope]
-  const excludedIds = new WeakSet<Identifier>()
-  const parentStack: Node[] = []
-  const propsLocalToPublicMap: Record<string, string> = Object.create(null)
-  let currentScope = rootScope
-
-  for (const [destructName, destructMeta] of Object.entries(vineCompFnCtx.propsDestructuredNames)) {
-    const local = destructMeta.alias ?? destructName
-    rootScope[local] = true
-    propsLocalToPublicMap[local] = destructName
-  }
-
-  function pushScope() {
-    currentScope = Object.create(currentScope)
-    scopeStack.push(currentScope)
-  }
-  function popScope() {
-    scopeStack.pop()
-    currentScope = scopeStack[scopeStack.length - 1]
-  }
-  function registerLocalBinding(id: Identifier) {
-    excludedIds.add(id)
-    if (currentScope) {
-      currentScope[id.name] = false
-    }
-  }
-  function walkScope(node: BlockStatement, isRoot = false) {
-    for (const stmt of node.body) {
-      if (stmt.type === 'VariableDeclaration') {
-        walkVariableDeclaration(stmt, isRoot)
-      }
-      else if (
-        stmt.type === 'FunctionDeclaration'
-        || stmt.type === 'ClassDeclaration'
-      ) {
-        if (stmt.declare || !stmt.id)
-          continue
-        registerLocalBinding(stmt.id)
-      }
-      else if (
-        (stmt.type === 'ForOfStatement' || stmt.type === 'ForInStatement')
-        && stmt.left.type === 'VariableDeclaration'
-      ) {
-        walkVariableDeclaration(stmt.left)
-      }
-      else if (
-        stmt.type === 'ExportNamedDeclaration'
-        && stmt.declaration
-        && stmt.declaration.type === 'VariableDeclaration'
-      ) {
-        walkVariableDeclaration(stmt.declaration, isRoot)
-      }
-      else if (
-        stmt.type === 'LabeledStatement'
-        && stmt.body.type === 'VariableDeclaration'
-      ) {
-        walkVariableDeclaration(stmt.body, isRoot)
-      }
-    }
-  }
-  function walkVariableDeclaration(stmt: VariableDeclaration, isRoot = false) {
-    if (stmt.declare) {
-      return
-    }
-    for (const decl of stmt.declarations) {
-      const isDefineProps
-        = isRoot && decl.init && isCallOf(unwrapTSNode(decl.init), 'defineProps')
-      for (const id of extractIdentifiers(decl.id)) {
-        if (isDefineProps) {
-          // for defineProps destructure, only exclude them since they
-          // are already passed in as knownProps
-          excludedIds.add(id)
-        }
-        else {
-          registerLocalBinding(id)
-        }
-      }
-    }
-  }
-  function checkUsage(node: Node, method: string, alias = method) {
-    if (isCallOf(node, alias)) {
-      const arg = unwrapTSNode(node.arguments[0])
-      if (arg.type === 'Identifier' && currentScope[arg.name]) {
-        compilerHooks.onError(
-          vineErr(
-            { vineFileCtx, vineCompFnCtx },
-            {
-              msg: `"${arg.name}" is a destructured prop and should not be passed directly to ${method}(). `
-                + `Pass a getter () => ${arg.name} instead.`,
-              location: arg.loc,
-            },
-          ),
-        )
-      }
-    }
-  }
-  function genPropsAccessExp(name: string, propsAlias: string): string {
-    return identRE.test(name)
-      ? `${propsAlias}.${name}`
-      : `${propsAlias}[${JSON.stringify(name)}]`
-  }
-  function rewriteId(id: Identifier, parent: Node, parentStack: Node[]) {
-    if (
-      (parent.type === 'AssignmentExpression' && id === parent.left)
-      || parent.type === 'UpdateExpression'
-    ) {
-      compilerHooks.onError(
-        vineErr(
-          { vineFileCtx, vineCompFnCtx },
-          {
-            msg: `Cannot assign to destructured props as they are readonly.`,
-            location: id.loc,
-          },
-        ),
-      )
-    }
-
-    if (isStaticProperty(parent) && parent.shorthand) {
-      // let binding used in a property shorthand
-      // skip for destructure patterns
-      if (
-        !(parent as any).inPattern
-        || isInDestructureAssignment(parent, parentStack)
-      ) {
-        // const x = { prop } -> const x = { prop: propsAlias.prop }
-        vineFileCtx.fileMagicCode.appendLeft(
-          id.end!,
-          `: ${genPropsAccessExp(propsLocalToPublicMap[id.name], vineCompFnCtx.propsAlias)}`,
-        )
-      }
-    }
-    else {
-      // x --> propsAlias.x
-      vineFileCtx.fileMagicCode.overwrite(
-        id.start!,
-        id.end!,
-        genPropsAccessExp(propsLocalToPublicMap[id.name], vineCompFnCtx.propsAlias),
-      )
-    }
-  }
-
-  walkScope(vineCompFnBody)
-
-  walk(vineCompFnBody, {
-    enter(node: Node, parent: Node | null) {
-      parent && parentStack.push(parent)
-
-      // skip type nodes
-      if (
-        parent
-        && parent.type.startsWith('TS')
-        && !TS_NODE_TYPES.includes(parent.type)
-      ) {
-        return this.skip()
-      }
-
-      checkUsage(node, 'watch', vineFileCtx.vueImportAliases.watch)
-      checkUsage(node, 'toRef', vineFileCtx.vueImportAliases.toRef)
-
-      // function scopes
-      if (isFunctionType(node)) {
-        pushScope()
-        walkFunctionParams(node, registerLocalBinding)
-        if (node.body.type === 'BlockStatement') {
-          walkScope(node.body)
-        }
-        return
-      }
-
-      // catch param
-      if (node.type === 'CatchClause') {
-        pushScope()
-        if (node.param && node.param.type === 'Identifier') {
-          registerLocalBinding(node.param)
-        }
-        walkScope(node.body)
-        return
-      }
-
-      // non-function block scopes
-      if (node.type === 'BlockStatement' && parent && !isFunctionType(parent)) {
-        pushScope()
-        walkScope(node)
-        return
-      }
-
-      if (node.type === 'Identifier') {
-        if (
-          isReferencedIdentifier(node, parent!, parentStack)
-          && !excludedIds.has(node)
-        ) {
-          if (currentScope[node.name]) {
-            rewriteId(node, parent!, parentStack)
-          }
-        }
-      }
-    },
-    leave(node: Node, parent: Node | null) {
-      parent && parentStack.pop()
-      if (
-        (node.type === 'BlockStatement' && parent && !isFunctionType(parent))
-        || isFunctionType(node)
-      ) {
-        popScope()
-      }
-    },
-  })
-}
+import {
+  createInlineTemplateComposer,
+  createSeparatedTemplateComposer,
+} from './template/compose'
+import {
+  buildSetupFormalParams,
+  createVueImportsSpecs,
+  generateAllImports,
+  generateAsyncContext,
+  generateBasicComponentOptions,
+  generateDefineComponentWrapper,
+  generateEmitsOptions,
+  generatePropsDeclaration,
+  generatePropsDestructure,
+  generatePropsOptions,
+  generatePropsRestProxy,
+  generateSetupReturns,
+  generateStyleImports,
+  generateUseCssVars,
+  generateVineExpose,
+  generateVineFactory,
+  generateVineModel,
+  generateVinePropToRefs,
+  generateVineSlots,
+  onlyRemainFunctionBody,
+  removeStatementsContainsMacro,
+} from './transform/steps'
 
 /**
  * Processing `.vine.ts` file transforming.
@@ -421,430 +50,67 @@ export function transformFile(
   inline = true,
   ssr = false,
 ): void {
-  const isDev = compilerHooks.getCompilerCtx().options.envMode !== 'production'
-  const ms = vineFileCtx.fileMagicCode
-
-  // Traverse file context's `styleDefine`, and generate import statements.
-  // Ordered by their import releationship.
-  const styleImportStmts = sortStyleImport(vineFileCtx)
-  const mergedImportsMap: MergedImportsMap = new Map()
-
-  // Get all explicit declared export in exportNamedDeclarations
-  const explicitExports = fineAllExplicitExports(vineFileCtx.exportNamedDeclarations)
-
-  // Flag that is used for noticing prepend `useDefaults` helper function.
-  let isPrependedUseDefaults = false
-
-  const {
-    templateCompileResults,
-    generatedPreambleStmts,
-    compileSetupFnReturns,
-  } = inline // Get template composer based on inline option
+  const templateComposer = inline // Get template composer based on inline option
     ? createInlineTemplateComposer(compilerHooks, ssr)
     : createSeparatedTemplateComposer(compilerHooks, ssr)
+  const transformCtx: TransformContext = {
+    inline,
+    ssr,
+    vineFileCtx,
+    compilerHooks,
+    mergedImportsMap: new Map(),
+    templateComposer,
+  }
 
   // Traverse all component functions and transform them into IIFE
   for (const vineCompFnCtx of vineFileCtx.vineCompFns) {
-    const setupFnReturns = compileSetupFnReturns({
-      vineFileCtx,
-      vineCompFnCtx,
-      templateSource: vineCompFnCtx.templateSource,
-      mergedImportsMap,
-      bindingMetadata: vineCompFnCtx.bindings,
-    })
-    const isNeedUseDefaults = Object
-      .values(vineCompFnCtx.props)
-      .some(meta => Boolean(meta.default))
-
-    // Add `defineComponent` helper function import specifier
-    let vueImportsMeta = mergedImportsMap.get('vue')
-    if (!vueImportsMeta) {
-      vueImportsMeta = {
-        type: 'namedSpecifier',
-        specs: new Map(),
-      } as NamedImportSpecifierMeta
-      mergedImportsMap.set('vue', vueImportsMeta)
-    }
-    const vueImportsSpecs = (vueImportsMeta as NamedImportSpecifierMeta).specs
-    if (!vueImportsSpecs.has(DEFINE_COMPONENT_HELPER)) {
-      vueImportsSpecs.set(DEFINE_COMPONENT_HELPER, `_${DEFINE_COMPONENT_HELPER}`)
-    }
-    // add useCssVars
-    if (!vueImportsSpecs.has(CSS_VARS_HELPER) && vineCompFnCtx.cssBindings) {
-      vueImportsSpecs.set(CSS_VARS_HELPER, `_${CSS_VARS_HELPER}`)
-      if (inline) {
-        vueImportsSpecs.set(UN_REF_HELPER, `_${UN_REF_HELPER}`)
-      }
-    }
-    // add useSlots
-    if (Object.entries(vineCompFnCtx.slots).length > 0) {
-      vueImportsSpecs.set(USE_SLOT_HELPER, `_${USE_SLOT_HELPER}`)
-    }
-    // add createPropsRestProxy
-    const isNeedCreatePropsRestProxy = Object.values(vineCompFnCtx.propsDestructuredNames).some(prop => prop.isRest)
-    if (isNeedCreatePropsRestProxy) {
-      vueImportsSpecs.set(CREATE_PROPS_REST_PROXY_HELPER, `_${CREATE_PROPS_REST_PROXY_HELPER}`)
-    }
-
-    const vineCompFnStart = vineCompFnCtx.fnDeclNode.start!
-    const vineCompFnEnd = vineCompFnCtx.fnDeclNode.end!
     const vineCompFnBody = vineCompFnCtx.fnItselfNode?.body
-
     if (!isBlockStatement(vineCompFnBody)) {
-      return
+      continue
     }
 
-    let hasAwait = false
-
-    // Handle component's setup logic from function body
-    for (const vineFnBodyStmt of vineCompFnBody.body) {
-      const mayContain = mayContainAwaitExpr(vineFnBodyStmt)
-      if (!mayContain || !mayContain.awaitExpr) {
-        continue
-      }
-
-      // has await expression in function body root level statements,
-      // we need to add 'withAsyncContext' helper, imported from 'vue'
-      vueImportsSpecs.set(WITH_ASYNC_CONTEXT_HELPER, `_${WITH_ASYNC_CONTEXT_HELPER}`)
-
-      const { awaitExpr, isNeedResult } = mayContain
-      hasAwait = true
-      ms.update(
-        awaitExpr.start!,
-        awaitExpr.end!,
-        wrapWithAsyncContext(
-          isNeedResult,
-          ms.original.slice(
-            awaitExpr.argument.start!,
-            awaitExpr.argument.end!,
-          ),
-        ),
-      )
-    }
-
-    const firstStmt = vineCompFnBody.body[0]
-    const lastStmt = vineCompFnBody.body[vineCompFnBody.body.length - 1]
-
-    // Replace the original function delcaration start to its body's first statement's start,
-    // and the last statement's end to the function declaration end.
-    // Wrap all body statements into a `setup(...) { ... }`
-    ms.remove(vineCompFnStart, firstStmt.start!)
-    ms.remove(lastStmt.end!, vineCompFnEnd)
-
-    // Remove all statements that contain macro calls
-    vineCompFnBody.body.forEach((stmt) => {
-      if (
-        isStatementContainsVineMacroCall(stmt)
-        || isReturnStatement(stmt)
-      ) {
-        ms.remove(stmt.start!, stmt.end!)
-      }
-    })
-
-    // Build formal parameters of `setup` function
-    const setupCtxDestructFormalParams: {
-      field: string
-      alias?: string
-    }[] = []
-    if (vineCompFnCtx.emits.length > 0) {
-      setupCtxDestructFormalParams.push({
-        field: 'emit',
-        alias: '__emit',
-      })
-      ms.prependLeft(
-        firstStmt.start!,
-        `const ${vineCompFnCtx.emitsAlias} = __emit;\n`,
-      )
-    }
-
-    // Always add `expose` to the setup context destructuring
-    setupCtxDestructFormalParams.push({
-      field: 'expose',
-      alias: '__expose',
-    })
-
-    let setupFormalParams = `__props${
-      setupCtxDestructFormalParams.length > 0
-        ? `, { ${
-          setupCtxDestructFormalParams.map(
-            ({ field, alias }) => `${field}${showIf(Boolean(alias), `: ${alias}`)}`,
-          ).join(', ')
-        } }`
-        : ' /* No setup ctx destructuring */'
-    }`
-
-    // Code generation for vineSlots
-    if (Object.entries(vineCompFnCtx.slots).length > 0) {
-      ms.prependLeft(
-        firstStmt.start!,
-        `const ${vineCompFnCtx.slotsAlias} = _${USE_SLOT_HELPER}();\n`,
-      )
-    }
-
-    // Code generation for vineModel
-    if (Object.entries(vineCompFnCtx.vineModels).length > 0) {
-      registerImport(
-        mergedImportsMap,
-        'vue',
-        USE_MODEL_HELPER,
-        `_${USE_MODEL_HELPER}`,
-      )
-      ms.prependLeft(
-        firstStmt.start!,
-        setupCodeGenerationForVineModel(vineCompFnCtx),
-      )
-    }
-
-    // Insert `useCssVars` helper function call
-    if (
-      Array.from(
-        Object.entries(vineCompFnCtx.cssBindings),
-      ).length > 0
-    ) {
-      ms.prependLeft(
-        firstStmt.start!,
-        `\n${compileCSSVars(vineCompFnCtx, inline)}\n`,
-      )
-    }
-
-    // If there's any prop that is from macro define,
-    // we need to import `toRefs`
-    if (
-      Object
-        .values(vineCompFnCtx.props)
-        .some(meta => Boolean(meta.isFromMacroDefine))
-    ) {
-      registerImport(
-        mergedImportsMap,
-        'vue',
-        TO_REFS_HELPER,
-        `_${TO_REFS_HELPER}`,
-      )
-      const propsFromMacro = Object.entries(vineCompFnCtx.props)
-        .filter(([_, meta]) => Boolean(meta.isFromMacroDefine))
-        .map(([propName, _]) => propName)
-      ms.prependLeft(
-        firstStmt.start!,
-        `const { ${propsFromMacro.join(', ')} } = _toRefs(${vineCompFnCtx.propsAlias});\n`,
-      )
-    }
-
-    // Replace references to destructured prop identifiers
-    // with access expressions like `x` to `props.x`
-    rewriteDestructuredPropAccess(
-      compilerHooks,
-      vineFileCtx,
+    const fnTransformCtx: SingleFnCompTransformCtx = {
       vineCompFnCtx,
       vineCompFnBody,
-    )
-    if (Object.keys(vineCompFnCtx.propsDestructuredNames).length > 0) {
-      // Add `const { ...< destructured names >... } = propsAlias` to the top of the function
-      const destructuredNames = Object.entries(vineCompFnCtx.propsDestructuredNames)
-        .reduce((acc, [name, data]) => {
-          if (data.isRest) {
-            acc.push(`...${name}`)
-          }
-          else if (data.alias) {
-            acc.push(`'${name}': ${data.alias}`)
-          }
-          else {
-            acc.push(name)
-          }
-          return acc
-        }, [] as string[])
+      vineCompFnStart: vineCompFnCtx.fnDeclNode.start!,
+      vineCompFnEnd: vineCompFnCtx.fnDeclNode.end!,
+      firstStmt: vineCompFnBody.body[0],
+      lastStmt: vineCompFnBody.body[vineCompFnBody.body.length - 1],
+      hasAwait: false,
+      vueImportsSpecs: createVueImportsSpecs(
+        transformCtx,
+        vineCompFnCtx,
+      ),
 
-      vineFileCtx.fileMagicCode.prependLeft(
-        vineCompFnBody.body[0].start!,
-        `const { ${destructuredNames.join(', ')} } = _${TO_REFS_HELPER}(${vineCompFnCtx.propsAlias});\n`,
-      )
-      // Add `toRefs` import specifier
-      registerImport(mergedImportsMap, 'vue', TO_REFS_HELPER, `_${TO_REFS_HELPER}`)
+      isPrependedUseDefaults: false,
+      isNeedUseDefaults: (
+        Object
+          .values(vineCompFnCtx.props)
+          .some(meta => Boolean(meta.default))
+      ),
     }
 
-    if (isNeedCreatePropsRestProxy) {
-      ms.prependLeft(
-        firstStmt.start!,
-        `const __propsRestProxy = _${CREATE_PROPS_REST_PROXY_HELPER}(__props, [${
-          Object.entries(vineCompFnCtx.propsDestructuredNames)
-            .filter(([_, propMeta]) => !propMeta.isRest)
-            .map(([propName, _]) => `'${propName}'`)
-            .join(', ')
-        }]);\n`,
-      )
-    }
+    onlyRemainFunctionBody(transformCtx, fnTransformCtx)
+    removeStatementsContainsMacro(transformCtx, fnTransformCtx)
+    generateVineSlots(transformCtx, fnTransformCtx)
+    generateVineModel(transformCtx, fnTransformCtx)
+    generateUseCssVars(transformCtx, fnTransformCtx)
+    generateVinePropToRefs(transformCtx, fnTransformCtx)
+    generatePropsRestProxy(transformCtx, fnTransformCtx)
+    generatePropsDestructure(transformCtx, fnTransformCtx)
+    generatePropsDeclaration(transformCtx, fnTransformCtx)
+    generateAsyncContext(transformCtx, fnTransformCtx)
+    generateVineExpose(transformCtx, fnTransformCtx)
 
-    // Insert `useDefaults` helper function import specifier.
-    // And prepend `const propsAlias = useDefaults(...)` before the first statement.
-    let propsDeclarationStmt = `const ${vineCompFnCtx.propsAlias} = __props;\n`
-    if (
-      isNeedUseDefaults
-      && !isPrependedUseDefaults
-    ) {
-      isPrependedUseDefaults = true
-      registerImport(
-        mergedImportsMap,
-        'vue-vine',
-        USE_DEFAULTS_HELPER,
-        `_${USE_DEFAULTS_HELPER}`,
-      )
-      propsDeclarationStmt = `const ${vineCompFnCtx.propsAlias} = _${USE_DEFAULTS_HELPER}(__props, {\n${
-        Object.entries(vineCompFnCtx.props)
-          .filter(([_, propMeta]) => Boolean(propMeta.default))
-          .map(([propName, propMeta]) => `  ${propName}: () => (${
-            ms.original.slice(
-              propMeta.default!.start!,
-              propMeta.default!.end!,
-            )
-          })`)
-          .join(',\n')
-      }\n})\n`
-    }
-    ms.prependLeft(
-      firstStmt.start!,
-      propsDeclarationStmt,
-    )
-
-    // Insert variables that required by async context generated code
-    if (hasAwait) {
-      ms.prependLeft(
-        firstStmt.start!,
-        'let __temp, __restore;\n',
-      )
-    }
-
-    // vineExpose
-    if (vineCompFnCtx.expose) {
-      const { paramObj } = vineCompFnCtx.expose
-      ms.appendRight(
-        lastStmt.end!,
-        `\n__expose(${
-          ms.original.slice(
-            paramObj.start!,
-            paramObj.end!,
-          )
-        });\n`,
-      )
-    }
-    else {
-      ms.prependLeft(
-        firstStmt.start!,
-        '\n__expose();\n',
-      )
-    }
-
-    // Insert setup function's return statement
-    ms.appendRight(lastStmt.end!, `\nreturn ${setupFnReturns};`)
-
-    ms.prependLeft(firstStmt.start!, `${vineCompFnCtx.isAsync ? 'async ' : ''}setup(${setupFormalParams}) {\n`)
-    ms.appendRight(lastStmt.end!, '\n}')
-
-    const emitsKeys = [
-      ...vineCompFnCtx.emits.map(emit => `'${emit}'`),
-      ...Object.keys(vineCompFnCtx.vineModels).map(modelName => `'update:${modelName}'`),
-    ]
-    const propsOptionFields = propsOptionsCodeGeneration(
-      vineFileCtx,
-      vineCompFnCtx,
-    )
-
-    ms.prependLeft(firstStmt.start!, `const __vine = _defineComponent({\n${
-      // Some basic component options
-      vineCompFnCtx.options
-        ? `...${ms.original.slice(
-          vineCompFnCtx.options.start!,
-          vineCompFnCtx.options.end!,
-        )},`
-        : `name: '${vineCompFnCtx.fnName}',`
-    }\n${
-      propsOptionFields.length > 0
-        ? `props: {\n${
-          propsOptionsCodeGeneration(
-            vineFileCtx,
-            vineCompFnCtx,
-          ).join('\n')
-        }\n},`
-        : '/* No props */'
-    }\n${
-      emitsKeys.length > 0
-        ? `emits: [${
-          emitsKeys.join(', ')
-        }],`
-        : '/* No emits */'
-    }\n`)
-    ms.appendRight(lastStmt.end!, '\n})')
-
-    // Defaultly set `export` for all component functions
-    // because it's required by HMR context.
-    ms.prependLeft(firstStmt.start!, `\n${
-      explicitExports.includes(vineCompFnCtx.fnName)
-        ? ''
-        : 'export'
-    } const ${
-      vineCompFnCtx.fnName
-    } = (() => {\n${
-      // Prepend all generated preamble statements
-      generatedPreambleStmts
-        .get(vineCompFnCtx)
-        ?.join('\n') ?? ''
-    }\n`)
-
-    ms.appendRight(lastStmt.end!, `\n${
-      inline
-        ? ''
-      // Not-inline mode, we need manually add the
-      // render function to the component object.
-        : `${
-          templateCompileResults.get(vineCompFnCtx) ?? ''
-        }\n__vine.${ssr ? 'ssrRender' : 'render'} = ${ssr ? '__sfc_ssr_render' : '__sfc_render'}`
-    }\n${
-      showIf(
-        Boolean(vineFileCtx.styleDefine[vineCompFnCtx.scopeId]),
-        `__vine.__scopeId = 'data-v-${vineCompFnCtx.scopeId}';`,
-      )}\n${
-      isDev ? `__vine.__hmrId = '${vineCompFnCtx.scopeId}';` : ''
-    }\n${showIf(
-      // handle Web Component styles
-      Boolean(vineCompFnCtx.isCustomElement),
-      `__vine.styles = [__${vineCompFnCtx.fnName.toLowerCase()}_styles];\n`,
-    )}\nreturn __vine\n})();`)
-
-    if (vineCompFnCtx.isExportDefault) {
-      ms.appendRight(
-        ms.length(),
-        `\n\nexport default ${vineCompFnCtx.fnName};\n\n`,
-      )
-    }
-
-    // Record component function to HMR
-    if (isDev) {
-      ms.appendRight(
-        ms.length(),
-        `\n\ntypeof __VUE_HMR_RUNTIME__ !== "undefined" && __VUE_HMR_RUNTIME__.createRecord(${vineCompFnCtx.fnName}.__hmrId, ${vineCompFnCtx.fnName});\n`,
-      )
-    }
+    generateSetupReturns(transformCtx, fnTransformCtx)
+    buildSetupFormalParams(transformCtx, fnTransformCtx)
+    generateEmitsOptions(transformCtx, fnTransformCtx)
+    generatePropsOptions(transformCtx, fnTransformCtx)
+    generateBasicComponentOptions(transformCtx, fnTransformCtx)
+    generateDefineComponentWrapper(transformCtx, fnTransformCtx)
+    generateVineFactory(transformCtx, fnTransformCtx)
   }
 
-  // Prepend all style import statements
-  ms.prepend(`\n${styleImportStmts.join('\n')}\n`)
-  // Prepend all imports
-  for (const [importSource, importMeta] of mergedImportsMap) {
-    if (importMeta.type === 'namedSpecifier') {
-      const { specs } = importMeta
-      const specifiers = [...specs.entries()]
-      const importStmt = `import { ${
-        specifiers.map(
-          ([specifier, alias]) => `${specifier}${showIf(Boolean(alias), ` as ${alias}`)}`,
-        ).join(', ')
-      } } from '${importSource}';\n`
-      ms.prepend(importStmt)
-    }
-    else if (importMeta.type === 'defaultSpecifier') {
-      const importStmt = `import ${importMeta.localName} from '${importSource}';\n`
-      ms.prepend(importStmt)
-    }
-    else if (importMeta.type === 'namespaceSpecifier') {
-      const importStmt = `import * as ${importMeta.localName} from '${importSource}';\n`
-      ms.prepend(importStmt)
-    }
-  }
+  generateStyleImports(transformCtx)
+  generateAllImports(transformCtx)
 }

--- a/packages/compiler/src/transform/steps.ts
+++ b/packages/compiler/src/transform/steps.ts
@@ -1,0 +1,921 @@
+import type { BlockStatement, Identifier, Node, VariableDeclaration } from '@babel/types'
+import type {
+  MergedImportsMap,
+  NamedImportSpecifierMeta,
+  TemplateCompileComposer,
+} from '../template/compose'
+import type { VineCompFnCtx, VineCompilerHooks, VineFileCtx } from '../types'
+import { isReturnStatement } from '@babel/types'
+import { extractIdentifiers, isFunctionType, isInDestructureAssignment, isReferencedIdentifier, isStaticProperty, TS_NODE_TYPES, unwrapTSNode, walkFunctionParams } from '@vue/compiler-dom'
+import { walk } from 'estree-walker'
+import { fineAllExplicitExports, isCallOf, isStatementContainsVineMacroCall } from '../babel-helpers/ast'
+import {
+  CREATE_PROPS_REST_PROXY_HELPER,
+  CSS_VARS_HELPER,
+  DEFINE_COMPONENT_HELPER,
+  TO_REFS_HELPER,
+  UN_REF_HELPER,
+  USE_DEFAULTS_HELPER,
+  USE_MODEL_HELPER,
+  USE_SLOT_HELPER,
+  WITH_ASYNC_CONTEXT_HELPER,
+} from '../constants'
+import { vineErr } from '../diagnostics'
+import { sortStyleImport } from '../style/order'
+import { compileCSSVars } from '../style/transform-css-var'
+import { filterJoin, showIf } from '../utils'
+import { mayContainAwaitExpr, registerImport, wrapWithAsyncContext } from './utils'
+
+const identRE = /^[_$a-z\xA0-\uFFFF][\w$\xA0-\uFFFF]*$/i
+
+export interface TransformContext {
+  vineFileCtx: VineFileCtx
+  compilerHooks: VineCompilerHooks
+  inline: boolean
+  ssr: boolean
+  mergedImportsMap: MergedImportsMap
+  templateComposer: TemplateCompileComposer
+}
+export interface SingleFnCompTransformCtx {
+  vineCompFnCtx: VineCompFnCtx
+  hasAwait: boolean
+  vueImportsSpecs: Map<string, string>
+  vineCompFnBody: BlockStatement
+  vineCompFnStart: number
+  vineCompFnEnd: number
+  firstStmt: Node
+  lastStmt: Node
+
+  isNeedUseDefaults: boolean
+  // Flag that is used for noticing prepend `useDefaults` helper function.
+  isPrependedUseDefaults: boolean
+}
+
+export function createVueImportsSpecs(
+  transformCtx: TransformContext,
+  vineCompFnCtx: VineCompFnCtx,
+) {
+  const { inline, mergedImportsMap } = transformCtx
+
+  // Add `defineComponent` helper function import specifier
+  let vueImportsMeta = mergedImportsMap.get('vue')
+  if (!vueImportsMeta) {
+    vueImportsMeta = {
+      type: 'namedSpecifier',
+      specs: new Map(),
+    } as NamedImportSpecifierMeta
+    mergedImportsMap.set('vue', vueImportsMeta)
+  }
+  const vueImportsSpecs = (vueImportsMeta as NamedImportSpecifierMeta).specs
+  if (!vueImportsSpecs.has(DEFINE_COMPONENT_HELPER)) {
+    vueImportsSpecs.set(DEFINE_COMPONENT_HELPER, `_${DEFINE_COMPONENT_HELPER}`)
+  }
+  // add useCssVars
+  if (!vueImportsSpecs.has(CSS_VARS_HELPER) && vineCompFnCtx.cssBindings) {
+    vueImportsSpecs.set(CSS_VARS_HELPER, `_${CSS_VARS_HELPER}`)
+    if (inline) {
+      vueImportsSpecs.set(UN_REF_HELPER, `_${UN_REF_HELPER}`)
+    }
+  }
+  // add useSlots
+  if (Object.entries(vineCompFnCtx.slots).length > 0) {
+    vueImportsSpecs.set(USE_SLOT_HELPER, `_${USE_SLOT_HELPER}`)
+  }
+
+  return vueImportsSpecs
+}
+
+export function generateAsyncContext(
+  transformCtx: TransformContext,
+  fnTransformCtx: SingleFnCompTransformCtx,
+) {
+  const { vueImportsSpecs, vineCompFnBody, firstStmt } = fnTransformCtx
+  const ms = transformCtx.vineFileCtx.fileMagicCode
+
+  // Handle component's setup logic from function body
+  for (const vineFnBodyStmt of vineCompFnBody.body) {
+    const mayContain = mayContainAwaitExpr(vineFnBodyStmt)
+    if (!mayContain || !mayContain.awaitExpr) {
+      continue
+    }
+
+    // has await expression in function body root level statements,
+    // we need to add 'withAsyncContext' helper, imported from 'vue'
+    vueImportsSpecs.set(WITH_ASYNC_CONTEXT_HELPER, `_${WITH_ASYNC_CONTEXT_HELPER}`)
+
+    const { awaitExpr, isNeedResult } = mayContain
+    fnTransformCtx.hasAwait = true
+    ms.update(
+      awaitExpr.start!,
+      awaitExpr.end!,
+      wrapWithAsyncContext(
+        isNeedResult,
+        ms.original.slice(
+          awaitExpr.argument.start!,
+          awaitExpr.argument.end!,
+        ),
+      ),
+    )
+  }
+
+  // Insert variables that required by async context generated code
+  if (fnTransformCtx.hasAwait) {
+    ms.prependLeft(
+      firstStmt.start!,
+      'let __temp, __restore;\n',
+    )
+  }
+}
+
+export function onlyRemainFunctionBody(
+  transformCtx: TransformContext,
+  fnTransformCtx: SingleFnCompTransformCtx,
+) {
+  const ms = transformCtx.vineFileCtx.fileMagicCode
+  const {
+    vineCompFnStart,
+    vineCompFnEnd,
+    firstStmt,
+    lastStmt,
+  } = fnTransformCtx
+
+  // Replace the original function delcaration start to its body's first statement's start,
+  // and the last statement's end to the function declaration end.
+  // Wrap all body statements into a `setup(...) { ... }`
+  ms.remove(vineCompFnStart, firstStmt.start!)
+  ms.remove(lastStmt.end!, vineCompFnEnd)
+}
+
+export function removeStatementsContainsMacro(
+  transformCtx: TransformContext,
+  fnTransformCtx: SingleFnCompTransformCtx,
+) {
+  const { vineCompFnBody } = fnTransformCtx
+  const ms = transformCtx.vineFileCtx.fileMagicCode
+
+  // Remove all statements that contain macro calls
+  vineCompFnBody.body.forEach((stmt) => {
+    if (
+      isStatementContainsVineMacroCall(stmt)
+      || isReturnStatement(stmt)
+    ) {
+      ms.remove(stmt.start!, stmt.end!)
+    }
+  })
+}
+
+export function buildSetupFormalParams(
+  transformCtx: TransformContext,
+  fnTransformCtx: SingleFnCompTransformCtx,
+) {
+  const { vineCompFnCtx, firstStmt, lastStmt } = fnTransformCtx
+  const ms = transformCtx.vineFileCtx.fileMagicCode
+
+  // Build formal parameters of `setup` function
+  const setupCtxDestructFormalParams: {
+    field: string
+    alias?: string
+  }[] = []
+  if (vineCompFnCtx.emits.length > 0) {
+    setupCtxDestructFormalParams.push({
+      field: 'emit',
+      alias: '__emit',
+    })
+    ms.prependLeft(
+      firstStmt.start!,
+      `const ${vineCompFnCtx.emitsAlias} = __emit;\n`,
+    )
+  }
+
+  // Always add `expose` to the setup context destructuring
+  setupCtxDestructFormalParams.push({
+    field: 'expose',
+    alias: '__expose',
+  })
+
+  const setupFormalParams = `__props${
+    setupCtxDestructFormalParams.length > 0
+      ? `, { ${
+        setupCtxDestructFormalParams.map(
+          ({ field, alias }) => `${field}${showIf(Boolean(alias), `: ${alias}`)}`,
+        ).join(', ')
+      } }`
+      : ' /* No setup ctx destructuring */'
+  }`
+
+  ms.prependLeft(firstStmt.start!, `${vineCompFnCtx.isAsync ? 'async ' : ''}setup(${setupFormalParams}) {\n`)
+  ms.appendRight(lastStmt.end!, '\n}')
+}
+
+export function generateVineSlots(
+  transformCtx: TransformContext,
+  fnTransformCtx: SingleFnCompTransformCtx,
+) {
+  const { vineCompFnCtx, firstStmt } = fnTransformCtx
+  const ms = transformCtx.vineFileCtx.fileMagicCode
+
+  // Code generation for vineSlots
+  if (Object.entries(vineCompFnCtx.slots).length > 0) {
+    ms.prependLeft(
+      firstStmt.start!,
+      `const ${vineCompFnCtx.slotsAlias} = _${USE_SLOT_HELPER}();\n`,
+    )
+  }
+}
+
+export function generateVineModel(
+  transformCtx: TransformContext,
+  fnTransformCtx: SingleFnCompTransformCtx,
+) {
+  const { mergedImportsMap } = transformCtx
+  const { vineCompFnCtx, firstStmt } = fnTransformCtx
+  const ms = transformCtx.vineFileCtx.fileMagicCode
+
+  // Code generation for vineModel
+  if (Object.entries(vineCompFnCtx.vineModels).length > 0) {
+    registerImport(
+      mergedImportsMap,
+      'vue',
+      USE_MODEL_HELPER,
+      `_${USE_MODEL_HELPER}`,
+    )
+
+    let modelCodeGen: string[] = []
+
+    for (const [modelName, modelDef] of Object.entries(vineCompFnCtx.vineModels)) {
+      const { varName } = modelDef
+      modelCodeGen.push(
+        `const ${varName} = _${USE_MODEL_HELPER}(__props, '${modelName}')`,
+      )
+    }
+
+    const modelCodeGenStr = `\n${modelCodeGen.join('\n')}\n`
+
+    ms.prependLeft(
+      firstStmt.start!,
+      modelCodeGenStr,
+    )
+  }
+}
+
+export function generateUseCssVars(
+  transformCtx: TransformContext,
+  fnTransformCtx: SingleFnCompTransformCtx,
+) {
+  const { inline } = transformCtx
+  const { vineCompFnCtx, firstStmt } = fnTransformCtx
+  const ms = transformCtx.vineFileCtx.fileMagicCode
+
+  // Insert `useCssVars` helper function call
+  if (
+    Array.from(
+      Object.entries(vineCompFnCtx.cssBindings),
+    ).length > 0
+  ) {
+    ms.prependLeft(
+      firstStmt.start!,
+      `\n${compileCSSVars(vineCompFnCtx, inline)}\n`,
+    )
+  }
+}
+
+export function generateVinePropToRefs(
+  transformCtx: TransformContext,
+  fnTransformCtx: SingleFnCompTransformCtx,
+) {
+  const { vineCompFnCtx, firstStmt } = fnTransformCtx
+  const { mergedImportsMap } = transformCtx
+  const ms = transformCtx.vineFileCtx.fileMagicCode
+
+  // If there's any prop that is from macro define,
+  // we need to import `toRefs`
+  if (
+    Object
+      .values(vineCompFnCtx.props)
+      .some(meta => Boolean(meta.isFromMacroDefine))
+  ) {
+    registerImport(
+      mergedImportsMap,
+      'vue',
+      TO_REFS_HELPER,
+      `_${TO_REFS_HELPER}`,
+    )
+    const propsFromMacro = Object.entries(vineCompFnCtx.props)
+      .filter(([_, meta]) => Boolean(meta.isFromMacroDefine))
+      .map(([propName, _]) => propName)
+    ms.prependLeft(
+      firstStmt.start!,
+      `const { ${propsFromMacro.join(', ')} } = _toRefs(${vineCompFnCtx.propsAlias});\n`,
+    )
+  }
+}
+
+export function generateVineExpose(
+  transformCtx: TransformContext,
+  fnTransformCtx: SingleFnCompTransformCtx,
+) {
+  const { vineCompFnCtx, firstStmt, lastStmt } = fnTransformCtx
+  const ms = transformCtx.vineFileCtx.fileMagicCode
+
+  // vineExpose
+  if (vineCompFnCtx.expose) {
+    const { paramObj } = vineCompFnCtx.expose
+    ms.appendRight(
+      lastStmt.end!,
+      `\n__expose(${
+        ms.original.slice(
+          paramObj.start!,
+          paramObj.end!,
+        )
+      });\n`,
+    )
+  }
+  else {
+    ms.prependLeft(
+      firstStmt.start!,
+      '\n__expose();\n',
+    )
+  }
+}
+
+export function generateSetupReturns(
+  transformCtx: TransformContext,
+  fnTransformCtx: SingleFnCompTransformCtx,
+) {
+  const { vineFileCtx, templateComposer, mergedImportsMap } = transformCtx
+  const { vineCompFnCtx, lastStmt } = fnTransformCtx
+  const { compileSetupFnReturns } = templateComposer
+  const ms = transformCtx.vineFileCtx.fileMagicCode
+
+  const setupFnReturns = compileSetupFnReturns({
+    vineFileCtx,
+    vineCompFnCtx,
+    templateSource: vineCompFnCtx.templateSource,
+    mergedImportsMap,
+    bindingMetadata: vineCompFnCtx.bindings,
+  })
+
+  // Insert setup function's return statement
+  ms.appendRight(lastStmt.end!, `\nreturn ${setupFnReturns};`)
+}
+
+export function generatePropsDestructure(
+  transformCtx: TransformContext,
+  fnTransformCtx: SingleFnCompTransformCtx,
+) {
+  // Replace references to destructured prop identifiers
+  // with access expressions like `x` to `props.x`~
+
+  const { vineFileCtx, compilerHooks, mergedImportsMap } = transformCtx
+  const { vineCompFnCtx, vineCompFnBody } = fnTransformCtx
+
+  if (Object.keys(vineCompFnCtx.propsDestructuredNames).length > 0) {
+    // Add `const { ...< destructured names >... } = propsAlias` to the top of the function
+    const destructuredNames = Object.entries(vineCompFnCtx.propsDestructuredNames)
+      .reduce((acc, [name, data]) => {
+        if (data.isRest) {
+          acc.push(`...${name}`)
+        }
+        else if (data.alias) {
+          acc.push(`'${name}': ${data.alias}`)
+        }
+        else {
+          acc.push(name)
+        }
+        return acc
+      }, [] as string[])
+
+    vineFileCtx.fileMagicCode.prependLeft(
+      vineCompFnBody.body[0].start!,
+      `const { ${destructuredNames.join(', ')} } = _${TO_REFS_HELPER}(${vineCompFnCtx.propsAlias});\n`,
+    )
+    // Add `toRefs` import specifier
+    registerImport(mergedImportsMap, 'vue', TO_REFS_HELPER, `_${TO_REFS_HELPER}`)
+  }
+
+  type Scope = Record<string, boolean>
+  const rootScope: Scope = Object.create(null)
+  const scopeStack: Scope[] = [rootScope]
+  const excludedIds = new WeakSet<Identifier>()
+  const parentStack: Node[] = []
+  const propsLocalToPublicMap: Record<string, string> = Object.create(null)
+  let currentScope = rootScope
+
+  for (const [destructName, destructMeta] of Object.entries(vineCompFnCtx.propsDestructuredNames)) {
+    const local = destructMeta.alias ?? destructName
+    rootScope[local] = true
+    propsLocalToPublicMap[local] = destructName
+  }
+
+  function pushScope() {
+    currentScope = Object.create(currentScope)
+    scopeStack.push(currentScope)
+  }
+  function popScope() {
+    scopeStack.pop()
+    currentScope = scopeStack[scopeStack.length - 1]
+  }
+  function registerLocalBinding(id: Identifier) {
+    excludedIds.add(id)
+    if (currentScope) {
+      currentScope[id.name] = false
+    }
+  }
+  function walkScope(node: BlockStatement, isRoot = false) {
+    for (const stmt of node.body) {
+      if (stmt.type === 'VariableDeclaration') {
+        walkVariableDeclaration(stmt, isRoot)
+      }
+      else if (
+        stmt.type === 'FunctionDeclaration'
+        || stmt.type === 'ClassDeclaration'
+      ) {
+        if (stmt.declare || !stmt.id)
+          continue
+        registerLocalBinding(stmt.id)
+      }
+      else if (
+        (stmt.type === 'ForOfStatement' || stmt.type === 'ForInStatement')
+        && stmt.left.type === 'VariableDeclaration'
+      ) {
+        walkVariableDeclaration(stmt.left)
+      }
+      else if (
+        stmt.type === 'ExportNamedDeclaration'
+        && stmt.declaration
+        && stmt.declaration.type === 'VariableDeclaration'
+      ) {
+        walkVariableDeclaration(stmt.declaration, isRoot)
+      }
+      else if (
+        stmt.type === 'LabeledStatement'
+        && stmt.body.type === 'VariableDeclaration'
+      ) {
+        walkVariableDeclaration(stmt.body, isRoot)
+      }
+    }
+  }
+  function walkVariableDeclaration(stmt: VariableDeclaration, isRoot = false) {
+    if (stmt.declare) {
+      return
+    }
+    for (const decl of stmt.declarations) {
+      const isDefineProps
+        = isRoot && decl.init && isCallOf(unwrapTSNode(decl.init), 'defineProps')
+      for (const id of extractIdentifiers(decl.id)) {
+        if (isDefineProps) {
+          // for defineProps destructure, only exclude them since they
+          // are already passed in as knownProps
+          excludedIds.add(id)
+        }
+        else {
+          registerLocalBinding(id)
+        }
+      }
+    }
+  }
+  function checkUsage(node: Node, method: string, alias = method) {
+    if (isCallOf(node, alias)) {
+      const arg = unwrapTSNode(node.arguments[0])
+      if (arg.type === 'Identifier' && currentScope[arg.name]) {
+        compilerHooks.onError(
+          vineErr(
+            { vineFileCtx, vineCompFnCtx },
+            {
+              msg: `"${arg.name}" is a destructured prop and should not be passed directly to ${method}(). `
+                + `Pass a getter () => ${arg.name} instead.`,
+              location: arg.loc,
+            },
+          ),
+        )
+      }
+    }
+  }
+  function genPropsAccessExp(name: string, propsAlias: string): string {
+    return identRE.test(name)
+      ? `${propsAlias}.${name}`
+      : `${propsAlias}[${JSON.stringify(name)}]`
+  }
+  function rewriteId(id: Identifier, parent: Node, parentStack: Node[]) {
+    if (
+      (parent.type === 'AssignmentExpression' && id === parent.left)
+      || parent.type === 'UpdateExpression'
+    ) {
+      compilerHooks.onError(
+        vineErr(
+          { vineFileCtx, vineCompFnCtx },
+          {
+            msg: `Cannot assign to destructured props as they are readonly.`,
+            location: id.loc,
+          },
+        ),
+      )
+    }
+
+    const publicName = propsLocalToPublicMap[id.name]
+    // If the current identifier is a rest prop, do not rewrite it.
+    if (vineCompFnCtx.propsDestructuredNames[publicName]?.isRest) {
+      return
+    }
+
+    if (isStaticProperty(parent) && parent.shorthand) {
+      // let binding used in a property shorthand
+      // skip for destructure patterns
+      if (
+        !(parent as any).inPattern
+        || isInDestructureAssignment(parent, parentStack)
+      ) {
+        // const x = { prop } -> const x = { prop: propsAlias.prop }
+        vineFileCtx.fileMagicCode.appendLeft(
+          id.end!,
+          `: ${genPropsAccessExp(publicName, vineCompFnCtx.propsAlias)}`,
+        )
+      }
+    }
+    else {
+      // x --> propsAlias.x
+      vineFileCtx.fileMagicCode.overwrite(
+        id.start!,
+        id.end!,
+        genPropsAccessExp(publicName, vineCompFnCtx.propsAlias),
+      )
+    }
+  }
+
+  walkScope(vineCompFnBody)
+
+  walk(vineCompFnBody, {
+    enter(node: Node, parent: Node | null) {
+      parent && parentStack.push(parent)
+
+      // skip type nodes
+      if (
+        parent
+        && parent.type.startsWith('TS')
+        && !TS_NODE_TYPES.includes(parent.type)
+      ) {
+        return this.skip()
+      }
+
+      checkUsage(node, 'watch', vineFileCtx.vueImportAliases.watch)
+      checkUsage(node, 'toRef', vineFileCtx.vueImportAliases.toRef)
+
+      // function scopes
+      if (isFunctionType(node)) {
+        pushScope()
+        walkFunctionParams(node, registerLocalBinding)
+        if (node.body.type === 'BlockStatement') {
+          walkScope(node.body)
+        }
+        return
+      }
+
+      // catch param
+      if (node.type === 'CatchClause') {
+        pushScope()
+        if (node.param && node.param.type === 'Identifier') {
+          registerLocalBinding(node.param)
+        }
+        walkScope(node.body)
+        return
+      }
+
+      // non-function block scopes
+      if (node.type === 'BlockStatement' && parent && !isFunctionType(parent)) {
+        pushScope()
+        walkScope(node)
+        return
+      }
+
+      if (node.type === 'Identifier') {
+        if (
+          isReferencedIdentifier(node, parent!, parentStack)
+          && !excludedIds.has(node)
+        ) {
+          if (currentScope[node.name]) {
+            rewriteId(node, parent!, parentStack)
+          }
+        }
+      }
+    },
+    leave(node: Node, parent: Node | null) {
+      parent && parentStack.pop()
+      if (
+        (node.type === 'BlockStatement' && parent && !isFunctionType(parent))
+        || isFunctionType(node)
+      ) {
+        popScope()
+      }
+    },
+  })
+}
+
+export function generatePropsRestProxy(
+  transformCtx: TransformContext,
+  fnTransformCtx: SingleFnCompTransformCtx,
+) {
+  const { vineCompFnCtx, firstStmt, vueImportsSpecs } = fnTransformCtx
+  const ms = transformCtx.vineFileCtx.fileMagicCode
+
+  // add createPropsRestProxy
+  const propsRestEntry = Object.entries(vineCompFnCtx.propsDestructuredNames).find(([_, propMeta]) => propMeta.isRest)
+  if (propsRestEntry) {
+    vueImportsSpecs.set(CREATE_PROPS_REST_PROXY_HELPER, `_${CREATE_PROPS_REST_PROXY_HELPER}`)
+  }
+
+  if (propsRestEntry) {
+    const [propName, _] = propsRestEntry
+    ms.prependLeft(
+      firstStmt.start!,
+      `const ${propName} = _${CREATE_PROPS_REST_PROXY_HELPER}(__props, [${
+        Object.entries(vineCompFnCtx.propsDestructuredNames)
+          .filter(([_, propMeta]) => !propMeta.isRest)
+          .map(([propName, _]) => `'${propName}'`)
+          .join(', ')
+      }]);\n`,
+    )
+  }
+}
+
+export function generatePropsDeclaration(
+  transformCtx: TransformContext,
+  fnTransformCtx: SingleFnCompTransformCtx,
+) {
+  const { mergedImportsMap } = transformCtx
+  const { vineCompFnCtx, firstStmt } = fnTransformCtx
+  const ms = transformCtx.vineFileCtx.fileMagicCode
+
+  // Insert `useDefaults` helper function import specifier.
+  // And prepend `const propsAlias = useDefaults(...)` before the first statement.
+  let propsDeclarationStmt = `const ${vineCompFnCtx.propsAlias} = __props;\n`
+  if (
+    fnTransformCtx.isNeedUseDefaults
+    && !fnTransformCtx.isPrependedUseDefaults
+  ) {
+    fnTransformCtx.isPrependedUseDefaults = true
+    registerImport(
+      mergedImportsMap,
+      'vue-vine',
+      USE_DEFAULTS_HELPER,
+      `_${USE_DEFAULTS_HELPER}`,
+    )
+    propsDeclarationStmt = `const ${vineCompFnCtx.propsAlias} = _${USE_DEFAULTS_HELPER}(__props, {\n${
+      Object.entries(vineCompFnCtx.props)
+        .filter(([_, propMeta]) => Boolean(propMeta.default))
+        .map(([propName, propMeta]) => `  ${propName}: () => (${
+          ms.original.slice(
+            propMeta.default!.start!,
+            propMeta.default!.end!,
+          )
+        })`)
+        .join(',\n')
+    }\n})\n`
+  }
+  ms.prependLeft(
+    firstStmt.start!,
+    propsDeclarationStmt,
+  )
+}
+
+export function generateVineFactory(
+  transformCtx: TransformContext,
+  fnTransformCtx: SingleFnCompTransformCtx,
+) {
+  const {
+    inline,
+    ssr,
+    vineFileCtx,
+    compilerHooks,
+    templateComposer: {
+      generatedPreambleStmts,
+      templateCompileResults,
+    },
+  } = transformCtx
+  const { vineCompFnCtx, firstStmt, lastStmt } = fnTransformCtx
+  const ms = transformCtx.vineFileCtx.fileMagicCode
+  const isDev = compilerHooks.getCompilerCtx().options.envMode !== 'production'
+
+  // Get all explicit declared export in exportNamedDeclarations
+  const explicitExports = fineAllExplicitExports(vineFileCtx.exportNamedDeclarations)
+
+  // Defaultly set `export` for all component functions
+  // because it's required by HMR context.
+  ms.prependLeft(firstStmt.start!, `${
+    explicitExports.includes(vineCompFnCtx.fnName)
+      ? ''
+      : 'export'
+  } const ${
+    vineCompFnCtx.fnName
+  } = (() => {\n${
+    // Prepend all generated preamble statements
+    generatedPreambleStmts
+      .get(vineCompFnCtx)
+      ?.join('\n') ?? ''
+  }\n`)
+
+  ms.appendRight(lastStmt.end!, `\n${
+    inline
+      ? ''
+      // Not-inline mode, we need manually add the
+      // render function to the component object.
+      : `${
+        templateCompileResults.get(vineCompFnCtx) ?? ''
+      }\n__vine.${ssr ? 'ssrRender' : 'render'} = ${ssr ? '__sfc_ssr_render' : '__sfc_render'}`
+  }\n`)
+
+  if (vineFileCtx.styleDefine[vineCompFnCtx.scopeId]) {
+    ms.appendRight(lastStmt.end!, `__vine.__scopeId = 'data-v-${vineCompFnCtx.scopeId}';\n`)
+  }
+
+  if (isDev) {
+    ms.appendRight(lastStmt.end!, `__vine.__hmrId = '${vineCompFnCtx.scopeId}';\n`)
+  }
+
+  // handle Web Component styles
+  if (vineCompFnCtx.isCustomElement) {
+    ms.appendRight(lastStmt.end!, `__vine.styles = [__${vineCompFnCtx.fnName.toLowerCase()}_styles];\n`)
+  }
+
+  ms.appendRight(lastStmt.end!, `\nreturn __vine\n})();`)
+
+  // Record component function to HMR
+  if (isDev) {
+    ms.appendRight(
+      ms.length(),
+      `\n\ntypeof __VUE_HMR_RUNTIME__ !== "undefined" && __VUE_HMR_RUNTIME__.createRecord(${vineCompFnCtx.fnName}.__hmrId, ${vineCompFnCtx.fnName});\n`,
+    )
+  }
+
+  if (vineCompFnCtx.isExportDefault) {
+    ms.appendRight(
+      ms.length(),
+      `\n\nexport default ${vineCompFnCtx.fnName};\n\n`,
+    )
+  }
+}
+
+export function generateDefineComponentWrapper(
+  transformCtx: TransformContext,
+  fnTransformCtx: SingleFnCompTransformCtx,
+) {
+  const { firstStmt, lastStmt } = fnTransformCtx
+  const ms = transformCtx.vineFileCtx.fileMagicCode
+
+  ms.prependLeft(firstStmt.start!, `const __vine = _defineComponent({\n`)
+  ms.appendRight(lastStmt.end!, '\n})')
+}
+
+export function generateBasicComponentOptions(
+  transformCtx: TransformContext,
+  fnTransformCtx: SingleFnCompTransformCtx,
+) {
+  const { vineCompFnCtx, firstStmt } = fnTransformCtx
+  const ms = transformCtx.vineFileCtx.fileMagicCode
+
+  const basicOptionsFields = `${vineCompFnCtx.options
+    ? `...${ms.original.slice(
+      vineCompFnCtx.options.start!,
+      vineCompFnCtx.options.end!,
+    )},`
+    : `name: '${vineCompFnCtx.fnName}',`
+  }\n`
+
+  ms.prependLeft(firstStmt.start!, basicOptionsFields)
+}
+
+export function generatePropsOptions(
+  transformCtx: TransformContext,
+  fnTransformCtx: SingleFnCompTransformCtx,
+) {
+  const { vineFileCtx } = transformCtx
+  const { vineCompFnCtx, firstStmt } = fnTransformCtx
+  const ms = transformCtx.vineFileCtx.fileMagicCode
+
+  const segementsFromProps = Object.entries(vineCompFnCtx.props).map(([propName, propMeta]) => {
+    const metaFields = []
+    if (propMeta.isRequired) {
+      metaFields.push('required: true')
+    }
+    if (propMeta.isBool) {
+      metaFields.push('type: Boolean')
+    }
+    if (propMeta.validator) {
+      metaFields.push(`validator: ${
+        vineFileCtx.originCode.slice(
+          propMeta.validator.start!,
+          propMeta.validator.end!,
+        )
+      }`)
+    }
+    return `${
+      propMeta.nameNeedQuoted
+        ? `'${propName}'`
+        : propName
+    }: { ${
+      showIf(
+        metaFields.filter(Boolean).length > 0,
+        filterJoin(metaFields, ', '),
+        '/* Simple prop */',
+      )
+    } },`
+  })
+
+  const segmentsFromVineModel = Object
+    .entries(vineCompFnCtx.vineModels)
+    .reduce<string[]>((segments, [modelName, modelDef]) => {
+      const { modelModifiersName, modelOptions } = modelDef
+      segments.push(
+        `${modelName}: ${
+          modelOptions
+            ? vineFileCtx.originCode.slice(
+                modelOptions.start!,
+                modelOptions.end!,
+              )
+            : '{}'
+        },`,
+      )
+      segments.push(
+        `${modelModifiersName}: {},`,
+      )
+
+      return segments
+    }, [])
+
+  const propsOptions = [
+    ...segementsFromProps,
+    ...segmentsFromVineModel,
+  ]
+
+  const propsOptionsFields = `${propsOptions.length > 0
+    ? `props: {\n${
+      propsOptions.join('\n')
+    }\n},`
+    : '/* No props */'
+  }\n`
+
+  ms.prependLeft(firstStmt.start!, propsOptionsFields)
+}
+
+export function generateEmitsOptions(
+  transformCtx: TransformContext,
+  fnTransformCtx: SingleFnCompTransformCtx,
+) {
+  const { vineCompFnCtx, firstStmt } = fnTransformCtx
+  const ms = transformCtx.vineFileCtx.fileMagicCode
+
+  const emitsKeys = [
+    ...vineCompFnCtx.emits.map(emit => `'${emit}'`),
+    ...Object.keys(vineCompFnCtx.vineModels).map(modelName => `'update:${modelName}'`),
+  ]
+
+  const emitsOptionsFields = `${emitsKeys.length > 0
+    ? `emits: [${
+      emitsKeys.join(', ')
+    }],`
+    : '/* No emits */'
+  }\n`
+
+  ms.prependLeft(firstStmt.start!, emitsOptionsFields)
+}
+
+export function generateStyleImports(
+  transformCtx: TransformContext,
+) {
+  const { vineFileCtx } = transformCtx
+  // Traverse file context's `styleDefine`, and generate import statements.
+  // Ordered by their import releationship.
+  const styleImportStmts = sortStyleImport(vineFileCtx)
+  const ms = transformCtx.vineFileCtx.fileMagicCode
+
+  // Prepend all style import statements
+  ms.prepend(`\n${styleImportStmts.join('\n')}\n`)
+}
+
+export function generateAllImports(
+  transformCtx: TransformContext,
+) {
+  const { mergedImportsMap } = transformCtx
+  const ms = transformCtx.vineFileCtx.fileMagicCode
+
+  // Prepend all imports
+  for (const [importSource, importMeta] of mergedImportsMap) {
+    if (importMeta.type === 'namedSpecifier') {
+      const { specs } = importMeta
+      const specifiers = [...specs.entries()]
+      const importStmt = `import { ${
+        specifiers.map(
+          ([specifier, alias]) => `${specifier}${showIf(Boolean(alias), ` as ${alias}`)}`,
+        ).join(', ')
+      } } from '${importSource}';\n`
+      ms.prepend(importStmt)
+    }
+    else if (importMeta.type === 'defaultSpecifier') {
+      const importStmt = `import ${importMeta.localName} from '${importSource}';\n`
+      ms.prepend(importStmt)
+    }
+    else if (importMeta.type === 'namespaceSpecifier') {
+      const importStmt = `import * as ${importMeta.localName} from '${importSource}';\n`
+      ms.prepend(importStmt)
+    }
+  }
+}

--- a/packages/compiler/src/transform/utils.ts
+++ b/packages/compiler/src/transform/utils.ts
@@ -1,0 +1,88 @@
+import type { AwaitExpression, Node } from '@babel/types'
+import type { MergedImportsMap, NamedImportSpecifierMeta } from '../template/compose'
+import {
+  isAwaitExpression,
+  isBlockStatement,
+  isExpressionStatement,
+  isVariableDeclaration,
+  traverse,
+} from '@babel/types'
+import { EXPECTED_ERROR } from '../constants'
+
+export function mayContainAwaitExpr(vineFnBodyStmt: Node) {
+  let awaitExpr: AwaitExpression | undefined
+  const isExprStmt = isExpressionStatement(vineFnBodyStmt)
+  const isVarDeclStmt = isVariableDeclaration(vineFnBodyStmt)
+
+  if (!(
+    isVarDeclStmt
+    || isExprStmt
+  )) {
+    return null
+  }
+
+  const isNeedResult = (
+    isVarDeclStmt
+    || vineFnBodyStmt.expression.type === 'AssignmentExpression'
+  )
+
+  try {
+    traverse(vineFnBodyStmt, (descendant) => {
+      if (isBlockStatement(descendant)) {
+        throw new Error(EXPECTED_ERROR)
+      }
+      else if (isAwaitExpression(descendant)) {
+        awaitExpr = descendant
+        throw new Error(EXPECTED_ERROR)
+      }
+    })
+  }
+  catch (error: any) {
+    if (error.message === EXPECTED_ERROR) {
+      return {
+        isNeedResult,
+        awaitExpr,
+      }
+    }
+    throw error
+  }
+
+  return null
+}
+
+export function wrapWithAsyncContext(
+  isNeedResult: boolean,
+  exprSourceCode: string,
+) {
+  return isNeedResult
+    ? `(
+    ([__temp,__restore] = _withAsyncContext(() => ${exprSourceCode})),
+    __temp = await __temp,
+    __restore(),
+    __temp
+    )`
+    : `;(
+    ([__temp,__restore] = _withAsyncContext(() => ${exprSourceCode})),
+    await __temp,
+    __restore()
+  );`
+}
+
+export function registerImport(
+  mergedImportsMap: MergedImportsMap,
+  importSource: string,
+  specifier: string,
+  alias: string,
+) {
+  const vueVineImports = mergedImportsMap.get(importSource)
+  if (!vueVineImports) {
+    mergedImportsMap.set(importSource, {
+      type: 'namedSpecifier',
+      specs: new Map([[specifier, alias]]),
+    })
+  }
+  else {
+    const vueImportsSpecs = (vueVineImports as NamedImportSpecifierMeta).specs
+    vueImportsSpecs.set(specifier, alias)
+  }
+}

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -83,7 +83,6 @@ export interface VineCompilerOptions {
   postcssOptions?: any
   postcssPlugins?: any[]
   disableTsMorph?: boolean
-  plugins?: VineCompilerPlugin[]
 }
 
 export interface VineStyleMeta {
@@ -296,12 +295,3 @@ export type VineAnalyzeRunner = (
   analyzeCtx: VineAnalyzeCtx,
   fnItselfNode: BabelFunctionNodeTypes,
 ) => void
-
-export interface VineCompilerPlugin {
-  name: string
-  validators?: Array<{
-    from: 'root' | 'fnDecl' | 'fnItself'
-    validator: VineValidator
-  }>
-  analyzers?: VineAnalyzeRunner[]
-}

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -27,7 +27,6 @@ import type MagicString from 'magic-string'
 import type { Project, TypeChecker } from 'ts-morph'
 import type { BARE_CALL_MACROS, VINE_MACROS } from './constants'
 
-// Types:
 export type Nil = null | undefined
 export type VineBabelRoot = ParseResult<File>
 export type VINE_MACRO_NAMES = typeof VINE_MACROS[number]
@@ -78,12 +77,13 @@ export interface VineCompilerHooks {
 
 export interface VineCompilerOptions {
   envMode?: string // 'development' | 'production'
-  vueCompilerOptions?: CompilerOptions
   inlineTemplate?: boolean
+  vueCompilerOptions?: CompilerOptions
   preprocessOptions?: Record<string, any>
   postcssOptions?: any
   postcssPlugins?: any[]
   disableTsMorph?: boolean
+  plugins?: VineCompilerPlugin[]
 }
 
 export interface VineStyleMeta {
@@ -269,4 +269,39 @@ export interface VineCompileCtx {
   compilerHooks: VineCompilerHooks
   fileCtxCache?: VineFileCtx
   babelParseOptions?: ParserOptions
+}
+
+export interface VineValidatorCtx {
+  vineCompilerHooks: VineCompilerHooks
+  vineFileCtx: VineFileCtx
+  vineCompFns: Node[]
+}
+
+export interface MacroAssertCtx extends VineValidatorCtx {
+  fromVineCompFnNode: Node
+}
+
+export type VineValidator = (
+  context: VineValidatorCtx,
+  fromNode: Node,
+) => boolean
+
+export interface VineAnalyzeCtx {
+  vineCompilerHooks: VineCompilerHooks
+  vineFileCtx: VineFileCtx
+  vineCompFnCtx: VineCompFnCtx
+}
+
+export type VineAnalyzeRunner = (
+  analyzeCtx: VineAnalyzeCtx,
+  fnItselfNode: BabelFunctionNodeTypes,
+) => void
+
+export interface VineCompilerPlugin {
+  name: string
+  validators?: Array<{
+    from: 'root' | 'fnDecl' | 'fnItself'
+    validator: VineValidator
+  }>
+  analyzers?: VineAnalyzeRunner[]
 }

--- a/packages/compiler/src/utils/index.ts
+++ b/packages/compiler/src/utils/index.ts
@@ -96,3 +96,10 @@ export function isBasicBoolTypeNames(type: string) {
     'false',
   ].includes(type)
 }
+
+export function createLinkedCodeTag(
+  side: 'left' | 'right',
+  itemLength: number,
+) {
+  return `/* __LINKED_CODE_${side.toUpperCase()}__#${itemLength} */`
+}

--- a/packages/compiler/src/utils/topo-sort.ts
+++ b/packages/compiler/src/utils/topo-sort.ts
@@ -18,7 +18,14 @@ export function topoSort(
     visited[node] = true
     stack[node] = true
 
-    for (const depNode of relationsMap[node]) {
+    const depNodes = relationsMap[node]
+    if (!depNodes) {
+      // Invalid dependency, maybe an external component,
+      // So we exit here to skip it
+      return
+    }
+
+    for (const depNode of depNodes) {
       const result = dfs(depNode, stack)
       if (result === null) {
         // sub-tree detected circle dependency, so just quit
@@ -32,11 +39,6 @@ export function topoSort(
 
   for (const node of Object.keys(relationsMap)) {
     dfs(node, {})
-  }
-
-  // If there're still some nodes not visited, it means there's a circle dependency.
-  if (sorted.length !== Object.keys(visited).length) {
-    return null
   }
 
   return sorted

--- a/packages/compiler/src/validate.ts
+++ b/packages/compiler/src/validate.ts
@@ -11,7 +11,7 @@ import type {
   VariableDeclaration,
   VariableDeclarator,
 } from '@babel/types'
-import type { CountingMacros, VINE_MACRO_NAMES, VineCompilerHooks, VineFileCtx, VineFnPickedInfo } from './types'
+import type { CountingMacros, MacroAssertCtx, VINE_MACRO_NAMES, VineCompilerHooks, VineFileCtx, VineFnPickedInfo, VineValidatorCtx } from './types'
 import process from 'node:process'
 import {
   isArrayExpression,
@@ -50,15 +50,6 @@ import {
 import { vineErr, vineWarn } from './diagnostics'
 import { _breakableTraverse } from './utils'
 import { colorful } from './utils/color-string'
-
-interface VineValidatorCtx {
-  vineCompilerHooks: VineCompilerHooks
-  vineFileCtx: VineFileCtx
-  vineCompFns: Node[]
-}
-interface MacroAssertCtx extends VineValidatorCtx {
-  fromVineCompFnNode: Node
-}
 
 interface VineModelValidateCtx {
   hasDefaultModel: boolean

--- a/packages/compiler/tests/__snapshots__/transform.spec.ts.snap
+++ b/packages/compiler/tests/__snapshots__/transform.spec.ts.snap
@@ -3,22 +3,22 @@
 exports[`test transform > inline mode output result 1`] = `
 "import { useDefaults as _useDefaults } from "vue-vine";
 import {
+  defineComponent as _defineComponent,
+  useCssVars as _useCssVars,
+  unref as _unref,
   createElementVNode as _createElementVNode,
   toDisplayString as _toDisplayString,
   Fragment as _Fragment,
   openBlock as _openBlock,
   createElementBlock as _createElementBlock,
-  defineComponent as _defineComponent,
-  useCssVars as _useCssVars,
-  unref as _unref,
-  createTextVNode as _createTextVNode,
-  vShow as _vShow,
-  withDirectives as _withDirectives,
   useSlots as _useSlots,
   useModel as _useModel,
   toRefs as _toRefs,
-  createVNode as _createVNode,
+  createTextVNode as _createTextVNode,
+  vShow as _vShow,
+  withDirectives as _withDirectives,
   withAsyncContext as _withAsyncContext,
+  createVNode as _createVNode,
 } from "vue";
 
 import "testTransformInlineResult?type=vine-style&scopeId=3921d7bd&comp=MyProfile&lang=css&index=0&virtual.css";
@@ -119,6 +119,7 @@ export const MyProfile = (() => {
       "update:count",
     ],
     setup(__props, { emit: __emit, expose: __expose }) {
+      const emits = __emit;
       const props = _useDefaults(__props, {
         age: () => 18,
       });
@@ -132,7 +133,6 @@ export const MyProfile = (() => {
       const title = _useModel(__props, "title");
       const count = _useModel(__props, "count");
       const mySlots = _useSlots();
-      const emits = __emit;
 
       const textColor = ref("#1c1c1c");
       const handleRefresh = () => {
@@ -189,7 +189,6 @@ export const MyProfile = (() => {
 
   return __vine;
 })();
-
 export const MyApp = (() => {
   const _hoisted_1 = { class: "my-app" };
   const __vine = _defineComponent({
@@ -245,32 +244,32 @@ typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
 typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
   __VUE_HMR_RUNTIME__.createRecord(MyProfile.__hmrId, MyProfile);
 
-export default MyApp;
-
 typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
   __VUE_HMR_RUNTIME__.createRecord(MyApp.__hmrId, MyApp);
+
+export default MyApp;
 "
 `;
 
 exports[`test transform > not output HMR content in non-dev mode 1`] = `
 "import { useDefaults as _useDefaults } from "vue-vine";
 import {
+  defineComponent as _defineComponent,
+  useCssVars as _useCssVars,
+  unref as _unref,
   createElementVNode as _createElementVNode,
   toDisplayString as _toDisplayString,
   Fragment as _Fragment,
   openBlock as _openBlock,
   createElementBlock as _createElementBlock,
-  defineComponent as _defineComponent,
-  useCssVars as _useCssVars,
-  unref as _unref,
-  createTextVNode as _createTextVNode,
-  vShow as _vShow,
-  withDirectives as _withDirectives,
   useSlots as _useSlots,
   useModel as _useModel,
   toRefs as _toRefs,
-  createVNode as _createVNode,
+  createTextVNode as _createTextVNode,
+  vShow as _vShow,
+  withDirectives as _withDirectives,
   withAsyncContext as _withAsyncContext,
+  createVNode as _createVNode,
 } from "vue";
 
 import "testNoHMRContentOnProduction?type=vine-style&scopeId=3b48c990&comp=MyProfile&lang=css&index=0&virtual.css";
@@ -369,6 +368,7 @@ export const MyProfile = (() => {
       "update:count",
     ],
     setup(__props, { emit: __emit, expose: __expose }) {
+      const emits = __emit;
       const props = _useDefaults(__props, {
         age: () => 18,
       });
@@ -382,7 +382,6 @@ export const MyProfile = (() => {
       const title = _useModel(__props, "title");
       const count = _useModel(__props, "count");
       const mySlots = _useSlots();
-      const emits = __emit;
 
       const textColor = ref("#1c1c1c");
       const handleRefresh = () => {
@@ -438,7 +437,6 @@ export const MyProfile = (() => {
 
   return __vine;
 })();
-
 export const MyApp = (() => {
   const _hoisted_1 = { class: "my-app" };
   const __vine = _defineComponent({
@@ -494,21 +492,21 @@ export default MyApp;
 exports[`test transform > separated mode output result 1`] = `
 "import { useDefaults as _useDefaults } from "vue-vine";
 import {
+  defineComponent as _defineComponent,
+  useCssVars as _useCssVars,
   createElementVNode as _createElementVNode,
   toDisplayString as _toDisplayString,
   Fragment as _Fragment,
   openBlock as _openBlock,
   createElementBlock as _createElementBlock,
-  defineComponent as _defineComponent,
-  useCssVars as _useCssVars,
-  createTextVNode as _createTextVNode,
-  vShow as _vShow,
-  withDirectives as _withDirectives,
   useSlots as _useSlots,
   useModel as _useModel,
   toRefs as _toRefs,
-  createVNode as _createVNode,
+  createTextVNode as _createTextVNode,
+  vShow as _vShow,
+  withDirectives as _withDirectives,
   withAsyncContext as _withAsyncContext,
+  createVNode as _createVNode,
 } from "vue";
 
 import "testTransformSeparatedResult?type=vine-style&scopeId=25e4e706&comp=MyProfile&lang=css&index=0&virtual.css";
@@ -579,7 +577,6 @@ export const AnotherComp = (() => {
     );
   }
   __vine.render = __sfc_render;
-
   __vine.__hmrId = "93184a5c";
 
   return __vine;
@@ -611,6 +608,7 @@ export const MyProfile = (() => {
       "update:count",
     ],
     setup(__props, { emit: __emit, expose: __expose }) {
+      const emits = __emit;
       const props = _useDefaults(__props, {
         age: () => 18,
       });
@@ -624,7 +622,6 @@ export const MyProfile = (() => {
       const title = _useModel(__props, "title");
       const count = _useModel(__props, "count");
       const mySlots = _useSlots();
-      const emits = __emit;
 
       const textColor = ref("#1c1c1c");
       const handleRefresh = () => {
@@ -696,7 +693,6 @@ export const MyProfile = (() => {
 
   return __vine;
 })();
-
 export const MyApp = (() => {
   const _hoisted_1 = { class: "my-app" };
   const __vine = _defineComponent({
@@ -753,30 +749,30 @@ typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
 typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
   __VUE_HMR_RUNTIME__.createRecord(MyProfile.__hmrId, MyProfile);
 
-export default MyApp;
-
 typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
   __VUE_HMR_RUNTIME__.createRecord(MyApp.__hmrId, MyApp);
+
+export default MyApp;
 "
 `;
 
 exports[`test transform > separated mode output result by ssr 1`] = `
 "import { useDefaults as _useDefaults } from "vue-vine";
 import {
-  defineComponent as _defineComponent,
-  useCssVars as _useCssVars,
-  mergeProps as _mergeProps,
-  useSlots as _useSlots,
-  useModel as _useModel,
-  toRefs as _toRefs,
-  withAsyncContext as _withAsyncContext,
-} from "vue";
-import {
   ssrInterpolate as _ssrInterpolate,
   ssrRenderStyle as _ssrRenderStyle,
   ssrRenderAttrs as _ssrRenderAttrs,
   ssrRenderComponent as _ssrRenderComponent,
 } from "vue/server-renderer";
+import {
+  defineComponent as _defineComponent,
+  useCssVars as _useCssVars,
+  useSlots as _useSlots,
+  useModel as _useModel,
+  toRefs as _toRefs,
+  mergeProps as _mergeProps,
+  withAsyncContext as _withAsyncContext,
+} from "vue";
 
 import "testTransformSeparatedResult?type=vine-style&scopeId=25e4e706&comp=MyProfile&lang=css&index=0&virtual.css";
 import "testTransformSeparatedResult?type=vine-style&scopeId=25e4e706&comp=MyProfile&lang=css&scoped=true&index=1&virtual.css";
@@ -831,7 +827,6 @@ export const AnotherComp = (() => {
     );
   }
   __vine.ssrRender = __sfc_ssr_render;
-
   __vine.__hmrId = "93184a5c";
 
   return __vine;
@@ -862,6 +857,7 @@ export const MyProfile = (() => {
       "update:count",
     ],
     setup(__props, { emit: __emit, expose: __expose }) {
+      const emits = __emit;
       const props = _useDefaults(__props, {
         age: () => 18,
       });
@@ -875,7 +871,6 @@ export const MyProfile = (() => {
       const title = _useModel(__props, "title");
       const count = _useModel(__props, "count");
       const mySlots = _useSlots();
-      const emits = __emit;
 
       const textColor = ref("#1c1c1c");
       const handleRefresh = () => {
@@ -941,7 +936,6 @@ export const MyProfile = (() => {
 
   return __vine;
 })();
-
 export const MyApp = (() => {
   const __vine = _defineComponent({
     name: "MyApp",
@@ -1012,20 +1006,20 @@ typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
 typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
   __VUE_HMR_RUNTIME__.createRecord(MyProfile.__hmrId, MyProfile);
 
-export default MyApp;
-
 typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
   __VUE_HMR_RUNTIME__.createRecord(MyApp.__hmrId, MyApp);
+
+export default MyApp;
 "
 `;
 
 exports[`test transform > should generate export default in correct position 1`] = `
 "import {
-  openBlock as _openBlock,
-  createElementBlock as _createElementBlock,
   defineComponent as _defineComponent,
   useCssVars as _useCssVars,
   unref as _unref,
+  openBlock as _openBlock,
+  createElementBlock as _createElementBlock,
 } from "vue";
 
 export const MyComp = (() => {
@@ -1048,21 +1042,21 @@ export const MyComp = (() => {
   return __vine;
 })();
 
-export default MyComp;
-
 typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
   __VUE_HMR_RUNTIME__.createRecord(MyComp.__hmrId, MyComp);
+
+export default MyComp;
 "
 `;
 
 exports[`test transform > should generate hmrId If there is no style 1`] = `
 "import {
-  createElementVNode as _createElementVNode,
-  openBlock as _openBlock,
-  createElementBlock as _createElementBlock,
   defineComponent as _defineComponent,
   useCssVars as _useCssVars,
   unref as _unref,
+  createElementVNode as _createElementVNode,
+  openBlock as _openBlock,
+  createElementBlock as _createElementBlock,
 } from "vue";
 
 export const About = (() => {
@@ -1108,7 +1102,6 @@ exports[`test transform > should not export on function delcaration when already
 } from "vue";
 
 const a = 1;
-
 const MyComp = (() => {
   const __vine = _defineComponent({
     name: "MyComp",
@@ -1140,14 +1133,14 @@ typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
 exports[`test transform > should transform destructured props 1`] = `
 "import { useDefaults as _useDefaults } from "vue-vine";
 import {
-  toDisplayString as _toDisplayString,
-  openBlock as _openBlock,
-  createElementBlock as _createElementBlock,
   defineComponent as _defineComponent,
   useCssVars as _useCssVars,
   unref as _unref,
   createPropsRestProxy as _createPropsRestProxy,
   toRefs as _toRefs,
+  toDisplayString as _toDisplayString,
+  openBlock as _openBlock,
+  createElementBlock as _createElementBlock,
 } from "vue";
 
 import { ref, watch } from "vue";
@@ -1170,20 +1163,19 @@ export const MyComp = (() => {
       const props = _useDefaults(__props, {
         bar: () => 1,
       });
-      const __propsRestProxy = _createPropsRestProxy(__props, [
-        "foo:zee",
-        "bar",
-        "arr",
-      ]);
       const { "foo:zee": fooZee, bar, arr, ...rest } = _toRefs(props);
+      const rest = _createPropsRestProxy(__props, ["foo:zee", "bar", "arr"]);
       const test1 = ref(props["foo:zee"]);
-
       const test2 = watch(
         () => props.bar,
         (newVal) => {
           console.log(newVal);
         },
       );
+      onMounted(() => {
+        console.log("other1", rest.other1);
+        console.log("other2", rest.other2);
+      });
 
       return (_ctx, _cache) => {
         return (
@@ -1211,12 +1203,12 @@ typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
 
 exports[`test transform > should transform top-level await expressions 1`] = `
 "import {
-  openBlock as _openBlock,
-  createElementBlock as _createElementBlock,
   defineComponent as _defineComponent,
   useCssVars as _useCssVars,
   unref as _unref,
   withAsyncContext as _withAsyncContext,
+  openBlock as _openBlock,
+  createElementBlock as _createElementBlock,
 } from "vue";
 
 export const MyComp = (() => {

--- a/packages/compiler/tests/transform.spec.ts
+++ b/packages/compiler/tests/transform.spec.ts
@@ -216,11 +216,11 @@ export function MyComp() {
     )
     expect(formated).toMatchInlineSnapshot(`
       "import {
+        defineComponent as _defineComponent,
+        useCssVars as _useCssVars,
         toDisplayString as _toDisplayString,
         openBlock as _openBlock,
         createElementBlock as _createElementBlock,
-        defineComponent as _defineComponent,
-        useCssVars as _useCssVars,
       } from "vue";
 
       import { ref, Ref } from "vue";
@@ -259,7 +259,6 @@ export function MyComp() {
           );
         }
         __vine.render = __sfc_render;
-
         __vine.__hmrId = "01d6e3a5";
 
         return __vine;
@@ -347,9 +346,12 @@ export function MyComp({
 }) {
 
   const test1 = ref(fooZee)
-
   const test2 = watch(() => bar, (newVal) => {
     console.log(newVal)
+  })
+  onMounted(() => {
+    console.log('other1', rest.other1)
+    console.log('other2', rest.other2)
   })
 
   return vine\`
@@ -369,10 +371,7 @@ export function MyComp({
 
     expect(formated).toMatch('const test1 = ref(props["foo:zee"])')
     expect(formated).toMatch('() => props.bar')
-    expect(formated).toMatch(
-      /const __propsRestProxy = _createPropsRestProxy\(__props, \[\s*"foo:zee",\s*"bar",\s*"arr",\s*\]\);/,
-    )
-
+    expect(formated).toMatch('const rest = _createPropsRestProxy(__props, ["foo:zee", "bar", "arr"]);')
     expect(formated).toMatchSnapshot()
   })
 

--- a/packages/playground/src/pages/about.vine.ts
+++ b/packages/playground/src/pages/about.vine.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { ref, Ref } from 'vue'
 //           ^^^^ Deliberately import an extra useless type item here
 //                - For ESLint rules to catch it
 //                - Test if it broke compilation in JS runtime

--- a/packages/playground/src/pages/test-ts-morph.vine.ts
+++ b/packages/playground/src/pages/test-ts-morph.vine.ts
@@ -3,9 +3,13 @@ import type { TestProps } from '../types';
 interface T1 {
   step?: number
 }
-function TestTsMorphAnother({ step = 3 }: T1) {
+function TestPropsDestruct({ step = 3 }: T1) {
   return vine`
-    <div class="text-zinc-500">Step: {{ step }}</div>
+    <div class="flex flex-col">
+      <h4>Test props destruct</h4>
+      <div class="text-zinc-500">Step: {{ step }}</div>
+      <p class="text-zinc-600">should be 3</p>
+    </div>
   `
 }
 
@@ -22,6 +26,7 @@ export function TestTsMorphChild(props: TestProps) {
 
 export function TestTsMorph() {
   return vine`
+    <PageHeader />
     <div>
       <h3>Test Ts Morph</h3>
       <div class="flex-row">
@@ -33,7 +38,7 @@ export function TestTsMorph() {
         <TestTsMorphChild variant="error" title="error" errorCode="404" />
       </div>
       <h3 class="mt-6">Another:</h3>
-      <TestTsMorphAnother />
+      <TestPropsDestruct />
     </div>
   `
 }

--- a/packages/vite-plugin/src/hot-update.ts
+++ b/packages/vite-plugin/src/hot-update.ts
@@ -51,6 +51,14 @@ function patchModule(
     return patchRes
   }
 
+  const oldFnNames = oVineCompFns.map(fn => fn.fnName)
+  const newFnNames = nVineCompFns.map(fn => fn.fnName)
+  if (!areStrArraysEqual(oldFnNames, newFnNames)) {
+    newVFCtx.renderOnly = false
+    patchRes.hmrCompFnsName = newFnNames.find(name => !oldFnNames.includes(name))!
+    return patchRes
+  }
+
   const nStyleDefine = newVFCtx.styleDefine
   const oStyleDefine = oldVFCtx.styleDefine
   const nOriginCode = normalizeLineEndings(newVFCtx.originCode)

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -170,6 +170,21 @@ function createVinePlugin(options: VineCompilerOptions = {}): PluginOption {
       return runCompileScript(code, id, ssr)
     },
     async handleHotUpdate(ctx: HmrContext) {
+      // Before executing HMR, TypeScript project (by ts-morph) should be updated
+      // to make sure the latest type information is available
+      if (tsMorphCache) {
+        // Update the source file in the project to reflect the latest changes
+        const { project } = tsMorphCache
+        const sourceFile = project.getSourceFileOrThrow(ctx.file)
+
+        // Read the updated file content
+        const updatedContent = await ctx.read()
+
+        // Update the source file with the new content
+        sourceFile.replaceWithText(updatedContent)
+        // Project's type checker will automatically update with the new content
+      }
+
       const affectedModules = await vineHMR(ctx, compilerCtx, compilerHooks)
       return affectedModules
     },


### PR DESCRIPTION
## Description
The code in the transform phase of the existing code is extremely chaotic and has very poor readability, making maintenance extremely complicated. It is necessary to break it down into independent steps to facilitate the location of issues during troubleshooting

## Other changes
- HMR: renaming component function should give a reload instead of re-render only

