### PR TITLE
feat(lang-service): support track virtual code generation

### DIFF
--- a/packages/language-server/src/index.ts
+++ b/packages/language-server/src/index.ts
@@ -15,6 +15,7 @@ import { create as createTypeScriptServices } from 'volar-service-typescript'
 import { createVineDiagnosticsPlugin } from './plugins/vine-diagnostics'
 import { createVineFoldingRangesPlugin } from './plugins/vine-folding-ranges'
 import { createVineTemplatePlugin } from './plugins/vine-template'
+import { track } from './track'
 
 const connection = createConnection()
 const server = createServer(connection)
@@ -86,6 +87,7 @@ connection.onInitialize(async (params) => {
           compilerOptions,
           vueCompilerOptions,
           target: 'extension',
+          track,
         },
       ),
     ]

--- a/packages/language-server/src/track.ts
+++ b/packages/language-server/src/track.ts
@@ -1,0 +1,24 @@
+import type { TrackOutputChannel } from '@vue-vine/language-service'
+import { env } from 'node:process'
+import { Track } from '@vue-vine/language-service'
+
+const {
+  vscodeVersion = 'unknown',
+  extensionVersion = 'unknown',
+  machineId = 'unknown',
+  isTrackDisabled = 'false',
+} = env
+
+const outputChannel: TrackOutputChannel = {
+  appendLine: (message) => {
+    console.log(message)
+  },
+}
+
+export const track: Track = new Track({
+  isTrackDisabled: isTrackDisabled === 'true',
+  vscodeVersion,
+  extensionVersion,
+  machineId,
+  outputChannel,
+})

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -49,6 +49,7 @@
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
+    "@umami/node": "catalog:miscs",
     "@volar/language-core": "catalog:volar",
     "@volar/language-server": "catalog:volar",
     "@volar/typescript": "catalog:volar",

--- a/packages/language-service/src/index.ts
+++ b/packages/language-service/src/index.ts
@@ -3,6 +3,7 @@ import type {
   VueCompilerOptions,
 } from '@vue/language-core'
 import type * as ts from 'typescript'
+import type { Track } from './track'
 import {
   forEachEmbeddedCode,
 } from '@volar/language-core'
@@ -34,6 +35,14 @@ export type {
 } from './shared'
 
 export {
+  getLogTimeLabel,
+  Track,
+} from './track'
+export type {
+  TrackOutputChannel,
+} from './track'
+
+export {
   createVueVineVirtualCode,
 } from './virtual-code'
 
@@ -41,6 +50,7 @@ interface VineLanguagePluginOptions {
   compilerOptions: ts.CompilerOptions
   vueCompilerOptions: VueCompilerOptions
   target?: 'extension' | 'tsc'
+  track?: Track
 }
 
 export function createVueVineLanguagePlugin(
@@ -50,6 +60,7 @@ export function createVueVineLanguagePlugin(
   const {
     compilerOptions,
     vueCompilerOptions,
+    track,
     target = 'extension',
   } = options
 
@@ -84,6 +95,7 @@ export function createVueVineLanguagePlugin(
             vueCompilerOptions,
             target,
           )
+          track?.trackEvent('virtual_code_created')
           return virtualCode
         }
         catch (err) {

--- a/packages/language-service/src/track.ts
+++ b/packages/language-service/src/track.ts
@@ -1,0 +1,92 @@
+import { Umami } from '@umami/node'
+
+export type TrackEvent
+  = | 'extension_activated'
+    | 'restart_server'
+    | 'virtual_code_created'
+
+const logFormat = new Intl.DateTimeFormat('zh-CN', {
+  hour12: false,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+})
+export function getLogTimeLabel(): string {
+  // Format: `2025-06-18 10:00:00`
+  return logFormat.format(new Date())
+}
+
+export interface TrackOutputChannel {
+  appendLine: (message: string) => void
+}
+
+export class Track {
+  private _isDisabled: boolean = false
+  private _vscodeVersion: string
+  private _extensionVersion: string
+  private _machineId: string
+  private _websiteId: string
+  private _hostUrl: string
+  private _client: Umami
+  private _outputChannel: TrackOutputChannel
+
+  constructor({
+    isTrackDisabled,
+    vscodeVersion,
+    extensionVersion,
+    machineId,
+    outputChannel,
+  }: {
+    isTrackDisabled: boolean
+    vscodeVersion: string
+    extensionVersion: string
+    machineId: string
+    outputChannel: TrackOutputChannel
+  }) {
+    this._websiteId = 'dc82842c-bd27-4bdd-8305-2f5558695020'
+    this._hostUrl = 'https://stats.dokduk.cc'
+    this._isDisabled = isTrackDisabled
+    this._vscodeVersion = vscodeVersion
+    this._extensionVersion = extensionVersion
+    this._machineId = machineId
+    this._outputChannel = outputChannel
+    this._client = new Umami({
+      websiteId: this._websiteId,
+      hostUrl: this._hostUrl,
+      sessionId: this._machineId,
+    })
+  }
+
+  public async trackEvent(
+    event: TrackEvent,
+  ): Promise<void> {
+    if (this._isDisabled)
+      return
+
+    try {
+      await this._client.send({
+        website: this._websiteId,
+        name: event,
+        data: {
+          vscodeVersion: this._vscodeVersion,
+          extensionVersion: this._extensionVersion,
+          machineId: this._machineId,
+        },
+      }, 'event')
+      this._outputChannel.appendLine(`${getLogTimeLabel()} - '${event}' event has been sent`)
+    }
+    catch (error) {
+      this._outputChannel.appendLine(`${getLogTimeLabel()} - '${event}' track failed: ${error}`)
+    }
+  }
+
+  public toggleDisabled(isDisabled: boolean): void {
+    this._isDisabled = isDisabled
+  }
+
+  public disable(): void {
+    this._isDisabled = true
+  }
+}

--- a/packages/vscode-ext/package.json
+++ b/packages/vscode-ext/package.json
@@ -123,7 +123,6 @@
     "@changesets/changelog-github": "catalog:utils",
     "@types/vscode": "catalog:types",
     "@typescript/native-preview": "catalog:compiler",
-    "@umami/node": "catalog:miscs",
     "@volar/vscode": "catalog:volar",
     "@vscode/vsce": "catalog:vscode",
     "@vue-vine/language-server": "workspace:*",

--- a/packages/vscode-ext/src/track.ts
+++ b/packages/vscode-ext/src/track.ts
@@ -1,82 +1,30 @@
 import type { OutputChannel } from 'vscode'
 import type { useExtensionConfigs } from './config'
-import { Umami } from '@umami/node'
-import { watchEffect } from 'reactive-vscode'
+import { Track } from '@vue-vine/language-service'
+import { watch } from 'reactive-vscode'
+import { useDataTrackWarning } from './view-features'
 
-export type TrackEvent
-  = | 'extension_activated'
-    | 'restart_server'
-
-export class Track {
-  private _isDisabled: boolean = false
-  private _vscodeVersion: string
-  private _extensionVersion: string
-  private _machineId: string
-  private _websiteId: string
-  private _hostUrl: string
-  private _client: Umami
-  private _outputChannel: OutputChannel
-
-  constructor({
-    extensionConfigs,
-    vscodeVersion,
-    extensionVersion,
-    machineId,
-    outputChannel,
-  }: {
-    extensionConfigs: ReturnType<typeof useExtensionConfigs>
+export async function useDataTrack(
+  extensionConfigs: ReturnType<typeof useExtensionConfigs>,
+  outputChannel: OutputChannel,
+  envInfo: {
     vscodeVersion: string
     extensionVersion: string
     machineId: string
-    outputChannel: OutputChannel
-  }) {
-    this._websiteId = 'dc82842c-bd27-4bdd-8305-2f5558695020'
-    this._hostUrl = 'https://stats.dokduk.cc'
-    this._vscodeVersion = vscodeVersion
-    this._extensionVersion = extensionVersion
-    this._machineId = machineId
-    this._outputChannel = outputChannel
-    this._client = new Umami({
-      websiteId: this._websiteId,
-      hostUrl: this._hostUrl,
-      sessionId: this._machineId,
-    })
+    isTrackDisabled: boolean
+  },
+): Promise<Track> {
+  useDataTrackWarning(extensionConfigs)
+  const track = new Track({
+    outputChannel,
+    ...envInfo,
+  })
+  watch(
+    extensionConfigs.dataTrack,
+    (isDisabled) => {
+      track.toggleDisabled(isDisabled)
+    },
+  )
 
-    outputChannel.appendLine(`\n[Vue Vine] track:\n${[
-      `- vscodeVersion: ${this._vscodeVersion}`,
-      `- extensionVersion: ${this._extensionVersion}`,
-      `- machineId: ${this._machineId}`,
-    ].join('\n')}`)
-
-    watchEffect(() => {
-      this._isDisabled = !extensionConfigs.dataTrack.value
-    })
-  }
-
-  public async trackEvent(
-    event: TrackEvent,
-  ): Promise<void> {
-    if (this._isDisabled)
-      return
-
-    try {
-      await this._client.send({
-        website: this._websiteId,
-        name: event,
-        data: {
-          vscodeVersion: this._vscodeVersion,
-          extensionVersion: this._extensionVersion,
-          machineId: this._machineId,
-        },
-      }, 'event')
-      this._outputChannel.appendLine(`[Vue Vine] ${new Date().toLocaleString()} - '${event}' event has been sent`)
-    }
-    catch (error) {
-      this._outputChannel.appendLine(`[Vue Vine] ${new Date().toLocaleString()} - '${event}' track failed: ${error}`)
-    }
-  }
-
-  public disable(): void {
-    this._isDisabled = true
-  }
+  return track
 }

--- a/packages/vscode-ext/src/view-features.ts
+++ b/packages/vscode-ext/src/view-features.ts
@@ -1,6 +1,6 @@
 import type * as lsp from '@volar/vscode/node'
+import type { Track } from '@vue-vine/language-service'
 import type { useExtensionConfigs } from './config'
-import type { Track } from './track'
 import { executeCommand, useCommand, useStatusBarItem, useVisibleTextEditors, watchEffect } from 'reactive-vscode'
 import * as vscode from 'vscode'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -823,6 +823,9 @@ importers:
 
   packages/language-service:
     dependencies:
+      '@umami/node':
+        specifier: catalog:miscs
+        version: 0.4.0
       '@volar/language-core':
         specifier: catalog:volar
         version: 2.4.14
@@ -961,9 +964,6 @@ importers:
       '@typescript/native-preview':
         specifier: catalog:compiler
         version: 7.0.0-dev.20250610.1
-      '@umami/node':
-        specifier: catalog:miscs
-        version: 0.4.0
       '@volar/vscode':
         specifier: catalog:volar
         version: 2.4.14


### PR DESCRIPTION
## Description

We add one more event for track, since `extension_activated` is too general and actually the extension is activated when opening any TS file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced telemetry tracking for key extension events, such as virtual code creation, with environment-aware configuration and logging.
- **Refactor**
  - Streamlined tracking implementation by delegating tracking logic to a shared analytics module, improving maintainability and consistency across components.
- **Chores**
  - Updated dependencies to include and remove analytics-related packages as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->