### PR TITLE
docs: add vitepress-plugin-group-icons

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -15,6 +15,7 @@
     "@iconify-json/logos": "catalog:icons",
     "@iconify-json/twemoji": "catalog:icons",
     "unocss": "catalog:styles",
-    "vitepress": "catalog:docs"
+    "vitepress": "catalog:docs",
+    "vitepress-plugin-group-icons": "catalog:docs"
   }
 }

--- a/packages/docs/src/.vitepress/config.ts
+++ b/packages/docs/src/.vitepress/config.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import UnoCSS from 'unocss/vite'
 import { defineConfig } from 'vitepress'
+import { groupIconMdPlugin, groupIconVitePlugin } from 'vitepress-plugin-group-icons'
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
 const vineGrammar = JSON.parse(
@@ -151,10 +152,14 @@ export default defineConfig({
         ...vineGrammar,
       },
     ],
+    config(md) {
+      md.use(groupIconMdPlugin)
+    },
   },
   vite: {
     plugins: [
       UnoCSS(),
+      groupIconVitePlugin(),
     ],
   },
 })

--- a/packages/docs/src/.vitepress/theme/index.ts
+++ b/packages/docs/src/.vitepress/theme/index.ts
@@ -4,6 +4,7 @@ import { h } from 'vue'
 import Recommend from './components/recommend.vue'
 import Sponsors from './components/sponsors.vue'
 import VersionTip from './components/version-tip.vue'
+import 'virtual:group-icons.css'
 
 import 'uno.css'
 import './style.css'

--- a/packages/docs/src/introduction/ecosystem.md
+++ b/packages/docs/src/introduction/ecosystem.md
@@ -18,7 +18,7 @@ pnpm i -D @vue-vine/eslint-config
 
 Then, add the following configuration to your `eslint.config.js`:
 
-```js
+```js [eslint.config.js]
 import antfu from '@antfu/eslint-config'
 
 // `VueVine()` returns an ESLint flat config
@@ -47,7 +47,7 @@ pnpm i -D vue-vine-tsc
 
 Then, you may replace the `vue-tsc -b && ...` command in `"build"` script of `package.json`:
 
-```diff
+```diff [package.json]
 {
   "scripts": {
 -    "build": "vue-tsc -b && vite build",
@@ -62,7 +62,7 @@ Since v1.4.0, Vine also provides a plugin for Slidev, you can use it to register
 
 To install the plugin, you should add a `setup/main.ts` file in your Slidev project for setup Vue application, find more details in [Slidev documentation](https://sli.dev/custom/config-vue).
 
-```ts
+```ts [setup/main.ts]
 import { defineAppSetup } from '@slidev/types'
 import { VueVineSlidevPlugin } from 'vue-vine/slidev'
 
@@ -82,7 +82,7 @@ export default defineAppSetup(({ app }) => {
 
 Because Vue Vine's template type checking enabled the strict mode of Vue language tools, so it is not allowed to use arbitrary attributes on the HTML tags in the template. This will affect the scenario of using UnoCSS Attribute Mode. To solve this problem, please add a `shims.d.ts` file to the project `tsconfig.json` (the `include` option) and write the following content:
 
-```ts
+```ts [shims.d.ts]
 declare module 'vue' {
   interface HTMLAttributes {
     [key: string]: any

--- a/packages/docs/src/introduction/quick-start.md
+++ b/packages/docs/src/introduction/quick-start.md
@@ -25,7 +25,7 @@ Besides, we also provide some other libraries that you might need during develop
 
 Use the plugin in `vite.config.ts`:
 
-```ts
+```ts [vite.config.ts]
 import { VineVitePlugin } from 'vue-vine/vite'
 
 export default defineConfig({
@@ -97,7 +97,7 @@ Search "Vue Vine" in the marketplace and install it.
 
 Vine provides a typescript declaration file to help you write macros with intellisense.
 
-```json
+```json [tsconfig.json]
 {
   "compilerOptions": {
     "types": ["vue-vine/macros"]

--- a/packages/docs/src/specification/vibe.md
+++ b/packages/docs/src/specification/vibe.md
@@ -35,8 +35,7 @@ You can import the `defineVibe` function from `vue-vine` to define a data store.
 
 You can configure in `unplugin-auto-import` to automatically import the `defineVibe` function.
 
-```ts
-// vite.config.ts
+```ts [vite.config.ts]
 import AutoImport from 'unplugin-auto-import/vite'
 
 export default defineConfig({

--- a/packages/docs/src/zh/introduction/ecosystem.md
+++ b/packages/docs/src/zh/introduction/ecosystem.md
@@ -18,7 +18,7 @@ pnpm i -D @vue-vine/eslint-config
 
 接着，请将以下配置添加到你的 `eslint.config.js` 文件中：
 
-```js
+```js [eslint.config.js]
 import antfu from '@antfu/eslint-config'
 
 // `VueVine()` 返回一个 ESLint flat config
@@ -47,7 +47,7 @@ pnpm i -D vue-vine-tsc
 
 接着，在 `package.json` 的 `"build"` 脚本中，你可以将 `vue-tsc -b && ...` 替换为：
 
-```diff
+```diff [package.json]
 {
   "scripts": {
 -    "build": "vue-tsc -b && vite build",
@@ -62,7 +62,7 @@ pnpm i -D vue-vine-tsc
 
 要安装这个插件，你需要在 Slidev 项目中添加一个 `setup/main.ts` 文件来设置 Vue 应用，更多细节请参考 [Slidev 文档](https://sli.dev/custom/config-vue)。
 
-```ts
+```ts [setup/main.ts]
 import { defineAppSetup } from '@slidev/types'
 import { VueVineSlidevPlugin } from 'vue-vine/slidev'
 
@@ -82,7 +82,7 @@ export default defineAppSetup(({ app }) => {
 
 因为 Vue Vine 的模板类型检查开启了 Vue language tools 的严格模式，所以本身是不允许随便在模板的 HTML 标签上使用任意名称的属性的，而这会影响到使用 UnoCSS Attribute Mode 的场景。为了解决此类问题，请你在项目 `tsconfig.json` 所包含（`include`）的范围内，添加一个 `shims.d.ts` 文件，并写入以下内容：
 
-```ts
+```ts [shims.d.ts]
 declare module 'vue' {
   interface HTMLAttributes {
     [key: string]: any

--- a/packages/docs/src/zh/introduction/quick-start.md
+++ b/packages/docs/src/zh/introduction/quick-start.md
@@ -25,7 +25,7 @@ Vine 提供了 Vite 插件和 VSCode 扩展来支持基础功能。
 
 在 `vite.config.ts` 中导入插件：
 
-```ts
+```ts [vite.config.ts]
 import { VineVitePlugin } from 'vue-vine/vite'
 
 export default defineConfig({
@@ -110,7 +110,7 @@ pnpm i -g create-vue-vine
 
 Vine 提供了一个 typescript 声明文件，以帮助你使用宏时获得智能提示。
 
-```json
+```json [tsconfig.json]
 {
   "compilerOptions": {
     "types": ["vue-vine/macros"]

--- a/packages/docs/src/zh/specification/vibe.md
+++ b/packages/docs/src/zh/specification/vibe.md
@@ -34,8 +34,7 @@ Vibe 的英语单词意思是 “氛围”，选择这个名字我们希望创�
 
 你可以配置 `unplugin-auto-import` 来自动导入 `defineVibe` 函数。
 
-```ts
-// vite.config.ts
+```ts [vite.config.ts]
 import AutoImport from 'unplugin-auto-import/vite'
 
 export default defineConfig({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ catalogs:
     vitepress:
       specifier: ^1.6.3
       version: 1.6.3
+    vitepress-plugin-group-icons:
+      specifier: ^1.6.0
+      version: 1.6.0
   icons:
     '@iconify-json/carbon':
       specifier: ^1.2.8
@@ -570,6 +573,9 @@ importers:
       vitepress:
         specifier: catalog:docs
         version: 1.6.3(@algolia/client-search@5.27.0)(@types/node@22.15.30)(async-validator@4.2.5)(fuse.js@7.1.0)(jwt-decode@4.0.0)(lightningcss@1.30.1)(postcss@8.5.4)(sass@1.89.1)(search-insights@2.17.3)(terser@5.41.0)(typescript@5.8.3)
+      vitepress-plugin-group-icons:
+        specifier: catalog:docs
+        version: 1.6.0(markdown-it@14.1.0)(vite@5.4.19(@types/node@22.15.30)(lightningcss@1.30.1)(sass@1.89.1)(terser@5.41.0))
 
   packages/e2e-test:
     devDependencies:
@@ -1925,6 +1931,9 @@ packages:
 
   '@iconify-json/twemoji@1.2.2':
     resolution: {integrity: sha512-ckWEY5KhIQgdFd9VGvfhecTtYUx3ihXycwlZcEws87LxuvIThMHNBCblrQQ5afhbGMfg21dF+z9F+ODMRDYHMg==}
+
+  '@iconify-json/vscode-icons@1.2.22':
+    resolution: {integrity: sha512-qQ+2q3E7ULfDreFOspoYKcGJ76o0/D7wZiBt5g8wco9v+Qq6JDH3z2YNoM/36zzAqRnhVEIs5A9sdZeAJeJUwA==}
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
@@ -8317,6 +8326,12 @@ packages:
       yaml:
         optional: true
 
+  vitepress-plugin-group-icons@1.6.0:
+    resolution: {integrity: sha512-+nxuVETpFkOYR5qHdvj3M5otWusJyS3ozEvVf1aQaE5Oz5e6NR0naYKTtH0Zf3Qss4vnhqaYt2Lq4jUTn9JVuA==}
+    peerDependencies:
+      markdown-it: '>=14'
+      vite: '>=3'
+
   vitepress@1.6.3:
     resolution: {integrity: sha512-fCkfdOk8yRZT8GD9BFqusW3+GggWYZ/rYncOfmgcDtP3ualNHCAg+Robxp2/6xfH1WwPHtGpPwv7mbA3qomtBw==}
     hasBin: true
@@ -9774,6 +9789,10 @@ snapshots:
       '@iconify/types': 2.0.0
 
   '@iconify-json/twemoji@1.2.2':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify-json/vscode-icons@1.2.22':
     dependencies:
       '@iconify/types': 2.0.0
 
@@ -17256,6 +17275,16 @@ snapshots:
       terser: 5.41.0
       tsx: 4.19.4
       yaml: 2.8.0
+
+  vitepress-plugin-group-icons@1.6.0(markdown-it@14.1.0)(vite@5.4.19(@types/node@22.15.30)(lightningcss@1.30.1)(sass@1.89.1)(terser@5.41.0)):
+    dependencies:
+      '@iconify-json/logos': 1.2.4
+      '@iconify-json/vscode-icons': 1.2.22
+      '@iconify/utils': 2.3.0
+      markdown-it: 14.1.0
+      vite: 5.4.19(@types/node@22.15.30)(lightningcss@1.30.1)(sass@1.89.1)(terser@5.41.0)
+    transitivePeerDependencies:
+      - supports-color
 
   vitepress@1.6.3(@algolia/client-search@5.27.0)(@types/node@22.15.30)(async-validator@4.2.5)(fuse.js@7.1.0)(jwt-decode@4.0.0)(lightningcss@1.30.1)(postcss@8.5.4)(sass@1.89.1)(search-insights@2.17.3)(terser@5.41.0)(typescript@5.8.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,6 +41,7 @@ catalogs:
     ts-morph: ^26.0.0
   docs:
     vitepress: ^1.6.3
+    vitepress-plugin-group-icons: ^1.6.0
   icons:
     '@iconify-json/carbon': ^1.2.8
     '@iconify-json/logos': ^1.2.4


### PR DESCRIPTION
This PR add [vitepress-plugin-group-icons](https://github.com/yuyinws/vitepress-plugin-group-icons) to enhance the document's readability.

## After

<img width="733" alt="image" src="https://github.com/user-attachments/assets/7e4dd4c1-2840-49d7-b27e-16b25d78d7cd" />

<img width="711" alt="image" src="https://github.com/user-attachments/assets/c930e68f-7112-49d0-bccf-b0d0b1733ebb" />

<img width="738" alt="image" src="https://github.com/user-attachments/assets/dac323fd-e886-487e-8e45-6b452b07f3c8" />

## Others

It's can also support show the `vue-vine` logo on `*.vine.ts` code block by custom icon:

```js
import { groupIconVitePlugin, localIconLoader } from 'vitepress-plugin-group-icons'

export default defineConfig({
// .vitepress/config.ts
 vite: {
    plugins: [
      groupIconVitePlugin({
          customIcon: {
            'vine.ts': localIconLoader(import.meta.url, 'path/to/vue-vine.svg'),
          },
        }),
    ],
  },
})

```

Then use it like this:

````md
```vue-vine [app.vine.ts]
// vue-vine code
```
````

But this requires the SVG file of the vue-vine logo, unfortunately, I couldn't find it.
