### PR TITLE
feat(lang-service): support request ID for pipeline requests

### DIFF
--- a/packages/language-server/src/pipeline/get-component-props.ts
+++ b/packages/language-server/src/pipeline/get-component-props.ts
@@ -1,6 +1,7 @@
 import type { VueVineCode } from '@vue-vine/language-service'
 import type * as ts from 'typescript'
-import type { HtmlTagInfo, PipelineStatus } from '../types'
+import type { HtmlTagInfo, PipelineContext, RequestResolver } from '../types'
+import { randomUUID } from 'node:crypto'
 import { pipelineRequest, tryParsePipelineResponse } from '@vue-vine/language-service'
 import { WebSocket } from 'ws'
 import { getPipelineServerPort } from './get-pipeline-server-port'
@@ -8,10 +9,16 @@ import { getPipelineServerPort } from './get-pipeline-server-port'
 interface GetComponentPropsContext {
   vineVirtualCode: VueVineCode
   tagInfos: Map<string, HtmlTagInfo>
-  pipelineStatus: PipelineStatus
+  pipelineStatus: PipelineContext
   tsConfigFileName: string
   tsHost: ts.System
 }
+
+const REQUEST_TIMEOUT = 10000
+
+// Create a cache to prevent duplicate requests for the same component
+// This will persist across multiple function calls
+const requestCache = new Set<string>()
 
 export function getComponentPropsFromPipeline(
   tag: string,
@@ -23,45 +30,129 @@ export function getComponentPropsFromPipeline(
     tsHost,
   }: GetComponentPropsContext,
 ) {
+  // Generate a cache key based on filename and component
+  const cacheKey = `${vineVirtualCode.fileName}:${tag}`
+
+  // Check if we already requested this component recently
+  if (requestCache.has(cacheKey)) {
+    console.log(`Pipeline: Hit request cache for component "${tag}"`)
+    return Promise.resolve()
+  }
+
+  // Add to cache to prevent duplicate requests
+  requestCache.add(cacheKey)
+  console.log(`Pipeline: Creating new request for component "${tag}"`)
+
   const port = getPipelineServerPort(tsConfigFileName, tsHost)
   const pipelineClient = new WebSocket(`ws://localhost:${port}`)
+
+  const requestId = randomUUID()
+
   const requestPromise = new Promise<void>((resolve, reject) => {
+    // set request timeout
+    const timeout = setTimeout(() => {
+      const resolver = pipelineStatus.pendingRequests.get(requestId)
+      if (resolver) {
+        resolver.reject(new Error(`Pipeline request timeout for component: ${tag}`))
+        pipelineStatus.pendingRequests.delete(requestId)
+      }
+      pipelineClient.close()
+    }, REQUEST_TIMEOUT)
+
+    // store resolver for later use
+    const resolver: RequestResolver = {
+      resolve,
+      reject,
+      timeout,
+    }
+    pipelineStatus.pendingRequests.set(requestId, resolver)
+
     pipelineClient.on('open', () => {
-      pipelineClient.on('message', (msgData) => {
-        const resp = tryParsePipelineResponse(msgData.toString(), (err) => {
-          reject(err)
-        })
-        if (!resp) {
-          const err = new Error(
-            '[Vue Vine Pipeline] Invalid pipeline response data',
-            { cause: msgData.toString() },
-          )
-          reject(err)
-          return
-        }
-
-        console.log(`Pipeline: Got message`, JSON.stringify(resp, null, 2))
-        if (resp.type === 'getPropsAndEmitsResponse') {
-          tagInfos.set(tag, {
-            props: [...resp.props],
-            events: [],
-          })
-          resolve()
-        }
-      })
-
-      console.log(`Pipeline: Fetching component '${tag}' props`)
+      console.log(`Pipeline: Fetching component '${tag}' props, requestId: ${requestId}`)
       pipelineClient.send(
         pipelineRequest({
-          type: 'getPropsAndEmitsRequest',
+          type: 'getComponentPropsRequest',
+          requestId,
           componentName: tag,
           fileName: vineVirtualCode.fileName,
         }),
       )
     })
-  }).finally(() => {
+
+    pipelineClient.on('message', (msgData) => {
+      const resp = tryParsePipelineResponse(msgData.toString(), (err) => {
+        reject(err)
+      })
+      if (!resp) {
+        const err = new Error(
+          '[Vue Vine Pipeline] Invalid pipeline response data',
+          { cause: msgData.toString() },
+        )
+        reject(err)
+        return
+      }
+
+      console.log(`Pipeline: Got message`, JSON.stringify(resp, null, 2))
+
+      if (
+        resp.type === 'getComponentPropsResponse'
+        && resp.requestId === requestId
+      ) {
+        // ensure this response is for our request
+        tagInfos.set(tag, {
+          props: [...resp.props],
+          events: [],
+        })
+
+        // Clear timeout timer
+        const resolver = pipelineStatus.pendingRequests.get(requestId)
+        if (resolver?.timeout) {
+          clearTimeout(resolver.timeout)
+        }
+
+        // Remove from pending requests
+        pipelineStatus.pendingRequests.delete(requestId)
+        // Close WebSocket connection and resolve Promise
+        pipelineClient.close()
+        // Remove from cache when done
+        requestCache.delete(cacheKey)
+        console.log(`Pipeline: Get component props for "${tag}" completed, removed from cache`)
+        resolve()
+      }
+    })
+
+    pipelineClient.on('error', (error) => {
+      console.error(`Pipeline error for requestId ${requestId}:`, error)
+      reject(error)
+
+      // 清理资源
+      const resolver = pipelineStatus.pendingRequests.get(requestId)
+      if (resolver?.timeout) {
+        clearTimeout(resolver.timeout)
+      }
+      pipelineStatus.pendingRequests.delete(requestId)
+
+      // Remove from cache on error
+      requestCache.delete(cacheKey)
+      console.log(`Pipeline: Request for "${tag}" failed, removed from cache`)
+    })
+
+    pipelineClient.on('close', () => {
+      // Ensure resources are cleaned up when closing
+      const resolver = pipelineStatus.pendingRequests.get(requestId)
+      if (resolver?.timeout) {
+        clearTimeout(resolver.timeout)
+      }
+    })
+  }).catch((err) => {
+    console.error(`Pipeline request failed for ${tag}:`, err)
+    pipelineStatus.pendingRequests.delete(requestId)
     pipelineClient.close()
-    pipelineStatus.pendingRequest.delete('getPropsAndEmitsRequest')
+    // Remove from cache when the promise is rejected
+    requestCache.delete(cacheKey)
+    console.log(`Pipeline: Request for "${tag}" failed in catch handler, removed from cache`)
+    throw err
   })
-  pipelineStatus.pendingRequest.set('getPropsAndEmitsRequest', requestPromise)
+
+  return requestPromise
 }

--- a/packages/language-server/src/types.ts
+++ b/packages/language-server/src/types.ts
@@ -1,5 +1,3 @@
-import type { PipelineRequest } from '@vue-vine/language-service'
-
 export type VineVirtualFileExtension =
   | 'ts'
   | 'css'
@@ -9,9 +7,14 @@ export type VineVirtualFileExtension =
   | 'styl'
   | 'html'
 
-export interface PipelineStatus {
-  isFetchDone: boolean
-  pendingRequest: Map<PipelineRequest['type'], Promise<void>>
+export interface RequestResolver {
+  resolve: (value: any) => void
+  reject: (reason?: any) => void
+  timeout?: NodeJS.Timeout
+}
+
+export interface PipelineContext {
+  pendingRequests: Map<string, RequestResolver>
 }
 
 export interface HtmlTagInfo {

--- a/packages/language-service/typescript-plugin/pipeline.ts
+++ b/packages/language-service/typescript-plugin/pipeline.ts
@@ -60,7 +60,7 @@ export function createVueVinePipelineServer(
 function handlePipelineRequest(request: PipelineRequest, context: PipelineContext) {
   try {
     switch (request.type) {
-      case 'getPropsAndEmitsRequest':
+      case 'getComponentPropsRequest':
         handleGetComponentPropsAndEmits(request, context)
         break
     }
@@ -72,7 +72,7 @@ function handlePipelineRequest(request: PipelineRequest, context: PipelineContex
 
 function handleGetComponentPropsAndEmits(request: PipelineRequest, context: PipelineContext) {
   const { ws, language } = context
-  const { componentName, fileName } = request
+  const { requestId, componentName, fileName } = request
 
   const volarFile = language.scripts.get(fileName)
   if (!(isVueVineVirtualCode(volarFile?.generated?.root))) {
@@ -90,12 +90,25 @@ function handleGetComponentPropsAndEmits(request: PipelineRequest, context: Pipe
 
     ws.send(
       pipelineResponse({
-        type: 'getPropsAndEmitsResponse',
+        type: 'getComponentPropsResponse',
+        requestId,
+        componentName,
+        fileName,
         props,
       }),
     )
   }
   catch (err) {
     context.tsPluginLogger.error('Pipeline: Error on getComponentProps:', err)
+    // Send empty response when error
+    ws.send(
+      pipelineResponse({
+        type: 'getComponentPropsResponse',
+        requestId,
+        componentName,
+        fileName,
+        props: [],
+      }),
+    )
   }
 }

--- a/packages/language-service/typescript-plugin/types.ts
+++ b/packages/language-service/typescript-plugin/types.ts
@@ -5,11 +5,18 @@ import type { WebSocket } from 'ws'
 export type TypeScriptSdk = Parameters<Parameters<(typeof createLanguageServicePlugin)>[0]>[0]
 export type TsPluginInfo = Parameters<Parameters<(typeof createLanguageServicePlugin)>[0]>[1]
 
+type _pipelineReq<T extends { type: string }> = {
+  requestId: string
+} & T
+type _pipelineResp<T extends { type: string }> = {
+  requestId: string
+} & T
+
 export type PipelineRequest =
-  | { type: 'getPropsAndEmitsRequest', componentName: string, fileName: string }
+  | (_pipelineReq<{ type: 'getComponentPropsRequest', componentName: string, fileName: string }>)
 
 export type PipelineResponse =
-  | { type: 'getPropsAndEmitsResponse', props: string[] }
+  | (_pipelineResp<{ type: 'getComponentPropsResponse', componentName: string, fileName: string, props: string[] }>)
 
 export interface PipelineContext {
   ts: TypeScriptSdk


### PR DESCRIPTION
Our implementation on the TS language service pipeline server is flawed. There is no guarantee that the request initiator can be distinguished when obtaining the request. At present, it is only because the user operates at a single location and the tsc response is fast enough that we did not discover this problem before. However, once in the future we expect to publicly use this Websocket pipe server for other purposes, facing a large number of requests will definitely cause problems. 