### PR TITLE
fix(eslint-parser): align type with `Linter.Parser`

### DIFF
--- a/packages/eslint-parser/src/index.ts
+++ b/packages/eslint-parser/src/index.ts
@@ -1,10 +1,17 @@
+import type { ESLint, Linter } from 'eslint'
 import type {
   ParseForESLintResult,
   VineESLintParserOptions,
 } from './types'
+import { name, version } from '../package.json'
 import { runParse } from './parse'
 
 export * from './ast'
+
+export const meta: ESLint.ObjectMetaProperties = {
+  name,
+  version,
+}
 
 export function parse(
   code: string,
@@ -36,3 +43,9 @@ export function parseForESLint(
     visitorKeys,
   }
 }
+
+export default {
+  meta,
+  parse,
+  parseForESLint,
+} as Linter.Parser

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,5 +1,5 @@
 import type { ESLint, Linter } from 'eslint'
-import * as VueVineESLintParser from '@vue-vine/eslint-parser'
+import VueVineESLintParser from '@vue-vine/eslint-parser'
 
 import { version } from '../package.json'
 


### PR DESCRIPTION
- add default export so that we don't need to use `* as` to import the eslint-parser
- export `ESLint.ObjectMetaProperties` to align the type with the `Linter.Parser`

related links:
- https://eslint.org/docs/head/extend/custom-parsers#meta-data-in-custom-parsers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added standardized metadata (name and version) to the ESLint parser, making it easier to identify parser details.
  - Introduced a unified default export for the ESLint parser module, bundling metadata and parsing functions for improved integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->