### PR TITLE
fix(eslint-parser): align default `ecmaVersion` with `vue-eslint-parser`

### DIFF
--- a/packages/eslint-parser/src/index.ts
+++ b/packages/eslint-parser/src/index.ts
@@ -30,7 +30,8 @@ export function parseForESLint(
       loc: true,
       range: true,
       tokens: true,
-    },
+      ecmaVersion: 'latest',
+    } as VineESLintParserOptions,
     parserOptions || {},
   )
 


### PR DESCRIPTION
Set the default value to `latest` like [`vue-eslint-parser`](https://github.com/vuejs/vue-eslint-parser/blob/master/src/index.ts#L97).

Otherwise, `v-for` (probably more cases) will not be parsed correctly.

Sorry, I don't have time to give a mini repo now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The parser now defaults to using the latest ECMAScript version if no version is specified in the options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->