### PR TITLE
fix(lang-service): virtual code generation strategy

### DIFF
--- a/packages/compiler/src/template/compose.ts
+++ b/packages/compiler/src/template/compose.ts
@@ -53,6 +53,12 @@ export function compileVineTemplate(
   & { templateParsedAst?: ReturnType<typeof parse> }
 ) | null {
   const _compile = ssr ? ssrCompile : compile
+  const {
+    __enableTransformAssetsURL = true,
+    __transformNegativeBool,
+  } = compilerHooks.getCompilerCtx()
+    ?.options
+    ?.vueCompilerOptions ?? {}
 
   try {
     return {
@@ -63,12 +69,12 @@ export function compileVineTemplate(
         prefixIdentifiers: true,
         inline: true,
         nodeTransforms: [
-          transformAssetUrl,
+          ...(__enableTransformAssetsURL
+            ? [transformAssetUrl]
+            : []
+          ),
           ...getTransformNegativeBoolPlugin(
-            compilerHooks.getCompilerCtx()
-              ?.options
-              ?.vueCompilerOptions
-              ?.__transformNegativeBool,
+            __transformNegativeBool,
           ),
         ],
         ...params,

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -83,6 +83,8 @@ export interface VineCompilerOptions {
   inlineTemplate?: boolean
   vueCompilerOptions?: CompilerOptions & {
     /** @internal */
+    __enableTransformAssetsURL?: boolean
+    /** @internal */
     __transformNegativeBool?: boolean | { constType: ConstantTypes }
   }
   preprocessOptions?: Record<string, any>

--- a/packages/e2e-test/src/fixtures/key-cases.vine.ts
+++ b/packages/e2e-test/src/fixtures/key-cases.vine.ts
@@ -176,3 +176,15 @@ export async function TestNoLifecycleHookAfterAwait() {
   `
 }
 // #endregion
+
+// #region Test generics on Vine component function 
+
+export function TestGenericComp1<T extends keyof HTMLElementTagNameMap = 'h1'>(
+  props: Partial<HTMLElementTagNameMap[T]> & { as: T }
+) {
+  return vine`
+    <component :is="as" />
+  `
+}
+
+// #endregion

--- a/packages/e2e-test/src/fixtures/mix-with-jsx.vine.ts
+++ b/packages/e2e-test/src/fixtures/mix-with-jsx.vine.ts
@@ -2,9 +2,7 @@ import { JsxComp } from '../components/mix-with-jsx/jsx-comp'
 
 export function TestVineWithJsx() {
   return vine`
-    <div
-      class="h-full w-full px-5 py-10 flex flex-col justify-center items-center"
-    >
+    <div class="h-full w-full px-5 py-10 flex flex-col justify-center items-center">
       <h3>This is a test page for Vine and JSX</h3>
       <JsxComp name="John" :age="20" />
     </div>

--- a/packages/e2e-test/src/fixtures/todo-list.vine.ts
+++ b/packages/e2e-test/src/fixtures/todo-list.vine.ts
@@ -120,11 +120,7 @@ function TodoContent() {
             <div class="todo-item-text">
               <div class="text-lg">{{ d.title }}</div>
             </div>
-            <ToDoAction
-              @delete="piniaStore.deleteTodo(d)"
-              :state="d.state"
-              show-delete
-            />
+            <ToDoAction @delete="piniaStore.deleteTodo(d)" :state="d.state" show-delete />
           </div>
         </div>
       </div>
@@ -186,11 +182,9 @@ export function TodoList() {
   vineStyle.import('../styles/todo-list.scss');
 
   return vine`
-    <div
-      class="todo-container container xl flex items-center justify-center flex-col"
-    >
+    <div class="todo-container container xl flex items-center justify-center flex-col">
       <TodoHeader />
-      <TodoContent />
+    <TodoContent />
     </div>
   `;
 }

--- a/packages/language-service/src/injectTypes.ts
+++ b/packages/language-service/src/injectTypes.ts
@@ -51,22 +51,22 @@ export function generateGlobalTypes(vueOptions: VueCompilerOptions): string {
     /declare global\s*\{/,
     `declare global {
   const VUE_VINE_COMPONENT: unique symbol;
-  type __StrictIsAny<T> = [unknown] extends [T]
+  type __VLS_StrictIsAny<T> = [unknown] extends [T]
     ? ([T] extends [unknown] ? true : false)
     : false;
-  type __OmitAny<T> = {
-    [K in keyof T as __StrictIsAny<T[K]> extends true ? never : K]: T[K]
+  type __VLS_OmitAny<T> = {
+    [K in keyof T as __VLS_StrictIsAny<T[K]> extends true ? never : K]: T[K]
   }
-  type MakeVLSCtx<T extends object> = {
+  type __VLS_MakeVLSCtx<T extends object> = {
     [K in keyof T]: T[K]
   }
-  const __createVineVLSCtx: <T>(ctx: T) => MakeVLSCtx<import('vue').UnwrapRef<T>>;
+  const __VLS_CreateVineVLSCtx: <T>(ctx: T) => __VLS_MakeVLSCtx<import('vue').ShallowUnwrapRef<T>>;
   type VueVineComponent = __VLS_Element;
 
   // From vuejs 'runtime-core.d.ts':
-  type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never;
-  type RecordToUnion<T extends Record<string, any>> = T[keyof T];
-  type VueDefineEmits<T extends Record<string, any>> = UnionToIntersection<Exclude<RecordToUnion<{
+  type __VLS_UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never;
+  type __VLS_RecordToUnion<T extends Record<string, any>> = T[keyof T];
+  type __VLS_VueDefineEmits<T extends Record<string, any>> = __VLS_UnionToIntersection<Exclude<__VLS_RecordToUnion<{
       [K in keyof T]: (evt: K, ...args: Exclude<T[K], undefined>) => void;
   }>, undefined>>;
 
@@ -135,7 +135,7 @@ export function generateVLSContext(
   )
 
   const __VINE_CONTEXT_TYPES = `
-const __VLS_ctx = __createVineVLSCtx({
+const __VLS_ctx = __VLS_CreateVineVLSCtx({
 ${notPropsBindings.map(([name]) => {
   // `name` maybe 'router-view' format,
   // so we need to convert it to PascalCase: `RouterView`
@@ -163,7 +163,7 @@ type __VLS_LocalDirectives = __OmitAny<typeof __VLS_ctx>;
 let __VLS_directives!: __VLS_LocalDirectives & __VLS_GlobalDirectives;
 const __VLS_components = {
   ...{} as __VLS_GlobalComponents,
-  ...__VLS_localComponents as __VLS_LocalComponents,
+  ...__VLS_localComponents as unknown as __VLS_LocalComponents,
 };
 `
 

--- a/packages/language-service/src/vine-ctx.ts
+++ b/packages/language-service/src/vine-ctx.ts
@@ -19,6 +19,7 @@ export function compileVineForVirtualCode(fileId: string, source: string): {
       cacheHandlers: false,
       prefixIdentifiers: false,
       scopeId: null,
+      __enableTransformAssetsURL: false,
       __transformNegativeBool: {
         constType: 0, // satisfies `ConstantTypes.NOT_CONSTANT`
       },

--- a/packages/language-service/tests/__snapshots__/global-types.spec.ts.snap
+++ b/packages/language-service/tests/__snapshots__/global-types.spec.ts.snap
@@ -4,22 +4,22 @@ exports[`verify global types generation > should match with fixture.vine.ts virt
 "
 ; declare global {
   const VUE_VINE_COMPONENT: unique symbol;
-  type __StrictIsAny<T> = [unknown] extends [T]
+  type __VINE_VLS_StrictIsAny<T> = [unknown] extends [T]
     ? ([T] extends [unknown] ? true : false)
     : false;
-  type __OmitAny<T> = {
-    [K in keyof T as __StrictIsAny<T[K]> extends true ? never : K]: T[K]
+  type __VINE_VLS_OmitAny<T> = {
+    [K in keyof T as __VINE_VLS_StrictIsAny<T[K]> extends true ? never : K]: T[K]
   }
-  type MakeVLSCtx<T extends object> = {
+  type __VINE_VLS_MakeVLSCtx<T extends object> = {
     [K in keyof T]: T[K]
   }
-  const __createVineVLSCtx: <T>(ctx: T) => MakeVLSCtx<import('vue').UnwrapRef<T>>;
+  const __VINE_VLS_CreateVineVLSCtx: <T>(ctx: T) => __VINE_VLS_MakeVLSCtx<import('vue').ShallowUnwrapRef<T>>;
   type VueVineComponent = __VINE_VLS_Element;
 
   // From vuejs 'runtime-core.d.ts':
-  type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never;
-  type RecordToUnion<T extends Record<string, any>> = T[keyof T];
-  type VueDefineEmits<T extends Record<string, any>> = UnionToIntersection<Exclude<RecordToUnion<{
+  type __VINE_VLS_UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never;
+  type __VINE_VLS_RecordToUnion<T extends Record<string, any>> = T[keyof T];
+  type __VINE_VLS_VueDefineEmits<T extends Record<string, any>> = __VINE_VLS_UnionToIntersection<Exclude<__VINE_VLS_RecordToUnion<{
       [K in keyof T]: (evt: K, ...args: Exclude<T[K], undefined>) => void;
   }>, undefined>>;
 

--- a/packages/language-service/tests/__snapshots__/virtual-code.spec.ts.snap
+++ b/packages/language-service/tests/__snapshots__/virtual-code.spec.ts.snap
@@ -25,7 +25,7 @@ const /* __LINKED_CODE_RIGHT__#3 */foo = vineProp<string>()
   
 // --- Start: Template virtual code
 
-const __VINE_VLS_ctx = __createVineVLSCtx({
+const __VINE_VLS_ctx = __VINE_VLS_CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#3 */foo: /* __LINKED_CODE_RIGHT__#3 */foo,
   /* __LINKED_CODE_LEFT__#9 */onMounted: /* __LINKED_CODE_RIGHT__#9 */onMounted,
   /* __LINKED_CODE_LEFT__#3 */ref: /* __LINKED_CODE_RIGHT__#3 */ref,
@@ -44,6 +44,7 @@ const __VINE_VLS_ctx = __createVineVLSCtx({
   /* __LINKED_CODE_LEFT__#20 */TestNoVforKeyOnChild: /* __LINKED_CODE_RIGHT__#20 */TestNoVforKeyOnChild,
   /* __LINKED_CODE_LEFT__#16 */doSomethingAsync: /* __LINKED_CODE_RIGHT__#16 */doSomethingAsync,
   /* __LINKED_CODE_LEFT__#29 */TestNoLifecycleHookAfterAwait: /* __LINKED_CODE_RIGHT__#29 */TestNoLifecycleHookAfterAwait,
+  /* __LINKED_CODE_LEFT__#16 */TestGenericComp1: /* __LINKED_CODE_RIGHT__#16 */TestGenericComp1,
   /* No props formal params */
 });
 const __VINE_VLS_localComponents = __VINE_VLS_ctx;
@@ -52,7 +53,7 @@ type __VINE_VLS_LocalDirectives = __OmitAny<typeof __VINE_VLS_ctx>;
 let __VINE_VLS_directives!: __VINE_VLS_LocalDirectives & __VINE_VLS_GlobalDirectives;
 const __VINE_VLS_components = {
   ...{} as __VINE_VLS_GlobalComponents,
-  ...__VINE_VLS_localComponents as __VINE_VLS_LocalComponents,
+  ...__VINE_VLS_localComponents as unknown as __VINE_VLS_LocalComponents,
 };
 
 type __VINE_VLS_StyleScopedClasses = {};
@@ -104,7 +105,7 @@ const count = ref(0)
   
 // --- Start: Template virtual code
 
-const __VINE_VLS_ctx = __createVineVLSCtx({
+const __VINE_VLS_ctx = __VINE_VLS_CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#4 */Comp: /* __LINKED_CODE_RIGHT__#4 */Comp,
   /* __LINKED_CODE_LEFT__#2 */p1: /* __LINKED_CODE_RIGHT__#2 */p1,
   /* __LINKED_CODE_LEFT__#5 */count: /* __LINKED_CODE_RIGHT__#5 */count,
@@ -125,6 +126,7 @@ const __VINE_VLS_ctx = __createVineVLSCtx({
   /* __LINKED_CODE_LEFT__#20 */TestNoVforKeyOnChild: /* __LINKED_CODE_RIGHT__#20 */TestNoVforKeyOnChild,
   /* __LINKED_CODE_LEFT__#16 */doSomethingAsync: /* __LINKED_CODE_RIGHT__#16 */doSomethingAsync,
   /* __LINKED_CODE_LEFT__#29 */TestNoLifecycleHookAfterAwait: /* __LINKED_CODE_RIGHT__#29 */TestNoLifecycleHookAfterAwait,
+  /* __LINKED_CODE_LEFT__#16 */TestGenericComp1: /* __LINKED_CODE_RIGHT__#16 */TestGenericComp1,
   /* No props formal params */
 });
 const __VINE_VLS_localComponents = __VINE_VLS_ctx;
@@ -133,7 +135,7 @@ type __VINE_VLS_LocalDirectives = __OmitAny<typeof __VINE_VLS_ctx>;
 let __VINE_VLS_directives!: __VINE_VLS_LocalDirectives & __VINE_VLS_GlobalDirectives;
 const __VINE_VLS_components = {
   ...{} as __VINE_VLS_GlobalComponents,
-  ...__VINE_VLS_localComponents as __VINE_VLS_LocalComponents,
+  ...__VINE_VLS_localComponents as unknown as __VINE_VLS_LocalComponents,
 };
 
 type __VINE_VLS_StyleScopedClasses = {};
@@ -196,7 +198,7 @@ let count = ref('0x' + Foo + 'CAFE')
   
 // --- Start: Template virtual code
 
-const __VINE_VLS_ctx = __createVineVLSCtx({
+const __VINE_VLS_ctx = __VINE_VLS_CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#5 */count: /* __LINKED_CODE_RIGHT__#5 */count,
   /* __LINKED_CODE_LEFT__#4 */type: /* __LINKED_CODE_RIGHT__#4 */type,
   /* __LINKED_CODE_LEFT__#9 */onMounted: /* __LINKED_CODE_RIGHT__#9 */onMounted,
@@ -216,6 +218,7 @@ const __VINE_VLS_ctx = __createVineVLSCtx({
   /* __LINKED_CODE_LEFT__#20 */TestNoVforKeyOnChild: /* __LINKED_CODE_RIGHT__#20 */TestNoVforKeyOnChild,
   /* __LINKED_CODE_LEFT__#16 */doSomethingAsync: /* __LINKED_CODE_RIGHT__#16 */doSomethingAsync,
   /* __LINKED_CODE_LEFT__#29 */TestNoLifecycleHookAfterAwait: /* __LINKED_CODE_RIGHT__#29 */TestNoLifecycleHookAfterAwait,
+  /* __LINKED_CODE_LEFT__#16 */TestGenericComp1: /* __LINKED_CODE_RIGHT__#16 */TestGenericComp1,
   /* No props formal params */
 });
 const __VINE_VLS_localComponents = __VINE_VLS_ctx;
@@ -224,7 +227,7 @@ type __VINE_VLS_LocalDirectives = __OmitAny<typeof __VINE_VLS_ctx>;
 let __VINE_VLS_directives!: __VINE_VLS_LocalDirectives & __VINE_VLS_GlobalDirectives;
 const __VINE_VLS_components = {
   ...{} as __VINE_VLS_GlobalComponents,
-  ...__VINE_VLS_localComponents as __VINE_VLS_LocalComponents,
+  ...__VINE_VLS_localComponents as unknown as __VINE_VLS_LocalComponents,
 };
 
 type __VINE_VLS_StyleScopedClasses = {};
@@ -268,7 +271,7 @@ type TestPlainTextTemplate_Props = Parameters<typeof TestPlainTextTemplate>[0];
   
 // --- Start: Template virtual code
 
-const __VINE_VLS_ctx = __createVineVLSCtx({
+const __VINE_VLS_ctx = __VINE_VLS_CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#9 */onMounted: /* __LINKED_CODE_RIGHT__#9 */onMounted,
   /* __LINKED_CODE_LEFT__#3 */ref: /* __LINKED_CODE_RIGHT__#3 */ref,
   /* __LINKED_CODE_LEFT__#14 */useTemplateRef: /* __LINKED_CODE_RIGHT__#14 */useTemplateRef,
@@ -286,6 +289,7 @@ const __VINE_VLS_ctx = __createVineVLSCtx({
   /* __LINKED_CODE_LEFT__#20 */TestNoVforKeyOnChild: /* __LINKED_CODE_RIGHT__#20 */TestNoVforKeyOnChild,
   /* __LINKED_CODE_LEFT__#16 */doSomethingAsync: /* __LINKED_CODE_RIGHT__#16 */doSomethingAsync,
   /* __LINKED_CODE_LEFT__#29 */TestNoLifecycleHookAfterAwait: /* __LINKED_CODE_RIGHT__#29 */TestNoLifecycleHookAfterAwait,
+  /* __LINKED_CODE_LEFT__#16 */TestGenericComp1: /* __LINKED_CODE_RIGHT__#16 */TestGenericComp1,
   /* No props formal params */
 });
 const __VINE_VLS_localComponents = __VINE_VLS_ctx;
@@ -294,7 +298,7 @@ type __VINE_VLS_LocalDirectives = __OmitAny<typeof __VINE_VLS_ctx>;
 let __VINE_VLS_directives!: __VINE_VLS_LocalDirectives & __VINE_VLS_GlobalDirectives;
 const __VINE_VLS_components = {
   ...{} as __VINE_VLS_GlobalComponents,
-  ...__VINE_VLS_localComponents as __VINE_VLS_LocalComponents,
+  ...__VINE_VLS_localComponents as unknown as __VINE_VLS_LocalComponents,
 };
 
 type __VINE_VLS_StyleScopedClasses = {};
@@ -341,7 +345,7 @@ const vBounce: Directive<HTMLElement> = {
   
 // --- Start: Template virtual code
 
-const __VINE_VLS_ctx = __createVineVLSCtx({
+const __VINE_VLS_ctx = __VINE_VLS_CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#7 */vBounce: /* __LINKED_CODE_RIGHT__#7 */vBounce,
   /* __LINKED_CODE_LEFT__#9 */onMounted: /* __LINKED_CODE_RIGHT__#9 */onMounted,
   /* __LINKED_CODE_LEFT__#3 */ref: /* __LINKED_CODE_RIGHT__#3 */ref,
@@ -360,6 +364,7 @@ const __VINE_VLS_ctx = __createVineVLSCtx({
   /* __LINKED_CODE_LEFT__#20 */TestNoVforKeyOnChild: /* __LINKED_CODE_RIGHT__#20 */TestNoVforKeyOnChild,
   /* __LINKED_CODE_LEFT__#16 */doSomethingAsync: /* __LINKED_CODE_RIGHT__#16 */doSomethingAsync,
   /* __LINKED_CODE_LEFT__#29 */TestNoLifecycleHookAfterAwait: /* __LINKED_CODE_RIGHT__#29 */TestNoLifecycleHookAfterAwait,
+  /* __LINKED_CODE_LEFT__#16 */TestGenericComp1: /* __LINKED_CODE_RIGHT__#16 */TestGenericComp1,
   /* No props formal params */
 });
 const __VINE_VLS_localComponents = __VINE_VLS_ctx;
@@ -368,7 +373,7 @@ type __VINE_VLS_LocalDirectives = __OmitAny<typeof __VINE_VLS_ctx>;
 let __VINE_VLS_directives!: __VINE_VLS_LocalDirectives & __VINE_VLS_GlobalDirectives;
 const __VINE_VLS_components = {
   ...{} as __VINE_VLS_GlobalComponents,
-  ...__VINE_VLS_localComponents as __VINE_VLS_LocalComponents,
+  ...__VINE_VLS_localComponents as unknown as __VINE_VLS_LocalComponents,
 };
 
 type __VINE_VLS_StyleScopedClasses = {};
@@ -423,7 +428,7 @@ type TestCompOne_Props = Parameters<typeof TestCompOne>[0];
   
 // --- Start: Template virtual code
 
-const __VINE_VLS_ctx = __createVineVLSCtx({
+const __VINE_VLS_ctx = __VINE_VLS_CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#3 */zee: /* __LINKED_CODE_RIGHT__#3 */zee,
   /* __LINKED_CODE_LEFT__#3 */foo: /* __LINKED_CODE_RIGHT__#3 */foo,
   /* __LINKED_CODE_LEFT__#9 */onMounted: /* __LINKED_CODE_RIGHT__#9 */onMounted,
@@ -443,6 +448,7 @@ const __VINE_VLS_ctx = __createVineVLSCtx({
   /* __LINKED_CODE_LEFT__#20 */TestNoVforKeyOnChild: /* __LINKED_CODE_RIGHT__#20 */TestNoVforKeyOnChild,
   /* __LINKED_CODE_LEFT__#16 */doSomethingAsync: /* __LINKED_CODE_RIGHT__#16 */doSomethingAsync,
   /* __LINKED_CODE_LEFT__#29 */TestNoLifecycleHookAfterAwait: /* __LINKED_CODE_RIGHT__#29 */TestNoLifecycleHookAfterAwait,
+  /* __LINKED_CODE_LEFT__#16 */TestGenericComp1: /* __LINKED_CODE_RIGHT__#16 */TestGenericComp1,
   /* No props formal params */
 });
 const __VINE_VLS_localComponents = __VINE_VLS_ctx;
@@ -451,7 +457,7 @@ type __VINE_VLS_LocalDirectives = __OmitAny<typeof __VINE_VLS_ctx>;
 let __VINE_VLS_directives!: __VINE_VLS_LocalDirectives & __VINE_VLS_GlobalDirectives;
 const __VINE_VLS_components = {
   ...{} as __VINE_VLS_GlobalComponents,
-  ...__VINE_VLS_localComponents as __VINE_VLS_LocalComponents,
+  ...__VINE_VLS_localComponents as unknown as __VINE_VLS_LocalComponents,
 };
 
 type __VINE_VLS_StyleScopedClasses = {};
@@ -493,7 +499,7 @@ const bar = ref('123')
   
 // --- Start: Template virtual code
 
-const __VINE_VLS_ctx = __createVineVLSCtx({
+const __VINE_VLS_ctx = __VINE_VLS_CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#11 */UnknownComp: /* __LINKED_CODE_RIGHT__#11 */UnknownComp,
   /* __LINKED_CODE_LEFT__#11 */TestCompOne: /* __LINKED_CODE_RIGHT__#11 */TestCompOne,
   /* __LINKED_CODE_LEFT__#3 */bar: /* __LINKED_CODE_RIGHT__#3 */bar,
@@ -513,6 +519,7 @@ const __VINE_VLS_ctx = __createVineVLSCtx({
   /* __LINKED_CODE_LEFT__#20 */TestNoVforKeyOnChild: /* __LINKED_CODE_RIGHT__#20 */TestNoVforKeyOnChild,
   /* __LINKED_CODE_LEFT__#16 */doSomethingAsync: /* __LINKED_CODE_RIGHT__#16 */doSomethingAsync,
   /* __LINKED_CODE_LEFT__#29 */TestNoLifecycleHookAfterAwait: /* __LINKED_CODE_RIGHT__#29 */TestNoLifecycleHookAfterAwait,
+  /* __LINKED_CODE_LEFT__#16 */TestGenericComp1: /* __LINKED_CODE_RIGHT__#16 */TestGenericComp1,
   /* No props formal params */
 });
 const __VINE_VLS_localComponents = __VINE_VLS_ctx;
@@ -521,7 +528,7 @@ type __VINE_VLS_LocalDirectives = __OmitAny<typeof __VINE_VLS_ctx>;
 let __VINE_VLS_directives!: __VINE_VLS_LocalDirectives & __VINE_VLS_GlobalDirectives;
 const __VINE_VLS_components = {
   ...{} as __VINE_VLS_GlobalComponents,
-  ...__VINE_VLS_localComponents as __VINE_VLS_LocalComponents,
+  ...__VINE_VLS_localComponents as unknown as __VINE_VLS_LocalComponents,
 };
 
 type __VINE_VLS_StyleScopedClasses = {};
@@ -590,7 +597,7 @@ vineExpose(__VINE_VLS_ComponentExpose__)
   
 // --- Start: Template virtual code
 
-const __VINE_VLS_ctx = __createVineVLSCtx({
+const __VINE_VLS_ctx = __VINE_VLS_CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#11 */TestCompOne: /* __LINKED_CODE_RIGHT__#11 */TestCompOne,
   /* __LINKED_CODE_LEFT__#5 */count: /* __LINKED_CODE_RIGHT__#5 */count,
   /* __LINKED_CODE_LEFT__#9 */onMounted: /* __LINKED_CODE_RIGHT__#9 */onMounted,
@@ -609,6 +616,7 @@ const __VINE_VLS_ctx = __createVineVLSCtx({
   /* __LINKED_CODE_LEFT__#20 */TestNoVforKeyOnChild: /* __LINKED_CODE_RIGHT__#20 */TestNoVforKeyOnChild,
   /* __LINKED_CODE_LEFT__#16 */doSomethingAsync: /* __LINKED_CODE_RIGHT__#16 */doSomethingAsync,
   /* __LINKED_CODE_LEFT__#29 */TestNoLifecycleHookAfterAwait: /* __LINKED_CODE_RIGHT__#29 */TestNoLifecycleHookAfterAwait,
+  /* __LINKED_CODE_LEFT__#16 */TestGenericComp1: /* __LINKED_CODE_RIGHT__#16 */TestGenericComp1,
   ...props,
 });
 const __VINE_VLS_localComponents = __VINE_VLS_ctx;
@@ -617,7 +625,7 @@ type __VINE_VLS_LocalDirectives = __OmitAny<typeof __VINE_VLS_ctx>;
 let __VINE_VLS_directives!: __VINE_VLS_LocalDirectives & __VINE_VLS_GlobalDirectives;
 const __VINE_VLS_components = {
   ...{} as __VINE_VLS_GlobalComponents,
-  ...__VINE_VLS_localComponents as __VINE_VLS_LocalComponents,
+  ...__VINE_VLS_localComponents as unknown as __VINE_VLS_LocalComponents,
 };
 
 type __VINE_VLS_StyleScopedClasses = {};
@@ -679,7 +687,7 @@ const target = useTemplateRef<__VINE_VLS_TemplateRefs['target'], keyof __VINE_VL
   
 // --- Start: Template virtual code
 
-const __VINE_VLS_ctx = __createVineVLSCtx({
+const __VINE_VLS_ctx = __VINE_VLS_CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#10 */TargetComp: /* __LINKED_CODE_RIGHT__#10 */TargetComp,
   /* __LINKED_CODE_LEFT__#9 */onMounted: /* __LINKED_CODE_RIGHT__#9 */onMounted,
   /* __LINKED_CODE_LEFT__#3 */ref: /* __LINKED_CODE_RIGHT__#3 */ref,
@@ -697,6 +705,7 @@ const __VINE_VLS_ctx = __createVineVLSCtx({
   /* __LINKED_CODE_LEFT__#20 */TestNoVforKeyOnChild: /* __LINKED_CODE_RIGHT__#20 */TestNoVforKeyOnChild,
   /* __LINKED_CODE_LEFT__#16 */doSomethingAsync: /* __LINKED_CODE_RIGHT__#16 */doSomethingAsync,
   /* __LINKED_CODE_LEFT__#29 */TestNoLifecycleHookAfterAwait: /* __LINKED_CODE_RIGHT__#29 */TestNoLifecycleHookAfterAwait,
+  /* __LINKED_CODE_LEFT__#16 */TestGenericComp1: /* __LINKED_CODE_RIGHT__#16 */TestGenericComp1,
   /* No props formal params */
 });
 const __VINE_VLS_localComponents = __VINE_VLS_ctx;
@@ -705,7 +714,7 @@ type __VINE_VLS_LocalDirectives = __OmitAny<typeof __VINE_VLS_ctx>;
 let __VINE_VLS_directives!: __VINE_VLS_LocalDirectives & __VINE_VLS_GlobalDirectives;
 const __VINE_VLS_components = {
   ...{} as __VINE_VLS_GlobalComponents,
-  ...__VINE_VLS_localComponents as __VINE_VLS_LocalComponents,
+  ...__VINE_VLS_localComponents as unknown as __VINE_VLS_LocalComponents,
 };
 
 type __VINE_VLS_StyleScopedClasses = {};
@@ -764,7 +773,7 @@ interface User { id: string; name: string }
   
 // --- Start: Template virtual code
 
-const __VINE_VLS_ctx = __createVineVLSCtx({
+const __VINE_VLS_ctx = __VINE_VLS_CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#5 */users: /* __LINKED_CODE_RIGHT__#5 */users,
   /* __LINKED_CODE_LEFT__#9 */onMounted: /* __LINKED_CODE_RIGHT__#9 */onMounted,
   /* __LINKED_CODE_LEFT__#3 */ref: /* __LINKED_CODE_RIGHT__#3 */ref,
@@ -783,6 +792,7 @@ const __VINE_VLS_ctx = __createVineVLSCtx({
   /* __LINKED_CODE_LEFT__#20 */TestNoVforKeyOnChild: /* __LINKED_CODE_RIGHT__#20 */TestNoVforKeyOnChild,
   /* __LINKED_CODE_LEFT__#16 */doSomethingAsync: /* __LINKED_CODE_RIGHT__#16 */doSomethingAsync,
   /* __LINKED_CODE_LEFT__#29 */TestNoLifecycleHookAfterAwait: /* __LINKED_CODE_RIGHT__#29 */TestNoLifecycleHookAfterAwait,
+  /* __LINKED_CODE_LEFT__#16 */TestGenericComp1: /* __LINKED_CODE_RIGHT__#16 */TestGenericComp1,
   /* No props formal params */
 });
 const __VINE_VLS_localComponents = __VINE_VLS_ctx;
@@ -791,7 +801,7 @@ type __VINE_VLS_LocalDirectives = __OmitAny<typeof __VINE_VLS_ctx>;
 let __VINE_VLS_directives!: __VINE_VLS_LocalDirectives & __VINE_VLS_GlobalDirectives;
 const __VINE_VLS_components = {
   ...{} as __VINE_VLS_GlobalComponents,
-  ...__VINE_VLS_localComponents as __VINE_VLS_LocalComponents,
+  ...__VINE_VLS_localComponents as unknown as __VINE_VLS_LocalComponents,
 };
 
 type __VINE_VLS_StyleScopedClasses = {};
@@ -846,7 +856,7 @@ await doSomethingAsync()
   
 // --- Start: Template virtual code
 
-const __VINE_VLS_ctx = __createVineVLSCtx({
+const __VINE_VLS_ctx = __VINE_VLS_CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#9 */onMounted: /* __LINKED_CODE_RIGHT__#9 */onMounted,
   /* __LINKED_CODE_LEFT__#3 */ref: /* __LINKED_CODE_RIGHT__#3 */ref,
   /* __LINKED_CODE_LEFT__#14 */useTemplateRef: /* __LINKED_CODE_RIGHT__#14 */useTemplateRef,
@@ -864,6 +874,7 @@ const __VINE_VLS_ctx = __createVineVLSCtx({
   /* __LINKED_CODE_LEFT__#20 */TestNoVforKeyOnChild: /* __LINKED_CODE_RIGHT__#20 */TestNoVforKeyOnChild,
   /* __LINKED_CODE_LEFT__#16 */doSomethingAsync: /* __LINKED_CODE_RIGHT__#16 */doSomethingAsync,
   /* __LINKED_CODE_LEFT__#29 */TestNoLifecycleHookAfterAwait: /* __LINKED_CODE_RIGHT__#29 */TestNoLifecycleHookAfterAwait,
+  /* __LINKED_CODE_LEFT__#16 */TestGenericComp1: /* __LINKED_CODE_RIGHT__#16 */TestGenericComp1,
   /* No props formal params */
 });
 const __VINE_VLS_localComponents = __VINE_VLS_ctx;
@@ -872,7 +883,7 @@ type __VINE_VLS_LocalDirectives = __OmitAny<typeof __VINE_VLS_ctx>;
 let __VINE_VLS_directives!: __VINE_VLS_LocalDirectives & __VINE_VLS_GlobalDirectives;
 const __VINE_VLS_components = {
   ...{} as __VINE_VLS_GlobalComponents,
-  ...__VINE_VLS_localComponents as __VINE_VLS_LocalComponents,
+  ...__VINE_VLS_localComponents as unknown as __VINE_VLS_LocalComponents,
 };
 
 type __VINE_VLS_StyleScopedClasses = {};
@@ -898,6 +909,80 @@ return vine\`\` as any as VueVineComponent;
 }
 // #endregion
 
+// #region Test generics on Vine component function 
+
+export function TestGenericComp1<T extends keyof HTMLElementTagNameMap = 'h1'>(
+  props: __VINE_VLS_VineComponentCommonProps & Partial<HTMLElementTagNameMap[T]> & { as: T },context: {}
+) {
+  
+type TestGenericComp1_Props = Parameters<typeof TestGenericComp1>[0];
+
+
+// --- Start: Template virtual code
+
+const __VINE_VLS_ctx = __VINE_VLS_CreateVineVLSCtx({
+  /* __LINKED_CODE_LEFT__#9 */component: /* __LINKED_CODE_RIGHT__#9 */component,
+  /* __LINKED_CODE_LEFT__#9 */onMounted: /* __LINKED_CODE_RIGHT__#9 */onMounted,
+  /* __LINKED_CODE_LEFT__#3 */ref: /* __LINKED_CODE_RIGHT__#3 */ref,
+  /* __LINKED_CODE_LEFT__#14 */useTemplateRef: /* __LINKED_CODE_RIGHT__#14 */useTemplateRef,
+  /* __LINKED_CODE_LEFT__#11 */watchEffect: /* __LINKED_CODE_RIGHT__#11 */watchEffect,
+  /* __LINKED_CODE_LEFT__#3 */Foo: /* __LINKED_CODE_RIGHT__#3 */Foo,
+  /* __LINKED_CODE_LEFT__#4 */Comp: /* __LINKED_CODE_RIGHT__#4 */Comp,
+  /* __LINKED_CODE_LEFT__#9 */SampleOne: /* __LINKED_CODE_RIGHT__#9 */SampleOne,
+  /* __LINKED_CODE_LEFT__#9 */SampleTwo: /* __LINKED_CODE_RIGHT__#9 */SampleTwo,
+  /* __LINKED_CODE_LEFT__#21 */TestPlainTextTemplate: /* __LINKED_CODE_RIGHT__#21 */TestPlainTextTemplate,
+  /* __LINKED_CODE_LEFT__#23 */TestUnoCssAttributeMode: /* __LINKED_CODE_RIGHT__#23 */TestUnoCssAttributeMode,
+  /* __LINKED_CODE_LEFT__#11 */TestCompOne: /* __LINKED_CODE_RIGHT__#11 */TestCompOne,
+  /* __LINKED_CODE_LEFT__#11 */TestCompTwo: /* __LINKED_CODE_RIGHT__#11 */TestCompTwo,
+  /* __LINKED_CODE_LEFT__#10 */TargetComp: /* __LINKED_CODE_RIGHT__#10 */TargetComp,
+  /* __LINKED_CODE_LEFT__#11 */TestCompRef: /* __LINKED_CODE_RIGHT__#11 */TestCompRef,
+  /* __LINKED_CODE_LEFT__#20 */TestNoVforKeyOnChild: /* __LINKED_CODE_RIGHT__#20 */TestNoVforKeyOnChild,
+  /* __LINKED_CODE_LEFT__#16 */doSomethingAsync: /* __LINKED_CODE_RIGHT__#16 */doSomethingAsync,
+  /* __LINKED_CODE_LEFT__#29 */TestNoLifecycleHookAfterAwait: /* __LINKED_CODE_RIGHT__#29 */TestNoLifecycleHookAfterAwait,
+  /* __LINKED_CODE_LEFT__#16 */TestGenericComp1: /* __LINKED_CODE_RIGHT__#16 */TestGenericComp1,
+  ...props,
+});
+const __VINE_VLS_localComponents = __VINE_VLS_ctx;
+type __VINE_VLS_LocalComponents = __OmitAny<typeof __VINE_VLS_localComponents>;
+type __VINE_VLS_LocalDirectives = __OmitAny<typeof __VINE_VLS_ctx>;
+let __VINE_VLS_directives!: __VINE_VLS_LocalDirectives & __VINE_VLS_GlobalDirectives;
+const __VINE_VLS_components = {
+  ...{} as __VINE_VLS_GlobalComponents,
+  ...__VINE_VLS_localComponents as unknown as __VINE_VLS_LocalComponents,
+};
+
+type __VINE_VLS_StyleScopedClasses = {};
+const __VINE_VLS_0 = ((__VINE_VLS_ctx.as));
+// @ts-ignore
+const __VINE_VLS_1 = __VINE_VLS_asFunctionalComponent(__VINE_VLS_0, new __VINE_VLS_0({
+}));
+const __VINE_VLS_2 = __VINE_VLS_1({
+}, ...__VINE_VLS_functionalComponentArgsRest(__VINE_VLS_1));
+var __VINE_VLS_4 = {} as (Parameters<NonNullable<typeof __VINE_VLS_3['expose']>>[0] | null);
+// @ts-ignore
+[as,];
+var __VINE_VLS_3!: __VINE_VLS_PickFunctionalComponentCtx<typeof __VINE_VLS_0, typeof __VINE_VLS_2>;
+type __VINE_VLS_Slots = {};
+type __VINE_VLS_InheritedAttrs = {};
+type __VINE_VLS_TemplateRefs = {
+};
+type __VINE_VLS_RootEl = 
+| NonNullable<typeof __VINE_VLS_4>['$el'];
+var __VINE_VLS_dollars!: {
+$slots: __VINE_VLS_Slots;
+$attrs: import('vue').ComponentPublicInstance['$attrs'] & Partial<__VINE_VLS_InheritedAttrs>;
+$refs: __VINE_VLS_TemplateRefs;
+$el: __VINE_VLS_RootEl;
+} & { [K in keyof import('vue').ComponentPublicInstance]: unknown };
+
+// --- End: Template virtual code
+
+return vine\`\` as any as VueVineComponent;
+
+}
+
+// #endregion
+
 const __VINE_VLS_ComponentsReferenceMap = {
   'Comp': Comp,
   'SampleOne': SampleOne,
@@ -910,7 +995,9 @@ const __VINE_VLS_ComponentsReferenceMap = {
   'TargetComp': TargetComp,
   'TestCompRef': TestCompRef,
   'TestNoVforKeyOnChild': TestNoVforKeyOnChild,
-  'TestNoLifecycleHookAfterAwait': TestNoLifecycleHookAfterAwait
+  'TestNoLifecycleHookAfterAwait': TestNoLifecycleHookAfterAwait,
+  'TestGenericComp1': TestGenericComp1,
+  'component': component
 };
 
 const __VINE_VLS_IntrinsicElements = {} as __VINE_VLS_IntrinsicElements;"
@@ -937,7 +1024,7 @@ const value = vineModel()
   
 // --- Start: Template virtual code
 
-const __VINE_VLS_ctx = __createVineVLSCtx({
+const __VINE_VLS_ctx = __VINE_VLS_CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#5 */value: /* __LINKED_CODE_RIGHT__#5 */value,
   /* __LINKED_CODE_LEFT__#3 */ref: /* __LINKED_CODE_RIGHT__#3 */ref,
   /* __LINKED_CODE_LEFT__#11 */SimpleInput: /* __LINKED_CODE_RIGHT__#11 */SimpleInput,
@@ -951,7 +1038,7 @@ type __VINE_VLS_LocalDirectives = __OmitAny<typeof __VINE_VLS_ctx>;
 let __VINE_VLS_directives!: __VINE_VLS_LocalDirectives & __VINE_VLS_GlobalDirectives;
 const __VINE_VLS_components = {
   ...{} as __VINE_VLS_GlobalComponents,
-  ...__VINE_VLS_localComponents as __VINE_VLS_LocalComponents,
+  ...__VINE_VLS_localComponents as unknown as __VINE_VLS_LocalComponents,
 };
 
 type __VINE_VLS_StyleScopedClasses = {}
@@ -999,7 +1086,7 @@ const value = vineModel('special')
   
 // --- Start: Template virtual code
 
-const __VINE_VLS_ctx = __createVineVLSCtx({
+const __VINE_VLS_ctx = __VINE_VLS_CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#5 */value: /* __LINKED_CODE_RIGHT__#5 */value,
   /* __LINKED_CODE_LEFT__#3 */ref: /* __LINKED_CODE_RIGHT__#3 */ref,
   /* __LINKED_CODE_LEFT__#11 */SimpleInput: /* __LINKED_CODE_RIGHT__#11 */SimpleInput,
@@ -1013,7 +1100,7 @@ type __VINE_VLS_LocalDirectives = __OmitAny<typeof __VINE_VLS_ctx>;
 let __VINE_VLS_directives!: __VINE_VLS_LocalDirectives & __VINE_VLS_GlobalDirectives;
 const __VINE_VLS_components = {
   ...{} as __VINE_VLS_GlobalComponents,
-  ...__VINE_VLS_localComponents as __VINE_VLS_LocalComponents,
+  ...__VINE_VLS_localComponents as unknown as __VINE_VLS_LocalComponents,
 };
 
 type __VINE_VLS_StyleScopedClasses = {}
@@ -1063,7 +1150,7 @@ const simpleMsg = ref('')
   
 // --- Start: Template virtual code
 
-const __VINE_VLS_ctx = __createVineVLSCtx({
+const __VINE_VLS_ctx = __VINE_VLS_CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#11 */SimpleInput: /* __LINKED_CODE_RIGHT__#11 */SimpleInput,
   /* __LINKED_CODE_LEFT__#15 */NamedModelInput: /* __LINKED_CODE_RIGHT__#15 */NamedModelInput,
   /* __LINKED_CODE_LEFT__#9 */simpleMsg: /* __LINKED_CODE_RIGHT__#9 */simpleMsg,
@@ -1078,7 +1165,7 @@ type __VINE_VLS_LocalDirectives = __OmitAny<typeof __VINE_VLS_ctx>;
 let __VINE_VLS_directives!: __VINE_VLS_LocalDirectives & __VINE_VLS_GlobalDirectives;
 const __VINE_VLS_components = {
   ...{} as __VINE_VLS_GlobalComponents,
-  ...__VINE_VLS_localComponents as __VINE_VLS_LocalComponents,
+  ...__VINE_VLS_localComponents as unknown as __VINE_VLS_LocalComponents,
 };
 
 type __VINE_VLS_StyleScopedClasses = {}

--- a/packages/language-service/typescript-plugin/proxy-ts-lang-service.ts
+++ b/packages/language-service/typescript-plugin/proxy-ts-lang-service.ts
@@ -33,7 +33,6 @@ export function proxyLanguageServiceForVine(
 
 const hiddenCompletions = [
   'VUE_VINE_COMPONENT',
-  '__createVineVLSCtx',
 ]
 function vineGetCompletionsAtPosition(
   originalGetCompletionsAtPosition: ts.LanguageService['getCompletionsAtPosition'],


### PR DESCRIPTION
- fix generics type resolving failed by deep unwrap ref
- rename all internal VLS util types


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a generic component for dynamically rendering HTML elements with typed props in test cases.
  - Made asset URL transformation during template compilation configurable via an internal option.

- **Bug Fixes**
  - Asset URL transformation is now explicitly disabled in certain language service scenarios.

- **Improvements**
  - Enhanced naming consistency for internal helper types and functions.
  - Adjusted type handling in the language service for better type safety.
  - Simplified formatting in test templates for improved readability.

- **Other**
  - Updated code completion behavior to include additional internal entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->