### PR TITLE
fix(lang-service): avoid error notification for output channel close

### DIFF
--- a/packages/language-service/src/index.ts
+++ b/packages/language-service/src/index.ts
@@ -60,7 +60,6 @@ export function createVueVineLanguagePlugin(
   const {
     compilerOptions,
     vueCompilerOptions,
-    track,
     target = 'extension',
   } = options
 
@@ -95,7 +94,6 @@ export function createVueVineLanguagePlugin(
             vueCompilerOptions,
             target,
           )
-          track?.trackEvent('virtual_code_created')
           return virtualCode
         }
         catch (err) {

--- a/packages/language-service/src/track.ts
+++ b/packages/language-service/src/track.ts
@@ -1,9 +1,8 @@
 import { Umami } from '@umami/node'
 
 export type TrackEvent
-  = | 'extension_activated'
-    | 'restart_server'
-    | 'virtual_code_created'
+  = | 'restart_server'
+// ... TODO: add more events
 
 const logFormat = new Intl.DateTimeFormat('zh-CN', {
   hour12: false,
@@ -45,7 +44,7 @@ export class Track {
     machineId: string
     outputChannel: TrackOutputChannel
   }) {
-    this._websiteId = '492c7ab5-02b6-4776-8d48-9aa8eb661e75'
+    this._websiteId = '4f9d14cd-73fa-46e1-8ef2-460fedb1fb0c'
     this._hostUrl = 'https://stats.dokduk.cc'
     this._isDisabled = isTrackDisabled
     this._vscodeVersion = vscodeVersion

--- a/packages/vscode-ext/src/output-channel.ts
+++ b/packages/vscode-ext/src/output-channel.ts
@@ -1,0 +1,10 @@
+import type * as lsp from '@volar/vscode/node'
+import type { OutputChannel } from 'vscode'
+import { shallowRef, type ShallowRef } from 'reactive-vscode'
+
+export function useVineOutputChannel(
+  client: lsp.BaseLanguageClient,
+): ShallowRef<OutputChannel | null> {
+  const outputChannelRef = shallowRef(client.outputChannel)
+  return outputChannelRef
+}


### PR DESCRIPTION
Now, this error notification will occur after restarting Vue Vine server

![image](https://github.com/user-attachments/assets/9ffb5cd8-9f4b-4b78-864a-1382a01b41de)
