### PR TITLE
fix(lang-service): add missing import in completions

### DIFF
--- a/packages/compiler/src/transform/steps.ts
+++ b/packages/compiler/src/transform/steps.ts
@@ -350,7 +350,6 @@ export function generateSetupReturns(
   const setupFnReturns = compileSetupFnReturns({
     vineFileCtx,
     vineCompFnCtx,
-    templateSource: vineCompFnCtx.templateSource,
     mergedImportsMap,
     bindingMetadata: vineCompFnCtx.bindings,
   })

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -86,6 +86,8 @@ export interface VineCompilerOptions {
     __enableTransformAssetsURL?: boolean
     /** @internal */
     __transformNegativeBool?: boolean | { constType: ConstantTypes }
+    /** @internal */
+    __shouldAddTemplateSuffix?: boolean // Add '>' when the last tag is not complete
   }
   preprocessOptions?: Record<string, any>
   postcssOptions?: any

--- a/packages/eslint-plugin/src/rules/format/format-vine-template.ts
+++ b/packages/eslint-plugin/src/rules/format/format-vine-template.ts
@@ -73,6 +73,11 @@ const rule: RuleModule<Options> = createEslintRule<Options, string>({
             templatePositionInfo,
           } = templateInfo
 
+          if (templateRawContent.trim() === '') {
+            // Skip formatting when given template is empty
+            return
+          }
+
           const formatOptions = context.options?.[0] ?? {}
           const lineStartIndex = context.sourceCode.getIndexFromLoc({
             line: templatePositionInfo.templateStartLine,

--- a/packages/eslint-plugin/tests/utils.spec.ts
+++ b/packages/eslint-plugin/tests/utils.spec.ts
@@ -13,12 +13,17 @@ describe('test utils', () => {
   })
 
   describe('test prettier output', () => {
-    it('should format the code with the default prettier options', async () => {
+    function getFormattedLines(formattedCode: string) {
+      const lines = formattedCode.split('\n').slice(1, -2)
+      return lines
+    }
+
+    it('should format normal sample with the default prettier options', async () => {
       const code = `
 <div
   class="flex flex-col justify-center items-center p-2 transition shadow-md rounded-lg"
   :data-testid="testId"
- >     
+ >
   <p
   v-text="sampleText"
 class="paragraph"
@@ -53,30 +58,30 @@ class="paragraph"
         },
       )
 
-      expect(`\n${formattedCode}`).toMatchInlineSnapshot(`
-        "
-        <template>
-          <div
-            class="flex flex-col justify-center items-center p-2 transition shadow-md rounded-lg"
-            :data-testid="testId"
-          >
-            <p v-text="sampleText" class="paragraph" />
-
-            <MyComponent
-              :foo="'hello'"
-              :bar="123"
-              baz
-              :class="{
-                active: count > 0,
-              }"
-            >
-              <template #default>
-                <span :class="['text-red-500', 'font-bold']">This is a placeholder</span>
-              </template>
-            </MyComponent>
-          </div>
-        </template>
-        "
+      expect(
+        getFormattedLines(formattedCode),
+      ).toMatchInlineSnapshot(`
+        [
+          "  <div",
+          "    class="flex flex-col justify-center items-center p-2 transition shadow-md rounded-lg"",
+          "    :data-testid="testId"",
+          "  >",
+          "    <p v-text="sampleText" class="paragraph" />",
+          "",
+          "    <MyComponent",
+          "      :foo="'hello'"",
+          "      :bar="123"",
+          "      baz",
+          "      :class="{",
+          "        active: count > 0,",
+          "      }"",
+          "    >",
+          "      <template #default>",
+          "        <span :class="['text-red-500', 'font-bold']">This is a placeholder</span>",
+          "      </template>",
+          "    </MyComponent>",
+          "  </div>",
+        ]
       `)
     })
   })

--- a/packages/language-service/src/vine-ctx.ts
+++ b/packages/language-service/src/vine-ctx.ts
@@ -20,6 +20,7 @@ export function compileVineForVirtualCode(fileId: string, source: string): {
       prefixIdentifiers: false,
       scopeId: null,
       __enableTransformAssetsURL: false,
+      __shouldAddTemplateSuffix: true,
       __transformNegativeBool: {
         constType: 0, // satisfies `ConstantTypes.NOT_CONSTANT`
       },

--- a/packages/language-service/src/virtual-code.ts
+++ b/packages/language-service/src/virtual-code.ts
@@ -157,6 +157,7 @@ export function createVueVineVirtualCode(
   const compileTime = (performance.now() - compileStartTime).toFixed(2)
 
   const tsCodeSegments: Segment<VineCodeInformation>[] = []
+
   if (typeof vueCompilerOptions.__setupedGlobalTypes === 'object') {
     const globalTypes = vueCompilerOptions.__setupedGlobalTypes
     let relativePath = path.relative(
@@ -170,10 +171,10 @@ export function createVueVineVirtualCode(
     ) {
       relativePath = `./${relativePath}`
     }
-    tsCodeSegments.push(`/// <reference types="${relativePath}" />\n\n`)
+    tsCodeSegments.push(`/// <reference types="${relativePath}" />\n`)
   }
   else {
-    tsCodeSegments.push(`/// <reference types=".vue-global-types/vine_${vueCompilerOptions.lib}_${vueCompilerOptions.target}_true" />\n\n`)
+    tsCodeSegments.push(`/// <reference types=".vue-global-types/vine_${vueCompilerOptions.lib}_${vueCompilerOptions.target}_true" />\n`)
   }
 
   let currentOffset = { value: 0 }

--- a/packages/language-service/tests/__snapshots__/virtual-code.spec.ts.snap
+++ b/packages/language-service/tests/__snapshots__/virtual-code.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`verify Volar virtual code snapshots > key-cases.vine.ts 1`] = `
 "/// <reference types=".vue-global-types/vine_vue_99_true" />
-
 import type { Directive } from 'vue'
 import { onMounted, ref, useTemplateRef, watchEffect } from 'vue'
 
@@ -1005,7 +1004,6 @@ const __VINE_VLS_IntrinsicElements = {} as __VINE_VLS_IntrinsicElements;"
 
 exports[`verify Volar virtual code snapshots > vine-model.vine.ts 1`] = `
 "/// <reference types=".vue-global-types/vine_vue_99_true" />
-
 import { ref } from 'vue'
 import '../styles/atom.css'
 


### PR DESCRIPTION
* Fix eslint formatting for template when it's totally empty
* Add missing import not working when referencing component tag name