### PR TITLE
fix(compiler): use defaults not working with boolean default true

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
       "args": [
         "--inspector",
         "--extensionDevelopmentPath=${workspaceFolder}/packages/vscode-ext",
-        "--folder-uri=${workspaceRoot}/packages/playground"
+        "--folder-uri=${workspaceRoot}/packages/e2e-test"
       ],
       "outFiles": [
         "${workspaceFolder}/packages/vscode-ext/node_modules/@vue-vine/typescript-plugin/**/*",

--- a/packages/compiler/src/transform/steps.ts
+++ b/packages/compiler/src/transform/steps.ts
@@ -801,6 +801,11 @@ export function generatePropsOptions(
     }
     if (propMeta.isMaybeBool) {
       metaFields.push('type: Boolean')
+      if (propMeta.default) {
+        metaFields.push(`default: ${
+          vineFileCtx.getAstNodeContent(propMeta.default)
+        }`)
+      }
     }
     if (propMeta.validator) {
       metaFields.push(`validator: ${

--- a/packages/docs/src/introduction/ecosystem.md
+++ b/packages/docs/src/introduction/ecosystem.md
@@ -114,7 +114,7 @@ You may seen the following output:
    Happy hacking!
 ```
 
-## Slidev plugin <VersionTip version="v1.3.3+" />
+## Slidev plugin <VersionTip version="v1.4.0+" />
 
 Vine also provides a plugin for Slidev, you can use it to register Vine components in your Slidev project.
 

--- a/packages/docs/src/zh/introduction/ecosystem.md
+++ b/packages/docs/src/zh/introduction/ecosystem.md
@@ -114,7 +114,7 @@ create-vue-vine my-vine-project
    Happy hacking!
 ```
 
-## Slidev 插件 <VersionTip version="v1.3.3+" /> {#slidev-plugin}
+## Slidev 插件 <VersionTip version="v1.4.0+" /> {#slidev-plugin}
 
 Vine 还提供了一个 Slidev 的插件，你可以使用它来注册 Vine 组件到你的 Slidev 项目中。
 

--- a/packages/e2e-test/src/app.vine.ts
+++ b/packages/e2e-test/src/app.vine.ts
@@ -5,6 +5,7 @@ const routes = [
   { path: '/transform-asset-url', label: 'Transform Asset Url' },
   { path: '/props-destructure', label: 'Props Destructure' },
   { path: '/vibe', label: 'Vibe' },
+  { path: '/use-defaults', label: 'Use Defaults' },
 ]
 
 export function NavList() {

--- a/packages/e2e-test/src/router.ts
+++ b/packages/e2e-test/src/router.ts
@@ -4,6 +4,7 @@ import { HmrApp } from './hmr.vine'
 import { TestDestructurePropsPage } from './props-destructure.vine'
 import { TestStyleOrder } from './style-order.vine'
 import { TestTransformAssetUrl } from './transform-asset-url.vine'
+import { TestUseDefaults } from './use-defaults.vine'
 import { TestVibe } from './vibe.vine'
 
 const routes = [
@@ -13,6 +14,7 @@ const routes = [
   { path: '/transform-asset-url', component: TestTransformAssetUrl },
   { path: '/props-destructure', component: TestDestructurePropsPage },
   { path: '/vibe', component: TestVibe },
+  { path: '/use-defaults', component: TestUseDefaults },
 ]
 
 const router = createRouter({

--- a/packages/e2e-test/src/styles/atom.css
+++ b/packages/e2e-test/src/styles/atom.css
@@ -1,0 +1,10 @@
+.row-flex {
+  display: flex;
+  flex-direction: row;
+}
+.items-center {
+  align-items: center;
+}
+.justify-center {
+  justify-content: center;
+}

--- a/packages/e2e-test/src/use-defaults.vine.ts
+++ b/packages/e2e-test/src/use-defaults.vine.ts
@@ -1,0 +1,26 @@
+import './styles/atom.css'
+
+interface LineProps {
+  center?: boolean
+}
+
+function Line({ center = true }: LineProps) {
+  return vine`
+    <div class="row-flex items-center" :class="{ 'justify-center': center }">
+      <slot />
+    </div>
+  `
+}
+
+export function TestUseDefaults() {
+  return vine`
+    <!-- No explicit given center, should be true by fallback to true as default -->
+    <Line class="line-1">
+      <p>Hello world</p>
+    </Line>
+    <!-- Explicit given center, should be true -->
+    <Line class="line-2" center>
+      <p>Hello world</p>
+    </Line>
+  `
+}

--- a/packages/e2e-test/tests/basic.spec.ts
+++ b/packages/e2e-test/tests/basic.spec.ts
@@ -1,6 +1,6 @@
 import type { E2EPlaywrightContext } from '../utils/test-utils'
 import { describe, expect, it } from 'vitest'
-import { createBrowserContext, getAssetUrl, getColor, untilUpdated } from '../utils/test-utils'
+import { createBrowserContext, getAssetUrl, getColor, getJustifyContent, untilUpdated } from '../utils/test-utils'
 
 function runTestAtPage(
   page: string,
@@ -81,6 +81,15 @@ describe('test basic functionality', async () => {
         await browserCtx.page!.click('.child-comp-1 button')
       }
       expect(await browserCtx.page!.textContent('.child-comp-1 p')).toBe('Count: 10')
+    },
+  ))
+
+  it('should get correct boolean default', runTestAtPage(
+    '/use-defaults',
+    browserCtx,
+    async () => {
+      expect(await getJustifyContent(browserCtx, '.line-1')).toBe('center')
+      expect(await getJustifyContent(browserCtx, '.line-2')).toBe('center')
     },
   ))
 })

--- a/packages/e2e-test/tests/hmr.spec.ts
+++ b/packages/e2e-test/tests/hmr.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest'
-import { createBrowserCtxEnvironment, editFile, getColor, getDisplayStyle, untilUpdated } from '../utils/test-utils'
+import { createBrowserCtxEnvironment, editFile, getColor, getDisplayStyle, untilUpdated, wait } from '../utils/test-utils'
 
 afterEach(() => {
   // reset
@@ -45,6 +45,8 @@ describe('hmr', () => {
       () => browserCtx.page!.textContent('.counter'),
       'Count: 2',
     )
+
+    await wait(500)
     editFile('hmr.vine.ts', code => code.replace('color: black', 'color: blue'))
     await untilUpdated(() => getColor(browserCtx, 'button.test-btn'), 'rgb(0, 0, 255)')
     await untilUpdated(() => browserCtx.page!.textContent('.counter'), 'Count: 2')
@@ -54,6 +56,8 @@ describe('hmr', () => {
     expect(await browserCtx.page!.textContent('.counter')).toBe('Count: 0')
     await browserCtx.page?.click('button.test-btn')
     await untilUpdated(() => browserCtx.page!.textContent('.counter'), 'Count: 2')
+
+    await wait(500)
     editFile('hmr.vine.ts', code => code.replace('text111', 'text222'))
     await untilUpdated(() => browserCtx.page!.textContent('.text-for-replace'), 'text222')
     await untilUpdated(() => browserCtx.page!.textContent('.counter'), 'Count: 2')
@@ -63,6 +67,8 @@ describe('hmr', () => {
     expect(await browserCtx.page!.textContent('.counter')).toBe('Count: 0')
     await browserCtx.page?.click('button.test-btn')
     await untilUpdated(() => browserCtx.page!.textContent('.counter'), 'Count: 2')
+
+    await wait(500)
     editFile('hmr.vine.ts', code =>
       code.replace(
         '<div class="name">{{name}}</div>',
@@ -77,6 +83,8 @@ describe('hmr', () => {
     await browserCtx.page?.click('button.test-btn')
     await untilUpdated(() => browserCtx.page!.textContent('.counter'), 'Count: 2')
     editFile('hmr.vine.ts', code => code.replace('ref(\'vine\')', 'ref(\'vue\')'))
+
+    await wait(500)
     await untilUpdated(() => browserCtx.page!.textContent('.name'), 'vue')
     expect(await browserCtx.page!.textContent('.counter')).toBe('Count: 0')
   }))

--- a/packages/e2e-test/utils/test-utils.ts
+++ b/packages/e2e-test/utils/test-utils.ts
@@ -26,7 +26,7 @@ export interface E2EPlaywrightContext {
   targetRoute?: string
 }
 
-const timeout = (n: number) => new Promise(resolve => setTimeout(resolve, n))
+export const wait = (n: number) => new Promise(resolve => setTimeout(resolve, n))
 
 async function startDefaultServe(e2eTestCtx: E2EPlaywrightContext) {
   const e2eRoot = resolve(import.meta.dirname, '..')
@@ -134,7 +134,7 @@ export async function untilUpdated(
       break
     }
     else {
-      await timeout(50)
+      await wait(50)
     }
   }
 }
@@ -188,6 +188,24 @@ export async function getAssetUrl(
         return null
       }
       return el.getAttribute('src')
+    },
+    selector,
+  )
+}
+
+export async function getJustifyContent(
+  e2eTestCtx: E2EPlaywrightContext,
+  selector: string,
+  page?: Page,
+) {
+  const pageCtx = page ?? e2eTestCtx.page
+  return await pageCtx?.evaluate(
+    (selector: string) => {
+      const el = document.querySelector(selector)
+      if (!el) {
+        return null
+      }
+      return getComputedStyle(el).justifyContent
     },
     selector,
   )

--- a/packages/language-service/src/injectTypes.ts
+++ b/packages/language-service/src/injectTypes.ts
@@ -74,7 +74,7 @@ export function generateGlobalTypes(vueOptions: VueCompilerOptions): string {
     exposed: infer E
   } ? (exposed: E) => void : never;
 
-  type __VLS_VineComponentCommonProps = {
+  type __VLS_VineComponentCommonProps = HTMLAttributes & {
     key?: PropertyKey
     ref?: string | import('vue').Ref | ((ref: Element | import('vue').ComponentPublicInstance | null, refs: Record<string, any>) => void);
   }

--- a/packages/language-service/tests/__snapshots__/virtual-code.spec.ts.snap
+++ b/packages/language-service/tests/__snapshots__/virtual-code.spec.ts.snap
@@ -11,7 +11,7 @@ type __VINE_VLS_Comp_props__ = {
 /* __LINKED_CODE_LEFT__#3 */foo: string
 }
 function Comp(
-  props: __VINE_VLS_Comp_props__  & __VINE_VLS_VineComponentCommonProps, 
+  props: __VINE_VLS_VineComponentCommonProps & __VINE_VLS_Comp_props__,
 context: {}) {
   
 type Comp_Props = Parameters<typeof Comp>[0];
@@ -77,7 +77,7 @@ type __VINE_VLS_SampleOne_props__ = {
 // - Case 1: 'vue-vine/format-vine-macros-leading'
 // - Case 2: 'vue-vine/essentials-no-child-content'
 export function SampleOne(
-  props: __VINE_VLS_SampleOne_props__  & __VINE_VLS_VineComponentCommonProps, 
+  props: __VINE_VLS_VineComponentCommonProps & __VINE_VLS_SampleOne_props__,
 context: {}) {
   
 type SampleOne_Props = Parameters<typeof SampleOne>[0];
@@ -168,7 +168,7 @@ type __VINE_VLS_SampleTwo_props__ = {}
 // - Case 1: 'vue-vine/format-prefer-template' with autofix in setup
 // - Case 2: 'vue-vine/format-prefer-template' not autofix in template
 export function SampleTwo(
-  props: __VINE_VLS_SampleTwo_props__  & __VINE_VLS_VineComponentCommonProps, 
+  props: __VINE_VLS_VineComponentCommonProps & __VINE_VLS_SampleTwo_props__,
 context: {}) {
   
 type SampleTwo_Props = Parameters<typeof SampleTwo>[0];
@@ -236,7 +236,7 @@ type __VINE_VLS_TestPlainTextTemplate_props__ = {}
 
 
 export function TestPlainTextTemplate(
-  props: __VINE_VLS_TestPlainTextTemplate_props__  & __VINE_VLS_VineComponentCommonProps, 
+  props: __VINE_VLS_VineComponentCommonProps & __VINE_VLS_TestPlainTextTemplate_props__,
 context: {}) {
   // This should not report any formatting warning
   
@@ -290,7 +290,7 @@ type __VINE_VLS_TestUnoCssAttributeMode_props__ = {}
 
 
 export function TestUnoCssAttributeMode(
-  props: __VINE_VLS_TestUnoCssAttributeMode_props__  & __VINE_VLS_VineComponentCommonProps, 
+  props: __VINE_VLS_VineComponentCommonProps & __VINE_VLS_TestUnoCssAttributeMode_props__,
 context: {}) {
   
 type TestUnoCssAttributeMode_Props = Parameters<typeof TestUnoCssAttributeMode>[0];
@@ -356,7 +356,7 @@ type __VINE_VLS_TestCompOne_props__ = {
 
 // #region Fixtures for testing component reference & props check in VSCode
 function TestCompOne(
-  props: __VINE_VLS_TestCompOne_props__  & __VINE_VLS_VineComponentCommonProps, 
+  props: __VINE_VLS_VineComponentCommonProps & __VINE_VLS_TestCompOne_props__,
 context: {}) {
   
 type TestCompOne_Props = Parameters<typeof TestCompOne>[0];
@@ -421,7 +421,7 @@ type __VINE_VLS_TestCompTwo_props__ = {}
 
 
 function TestCompTwo(
-  props: __VINE_VLS_TestCompTwo_props__  & __VINE_VLS_VineComponentCommonProps, 
+  props: __VINE_VLS_VineComponentCommonProps & __VINE_VLS_TestCompTwo_props__,
 context: {}) {
   
 type TestCompTwo_Props = Parameters<typeof TestCompTwo>[0];
@@ -501,9 +501,9 @@ return vine\`\` as any as VueVineComponent;
 
 
 // #region Test vineExpose and component ref
-function TargetComp(props: {
+function TargetComp(props: __VINE_VLS_VineComponentCommonProps & {
   foo: boolean
-} & __VINE_VLS_VineComponentCommonProps, context: {
+}, context: {
   expose: __VINE_VLS_PickComponentExpose<typeof TargetComp>,
 }) {
   
@@ -581,7 +581,7 @@ type __VINE_VLS_TestCompRef_props__ = {}
 
 
 export function TestCompRef(
-  props: __VINE_VLS_TestCompRef_props__  & __VINE_VLS_VineComponentCommonProps, 
+  props: __VINE_VLS_VineComponentCommonProps & __VINE_VLS_TestCompRef_props__,
 context: {}) {
   
 type TestCompRef_Props = Parameters<typeof TestCompRef>[0];
@@ -662,7 +662,7 @@ type __VINE_VLS_TestNoVforKeyOnChild_props__ = {}
 
 // #region Test ESLint rule: no-v-for-key-on-child
 export function TestNoVforKeyOnChild(
-  props: __VINE_VLS_TestNoVforKeyOnChild_props__  & __VINE_VLS_VineComponentCommonProps, 
+  props: __VINE_VLS_VineComponentCommonProps & __VINE_VLS_TestNoVforKeyOnChild_props__,
 context: {}) {
   
 type TestNoVforKeyOnChild_Props = Parameters<typeof TestNoVforKeyOnChild>[0];
@@ -734,7 +734,7 @@ type __VINE_VLS_TestNoLifecycleHookAfterAwait_props__ = {}
 // #region Test ESLint rule: no-lifecycle-hook-after-await
 declare const doSomethingAsync: () => Promise<void>
 export async function TestNoLifecycleHookAfterAwait(
-  props: __VINE_VLS_TestNoLifecycleHookAfterAwait_props__  & __VINE_VLS_VineComponentCommonProps, 
+  props: __VINE_VLS_VineComponentCommonProps & __VINE_VLS_TestNoLifecycleHookAfterAwait_props__,
 context: {}) {
   
 type TestNoLifecycleHookAfterAwait_Props = Parameters<typeof TestNoLifecycleHookAfterAwait>[0];


### PR DESCRIPTION
- BUG description: 

```ts
import './styles/atom.css'

interface LineProps {
  center?: boolean
}

function Line({ center = true }: LineProps) {
  return vine`
    <div class="row-flex items-center" :class="{ 'justify-center': center }">
      <slot />
    </div>
  `
}

export function TestUseDefaults() {
  return vine`
    <!-- No explicit given center, should be true by fallback to true as default -->
    <Line class="line-1">
      <p>Hello world</p>
    </Line>
    <!-- Explicit given center, should be true -->
    <Line class="line-2" center>
      <p>Hello world</p>
    </Line>
  `
}
```

Now the first `Line` doesn't put p element in center position by `'justify-center'`, which is not as expected.

- Other change: consider some bug and no-good user experience, we decide to recommend use slidev plugin after v1.4.0