### PR TITLE
fix(compiler): compilation for custom elements support

### DIFF
--- a/packages/compiler/src/babel-helpers/ast.ts
+++ b/packages/compiler/src/babel-helpers/ast.ts
@@ -279,7 +279,7 @@ export function getFunctionPickedInfos(fnDecl: Node): VineFnPickedInfo[] {
           && isIdentifier(decl.id)
         ) {
           pickedInfo.push({
-            fnDeclNode: fnDecl,
+            fnDeclNode: fnDecl, // VariableDeclarator
             fnItselfNode: decl.init,
             fnName: decl.id.name,
           })
@@ -292,7 +292,7 @@ export function getFunctionPickedInfos(fnDecl: Node): VineFnPickedInfo[] {
 
   if (isFunctionDeclaration(target)) {
     pickedInfo.push({
-      fnDeclNode: fnDecl,
+      fnDeclNode: fnDecl, // FunctionDeclaration
       fnItselfNode: target,
       fnName: target.id?.name ?? '',
     })

--- a/packages/compiler/src/constants.ts
+++ b/packages/compiler/src/constants.ts
@@ -1,6 +1,7 @@
 import type { BindingTypes as VueBindingTypes } from '@vue/compiler-dom'
 
 export const DEFINE_COMPONENT_HELPER = 'defineComponent'
+export const DEFINE_CUSTOM_ELEMENT_HELPER = 'defineCustomElement'
 export const USE_DEFAULTS_HELPER = 'useDefaults'
 export const TO_REFS_HELPER = 'toRefs'
 export const USE_MODEL_HELPER = 'useModel'

--- a/packages/compiler/tests/__snapshots__/transform.spec.ts.snap
+++ b/packages/compiler/tests/__snapshots__/transform.spec.ts.snap
@@ -5,13 +5,14 @@ exports[`test transform > inline mode output result 1`] = `
 import { useDefaults as _useDefaults } from "vue-vine";
 import {
   defineComponent as _defineComponent,
+  defineCustomElement as _defineCustomElement,
   useCssVars as _useCssVars,
   unref as _unref,
+  openBlock as _openBlock,
+  createElementBlock as _createElementBlock,
   createElementVNode as _createElementVNode,
   toDisplayString as _toDisplayString,
   Fragment as _Fragment,
-  openBlock as _openBlock,
-  createElementBlock as _createElementBlock,
   useSlots as _useSlots,
   useModel as _useModel,
   toRefs as _toRefs,
@@ -40,6 +41,35 @@ const v2 = ref(0);
 
 someExternalFunction2();
 
+export const SampleCustomElement = (() => {
+  const __vine = _defineComponent({
+    name: "SampleCustomElement",
+    /* No props */
+    /* No emits */
+    setup(__props, { expose: __expose }) {
+      __expose();
+      const props = __props;
+
+      return (_ctx, _cache) => {
+        return (
+          _openBlock(),
+          _createElementBlock("div", null, "SampleCustomElement")
+        );
+      };
+    },
+  });
+
+  __vine.__vue_vine = true;
+  __vine.__hmrId = "10115e21";
+  __vine.styles = [
+    typeof __samplecustomelement_styles === "undefined"
+      ? null
+      : __samplecustomelement_styles,
+  ].filter(Boolean);
+
+  return _defineCustomElement(__vine);
+})();
+
 export const AnotherComp = (() => {
   const __vine = _defineComponent({
     name: "AnotherComp",
@@ -54,6 +84,8 @@ export const AnotherComp = (() => {
     setup(__props, { expose: __expose }) {
       __expose();
       const props = __props;
+
+      customElements.define("vi-sample-custom-element", SampleCustomElement);
 
       return (_ctx, _cache) => {
         return (
@@ -81,6 +113,13 @@ export const AnotherComp = (() => {
                 "bar:" + _toDisplayString(__props.bar),
                 1 /* TEXT */,
               ),
+              _cache[1] ||
+                (_cache[1] = _createElementVNode(
+                  "vi-sample-custom-element",
+                  null,
+                  null,
+                  -1 /* CACHED */,
+                )),
             ],
             64 /* STABLE_FRAGMENT */,
           )
@@ -253,6 +292,12 @@ export const MyApp = (() => {
 })();
 
 typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
+  __VUE_HMR_RUNTIME__.createRecord(
+    SampleCustomElement.__hmrId,
+    SampleCustomElement,
+  );
+
+typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
   __VUE_HMR_RUNTIME__.createRecord(AnotherComp.__hmrId, AnotherComp);
 
 typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
@@ -270,13 +315,16 @@ exports[`test transform > not output HMR content in non-dev mode 1`] = `
 import { useDefaults as _useDefaults } from "vue-vine";
 import {
   defineComponent as _defineComponent,
+  defineCustomElement as _defineCustomElement,
   useCssVars as _useCssVars,
   unref as _unref,
-  createElementVNode as _createElementVNode,
-  toDisplayString as _toDisplayString,
-  Fragment as _Fragment,
   openBlock as _openBlock,
   createElementBlock as _createElementBlock,
+  createElementVNode as _createElementVNode,
+  toDisplayString as _toDisplayString,
+  resolveComponent as _resolveComponent,
+  createVNode as _createVNode,
+  Fragment as _Fragment,
   useSlots as _useSlots,
   useModel as _useModel,
   toRefs as _toRefs,
@@ -284,7 +332,6 @@ import {
   vShow as _vShow,
   withDirectives as _withDirectives,
   withAsyncContext as _withAsyncContext,
-  createVNode as _createVNode,
 } from "vue";
 
 import "testNoHMRContentOnProduction?type=vine-style&vineFileId=testNoHMRContentOnProduction&scopeId=3b48c990&comp=MyProfile&lang=css&index=0&virtual.css";
@@ -305,6 +352,34 @@ const v2 = ref(0);
 
 someExternalFunction2();
 
+export const SampleCustomElement = (() => {
+  const __vine = _defineComponent({
+    name: "SampleCustomElement",
+    /* No props */
+    /* No emits */
+    setup(__props, { expose: __expose }) {
+      __expose();
+      const props = __props;
+
+      return (_ctx, _cache) => {
+        return (
+          _openBlock(),
+          _createElementBlock("div", null, "SampleCustomElement")
+        );
+      };
+    },
+  });
+
+  __vine.__vue_vine = true;
+  __vine.styles = [
+    typeof __samplecustomelement_styles === "undefined"
+      ? null
+      : __samplecustomelement_styles,
+  ].filter(Boolean);
+
+  return _defineCustomElement(__vine);
+})();
+
 export const AnotherComp = (() => {
   const __vine = _defineComponent({
     name: "AnotherComp",
@@ -320,7 +395,14 @@ export const AnotherComp = (() => {
       __expose();
       const props = __props;
 
+      customElements.define("vi-sample-custom-element", SampleCustomElement);
+
       return (_ctx, _cache) => {
+        const _component_vi_sample_custom_element =
+          typeof ViSampleCustomElement === "undefined"
+            ? _resolveComponent("vi-sample-custom-element")
+            : ViSampleCustomElement;
+
         return (
           _openBlock(),
           _createElementBlock(
@@ -346,6 +428,7 @@ export const AnotherComp = (() => {
                 "bar:" + _toDisplayString(__props.bar),
                 1 /* TEXT */,
               ),
+              _createVNode(_component_vi_sample_custom_element),
             ],
             64 /* STABLE_FRAGMENT */,
           )
@@ -523,12 +606,15 @@ exports[`test transform > separated mode output result 1`] = `
 import { useDefaults as _useDefaults } from "vue-vine";
 import {
   defineComponent as _defineComponent,
+  defineCustomElement as _defineCustomElement,
   useCssVars as _useCssVars,
-  createElementVNode as _createElementVNode,
-  toDisplayString as _toDisplayString,
-  Fragment as _Fragment,
   openBlock as _openBlock,
   createElementBlock as _createElementBlock,
+  createElementVNode as _createElementVNode,
+  toDisplayString as _toDisplayString,
+  resolveComponent as _resolveComponent,
+  createVNode as _createVNode,
+  Fragment as _Fragment,
   useSlots as _useSlots,
   useModel as _useModel,
   toRefs as _toRefs,
@@ -536,7 +622,6 @@ import {
   vShow as _vShow,
   withDirectives as _withDirectives,
   withAsyncContext as _withAsyncContext,
-  createVNode as _createVNode,
 } from "vue";
 
 import "testTransformSeparatedResult?type=vine-style&vineFileId=testTransformSeparatedResult&scopeId=25e4e706&comp=MyProfile&lang=css&index=0&virtual.css";
@@ -557,6 +642,36 @@ const v2 = ref(0);
 
 someExternalFunction2();
 
+export const SampleCustomElement = (() => {
+  const __vine = _defineComponent({
+    name: "SampleCustomElement",
+    /* No props */
+    /* No emits */
+    setup(__props, { expose: __expose }) {
+      __expose();
+      const props = __props;
+
+      return { v1, v2, SampleCustomElement, AnotherComp, MyProfile, MyApp };
+    },
+  });
+  function __sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+    return (
+      _openBlock(),
+      _createElementBlock("div", null, "SampleCustomElement")
+    );
+  }
+  __vine.render = __sfc_render;
+  __vine.__vue_vine = true;
+  __vine.__hmrId = "d91bba3e";
+  __vine.styles = [
+    typeof __samplecustomelement_styles === "undefined"
+      ? null
+      : __samplecustomelement_styles,
+  ].filter(Boolean);
+
+  return _defineCustomElement(__vine);
+})();
+
 export const AnotherComp = (() => {
   const __vine = _defineComponent({
     name: "AnotherComp",
@@ -572,10 +687,17 @@ export const AnotherComp = (() => {
       __expose();
       const props = __props;
 
-      return { v1, v2, AnotherComp, MyProfile, MyApp };
+      customElements.define("vi-sample-custom-element", SampleCustomElement);
+
+      return { v1, v2, SampleCustomElement, AnotherComp, MyProfile, MyApp };
     },
   });
   function __sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+    const _component_vi_sample_custom_element =
+      typeof ViSampleCustomElement === "undefined"
+        ? _resolveComponent("vi-sample-custom-element")
+        : ViSampleCustomElement;
+
     return (
       _openBlock(),
       _createElementBlock(
@@ -601,6 +723,7 @@ export const AnotherComp = (() => {
             "bar:" + _toDisplayString($props.bar),
             1 /* TEXT */,
           ),
+          _createVNode(_component_vi_sample_custom_element),
         ],
         64 /* STABLE_FRAGMENT */,
       )
@@ -682,6 +805,7 @@ export const MyProfile = (() => {
         handleRefresh,
         v1,
         v2,
+        SampleCustomElement,
         AnotherComp,
         MyProfile,
         MyApp,
@@ -753,7 +877,15 @@ export const MyApp = (() => {
         __restore(),
         __temp);
 
-      return { data, v1, v2, AnotherComp, MyProfile, MyApp };
+      return {
+        data,
+        v1,
+        v2,
+        SampleCustomElement,
+        AnotherComp,
+        MyProfile,
+        MyApp,
+      };
     },
   });
   function __sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
@@ -787,6 +919,12 @@ export const MyApp = (() => {
 })();
 
 typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
+  __VUE_HMR_RUNTIME__.createRecord(
+    SampleCustomElement.__hmrId,
+    SampleCustomElement,
+  );
+
+typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
   __VUE_HMR_RUNTIME__.createRecord(AnotherComp.__hmrId, AnotherComp);
 
 typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
@@ -803,15 +941,17 @@ exports[`test transform > separated mode output result by ssr 1`] = `
 "import _imports_0 from "@/assets/sample.png";
 import { useDefaults as _useDefaults } from "vue-vine";
 import {
+  ssrRenderAttrs as _ssrRenderAttrs,
+  ssrRenderComponent as _ssrRenderComponent,
   ssrInterpolate as _ssrInterpolate,
   ssrRenderStyle as _ssrRenderStyle,
   ssrRenderAttr as _ssrRenderAttr,
-  ssrRenderAttrs as _ssrRenderAttrs,
-  ssrRenderComponent as _ssrRenderComponent,
 } from "vue/server-renderer";
 import {
   defineComponent as _defineComponent,
+  defineCustomElement as _defineCustomElement,
   useCssVars as _useCssVars,
+  resolveComponent as _resolveComponent,
   useSlots as _useSlots,
   useModel as _useModel,
   toRefs as _toRefs,
@@ -837,6 +977,44 @@ const v2 = ref(0);
 
 someExternalFunction2();
 
+export const SampleCustomElement = (() => {
+  const __vine = _defineComponent({
+    name: "SampleCustomElement",
+    /* No props */
+    /* No emits */
+    setup(__props, { expose: __expose }) {
+      __expose();
+      const props = __props;
+
+      return { v1, v2, SampleCustomElement, AnotherComp, MyProfile, MyApp };
+    },
+  });
+  function __sfc_ssr_render(
+    _ctx,
+    _push,
+    _parent,
+    _attrs,
+    $props,
+    $setup,
+    $data,
+    $options,
+  ) {
+    _push(
+      \`<div\${_ssrRenderAttrs(_attrs)} data-v-d91bba3e>SampleCustomElement</div>\`,
+    );
+  }
+  __vine.ssrRender = __sfc_ssr_render;
+  __vine.__vue_vine = true;
+  __vine.__hmrId = "d91bba3e";
+  __vine.styles = [
+    typeof __samplecustomelement_styles === "undefined"
+      ? null
+      : __samplecustomelement_styles,
+  ].filter(Boolean);
+
+  return _defineCustomElement(__vine);
+})();
+
 export const AnotherComp = (() => {
   const __vine = _defineComponent({
     name: "AnotherComp",
@@ -852,7 +1030,9 @@ export const AnotherComp = (() => {
       __expose();
       const props = __props;
 
-      return { v1, v2, AnotherComp, MyProfile, MyApp };
+      customElements.define("vi-sample-custom-element", SampleCustomElement);
+
+      return { v1, v2, SampleCustomElement, AnotherComp, MyProfile, MyApp };
     },
   });
   function __sfc_ssr_render(
@@ -865,11 +1045,25 @@ export const AnotherComp = (() => {
     $data,
     $options,
   ) {
+    const _component_vi_sample_custom_element =
+      typeof ViSampleCustomElement === "undefined"
+        ? _resolveComponent("vi-sample-custom-element")
+        : ViSampleCustomElement;
+
     _push(
       \`<!--[--><div data-v-93184a5c>AnotherComp</div><p data-v-93184a5c>foo:\${_ssrInterpolate(
         $props.foo,
-      )}</p><p data-v-93184a5c>bar:\${_ssrInterpolate($props.bar)}</p><!--]-->\`,
+      )}</p><p data-v-93184a5c>bar:\${_ssrInterpolate($props.bar)}</p>\`,
     );
+    _push(
+      _ssrRenderComponent(
+        _component_vi_sample_custom_element,
+        null,
+        null,
+        _parent,
+      ),
+    );
+    _push(\`<!--]-->\`);
   }
   __vine.ssrRender = __sfc_ssr_render;
   __vine.__vue_vine = true;
@@ -946,6 +1140,7 @@ export const MyProfile = (() => {
         handleRefresh,
         v1,
         v2,
+        SampleCustomElement,
         AnotherComp,
         MyProfile,
         MyApp,
@@ -1003,7 +1198,15 @@ export const MyApp = (() => {
         __restore(),
         __temp);
 
-      return { data, v1, v2, AnotherComp, MyProfile, MyApp };
+      return {
+        data,
+        v1,
+        v2,
+        SampleCustomElement,
+        AnotherComp,
+        MyProfile,
+        MyApp,
+      };
     },
   });
   function __sfc_ssr_render(
@@ -1050,6 +1253,12 @@ export const MyApp = (() => {
 
   return __vine;
 })();
+
+typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
+  __VUE_HMR_RUNTIME__.createRecord(
+    SampleCustomElement.__hmrId,
+    SampleCustomElement,
+  );
 
 typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
   __VUE_HMR_RUNTIME__.createRecord(AnotherComp.__hmrId, AnotherComp);

--- a/packages/compiler/tests/test-utils.ts
+++ b/packages/compiler/tests/test-utils.ts
@@ -1,7 +1,13 @@
 import type { VineCompilerCtx, VineCompilerHooks, VineCompilerOptions } from '../src/types'
 import { createCompilerCtx } from '../src/index'
 
-export function createMockTransformCtx(option: VineCompilerOptions = {}): {
+export function createMockTransformCtx(
+  option: VineCompilerOptions = {
+    vueCompilerOptions: {
+      isCustomElement: tag => tag.startsWith('vi-'),
+    },
+  },
+): {
   mockCompilerHooks: VineCompilerHooks
   mockCompilerCtx: VineCompilerCtx
 } {

--- a/packages/compiler/tests/transform.spec.ts
+++ b/packages/compiler/tests/transform.spec.ts
@@ -16,6 +16,14 @@ const v2 = ref(0)
 
 someExternalFunction2()
 
+export function SampleCustomElement() {
+  vineCustomElement()
+
+  return vine\`
+    <div>SampleCustomElement</div>
+  \`
+}
+
 function AnotherComp(props: {
   foo: string;
   bar: number;
@@ -25,10 +33,13 @@ function AnotherComp(props: {
     bar: (val: number) => val > 5,
   })
 
+  customElements.define('vi-sample-custom-element', SampleCustomElement)
+
   return vine\`
     <div>AnotherComp</div>
     <p>foo:{{ foo }}</p>
     <p>bar:{{ bar }}</p>
+    <vi-sample-custom-element />
   \`
 }
 

--- a/packages/docs/src/specification/macros.md
+++ b/packages/docs/src/specification/macros.md
@@ -180,3 +180,41 @@ const count = vineModel('count', { default: 0 }) // count's type is Ref<number>
 // When it's modified, the "update:count" event is triggered
 count.value++
 ```
+
+## `vineCustomElement`
+
+This macro is used to mark a Vue Vine component as a custom element constructor.
+
+```vue-vine
+function SampleCustomElement() {
+  vineCustomElement()
+
+  return vine`...`
+}
+
+function WhereYouUseIt() {
+  customElements.define('my-custom-element', SampleCustomElement)
+
+  return vine`
+    <my-custom-element />
+  `
+}
+```
+
+You should configure the `compilerOptions.customElement` option to let Vue recognize custom elements.
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite'
+import { VineVitePlugin } from 'vue-vine/vite'
+
+export default defineConfig({
+  plugins: [
+    VineVitePlugin({
+      vueCompilerOptions: {
+        isCustomElement: tag => tag.startsWith('my-'),
+      },
+    })
+  ],
+})
+```

--- a/packages/docs/src/zh/specification/macros.md
+++ b/packages/docs/src/zh/specification/macros.md
@@ -179,3 +179,41 @@ const count = vineModel('count', { default: 0 }) // count 的类型是 Ref<numbe
 // 在被修改时，触发 "update:count" 事件
 count.value++
 ```
+
+## `vineCustomElement` {#vinecustomelement}
+
+这个宏用于将 Vue Vine 组件标记为自定义元素构造函数。
+
+```vue-vine
+function SampleCustomElement() {
+  vineCustomElement()
+
+  return vine`...`
+}
+
+function WhereYouUseIt() {
+  customElements.define('my-custom-element', SampleCustomElement)
+
+  return vine`
+    <my-custom-element />
+  `
+}
+```
+
+同时，你需要配置 `compilerOptions.customElement` 选项，让 Vue 识别到自定义元素。
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite'
+import { VineVitePlugin } from 'vue-vine/vite'
+
+export default defineConfig({
+  plugins: [
+    VineVitePlugin({
+      vueCompilerOptions: {
+        isCustomElement: tag => tag.startsWith('my-'),
+      },
+    })
+  ],
+})
+```

--- a/packages/e2e-test/src/app.vine.ts
+++ b/packages/e2e-test/src/app.vine.ts
@@ -13,6 +13,7 @@ const routes = [
   { path: '/ts-morph-complex-external', label: 'Ts Morph Complex External' },
   { path: '/vine-prop', label: 'vineProp macro' },
   { path: '/vine-slots', label: 'vineSlots macro' },
+  { path: '/custom-elements', label: 'Custom Elements' },
 ]
 
 export function NavList() {

--- a/packages/e2e-test/src/fixtures/custom-elements.vine.ts
+++ b/packages/e2e-test/src/fixtures/custom-elements.vine.ts
@@ -1,0 +1,37 @@
+export function SampleCustomElement() {
+  vineCustomElement()
+
+  const count = ref(0)
+  const addCount = () => count.value += 1
+
+  return vine`
+    <div class="border-1 border-amber-100 border-solid bg-amber-100/50 p-4">
+      <p class="text-content mb-2">Count: {{ count }}</p>
+      <button class="add-count-btn bg-amber-200" @click="addCount">+1</button>
+    </div>
+  `
+}
+
+// eslint-disable-next-line antfu/top-level-function
+export const AnotherCustomElement = (
+  props: { foo: string },
+) => {
+  vineCustomElement()
+
+  return vine`
+    <div>Another Custom Element</div>
+  `
+}
+
+export function TestCustomElement() {
+  customElements.define('vi-sample-custom-element', SampleCustomElement)
+  customElements.define('vi-another-custom-element', AnotherCustomElement)
+
+  return vine`
+    <div class="flex flex-col gap-4">
+      <h3>Custom Elements</h3>
+      <vi-sample-custom-element />
+      <vi-another-custom-element />
+    </div>
+  `
+}

--- a/packages/e2e-test/src/router.ts
+++ b/packages/e2e-test/src/router.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import { TestTsMorphComplexExternal } from './components/ts-morph-complex-external/test-ts-morph.vine'
+import { TestCustomElement } from './fixtures/custom-elements.vine'
 import { TestExternalStyleImport } from './fixtures/external-style-import.vine'
 import { HmrApp } from './fixtures/hmr.vine'
 import { TestVineWithJsx } from './fixtures/mix-with-jsx.vine'
@@ -31,6 +32,7 @@ const routes = [
   { path: '/ts-morph-complex-external', component: TestTsMorphComplexExternal },
   { path: '/vine-prop', component: TestVinePropPage },
   { path: '/vine-slots', component: TestVineSlots },
+  { path: '/custom-elements', component: TestCustomElement },
 ]
 
 const router = createRouter({

--- a/packages/e2e-test/src/shims.d.ts
+++ b/packages/e2e-test/src/shims.d.ts
@@ -1,0 +1,8 @@
+declare module 'vue' {
+  interface GlobalComponents {
+    'vi-sample-custom-element': typeof import('./fixtures/custom-elements.vine')['SampleCustomElement']
+    'vi-another-custom-element': typeof import('./fixtures/custom-elements.vine')['AnotherCustomElement']
+  }
+}
+
+export {}

--- a/packages/e2e-test/src/styles/main.css
+++ b/packages/e2e-test/src/styles/main.css
@@ -2,8 +2,16 @@
   box-sizing: border-box;
   margin: 0;
   padding: 0;
+  font-family: 'Maple Mono NF CN';
 }
 
 body {
   padding: 1rem;
+}
+
+button {
+  border: none;
+  background-color: darkolivegreen;
+  padding: 0.5rem;
+  border-radius: 0.25rem;
 }

--- a/packages/e2e-test/tests/basic.spec.ts
+++ b/packages/e2e-test/tests/basic.spec.ts
@@ -203,4 +203,24 @@ describe('test basic functionality', async () => {
       expect(await evaluator.getTextContent('.slot-with-fallback .slot-with-fallback-wrapper:nth-child(3) .fallback')).toMatchInlineSnapshot(`"This is fallback content when no slot is provided"`)
     },
   ))
+
+  it('should support vineCustomElement', runTestAtPage(
+    '/custom-elements',
+    browserCtx,
+    async () => {
+      const sampleCustomElement = await browserCtx.page?.locator('vi-sample-custom-element')
+      expect(sampleCustomElement).toBeDefined()
+
+      // Find .text-content in shadow DOM
+      expect(await sampleCustomElement?.locator('.text-content').textContent()).toMatchInlineSnapshot(`"Count: 0"`)
+
+      // Find .add-count-btn in shadow DOM
+      const addCountBtn = await sampleCustomElement?.locator('.add-count-btn')
+      expect(addCountBtn).toBeDefined()
+
+      // Click the button
+      await addCountBtn?.click()
+      expect(await sampleCustomElement?.locator('.text-content').textContent()).toMatchInlineSnapshot(`"Count: 1"`)
+    },
+  ))
 })

--- a/packages/e2e-test/vite.config.ts
+++ b/packages/e2e-test/vite.config.ts
@@ -36,6 +36,10 @@ export default defineConfig({
         'src/components',
       ],
     }),
-    VineVitePlugin() as PluginOption,
+    VineVitePlugin({
+      vueCompilerOptions: {
+        isCustomElement: tag => tag.startsWith('vi-'),
+      },
+    }) as PluginOption,
   ],
 })

--- a/packages/language-service/tests/__snapshots__/virtual-code.spec.ts.snap
+++ b/packages/language-service/tests/__snapshots__/virtual-code.spec.ts.snap
@@ -1,5 +1,220 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`verify Volar virtual code snapshots > custom-elements.vine.ts 1`] = `
+"/// <reference types=".vue-global-types/vine_vue_99_true" />
+
+type __VINE_VLS_SampleCustomElement_props__ = {}
+export const SampleCustomElement = (function (
+  props: __VINE_VLS_VineComponentCommonProps & __VINE_VLS_SampleCustomElement_props__,
+context: {}) {
+  
+type SampleCustomElement_Props = Parameters<typeof SampleCustomElement>[0];
+
+vineCustomElement()
+
+  const count = ref(0)
+  const addCount = () => count.value += 1
+
+  
+// --- Start: Template virtual code
+
+const __VINE_VLS_ctx = __VINE_VLS_CreateVineVLSCtx({
+  /* __LINKED_CODE_LEFT__#5 */count: /* __LINKED_CODE_RIGHT__#5 */count,
+  /* __LINKED_CODE_LEFT__#8 */addCount: /* __LINKED_CODE_RIGHT__#8 */addCount,
+  /* __LINKED_CODE_LEFT__#19 */SampleCustomElement: /* __LINKED_CODE_RIGHT__#19 */SampleCustomElement,
+  /* __LINKED_CODE_LEFT__#20 */AnotherCustomElement: /* __LINKED_CODE_RIGHT__#20 */AnotherCustomElement,
+  /* __LINKED_CODE_LEFT__#17 */TestCustomElement: /* __LINKED_CODE_RIGHT__#17 */TestCustomElement,
+  /* No props formal params */
+});
+const __VINE_VLS_localComponents = __VINE_VLS_ctx;
+type __VINE_VLS_LocalComponents = __VINE_VLS_OmitAny<typeof __VINE_VLS_localComponents>;
+type __VINE_VLS_LocalDirectives = __VINE_VLS_OmitAny<typeof __VINE_VLS_ctx>;
+let __VINE_VLS_directives!: __VINE_VLS_LocalDirectives & __VINE_VLS_GlobalDirectives;
+const __VINE_VLS_components = {
+  ...{} as __VINE_VLS_GlobalComponents,
+  ...__VINE_VLS_localComponents as unknown as __VINE_VLS_LocalComponents,
+};
+
+type __VINE_VLS_StyleScopedClasses = {};
+__VINE_VLS_asFunctionalElement(__VINE_VLS_elements.div, __VINE_VLS_elements.div)({
+...{ class: "border-1 border-amber-100 border-solid bg-amber-100/50 p-4" },
+});
+__VINE_VLS_asFunctionalElement(__VINE_VLS_elements.p, __VINE_VLS_elements.p)({
+...{ class: "text-content mb-2" },
+});
+( __VINE_VLS_ctx.count );
+// @ts-ignore
+[count,];
+__VINE_VLS_asFunctionalElement(__VINE_VLS_elements.button, __VINE_VLS_elements.button)({
+...{ onClick: (__VINE_VLS_ctx.addCount)},
+...{ class: "add-count-btn bg-amber-200" },
+});
+// @ts-ignore
+[addCount,];
+/** @type {__VINE_VLS_StyleScopedClasses['border-1']} */;
+/** @type {__VINE_VLS_StyleScopedClasses['border-amber-100']} */;
+/** @type {__VINE_VLS_StyleScopedClasses['border-solid']} */;
+/** @type {__VINE_VLS_StyleScopedClasses['bg-amber-100/50']} */;
+/** @type {__VINE_VLS_StyleScopedClasses['p-4']} */;
+/** @type {__VINE_VLS_StyleScopedClasses['text-content']} */;
+/** @type {__VINE_VLS_StyleScopedClasses['mb-2']} */;
+/** @type {__VINE_VLS_StyleScopedClasses['add-count-btn']} */;
+/** @type {__VINE_VLS_StyleScopedClasses['bg-amber-200']} */;
+type __VINE_VLS_Slots = {};
+type __VINE_VLS_InheritedAttrs = {};
+type __VINE_VLS_TemplateRefs = {};
+type __VINE_VLS_RootEl = 
+| __VINE_VLS_NativeElements['div'];
+var __VINE_VLS_dollars!: {
+$slots: __VINE_VLS_Slots;
+$attrs: import('vue').ComponentPublicInstance['$attrs'] & Partial<__VINE_VLS_InheritedAttrs>;
+$refs: __VINE_VLS_TemplateRefs;
+$el: __VINE_VLS_RootEl;
+} & { [K in keyof import('vue').ComponentPublicInstance]: unknown };
+
+// --- End: Template virtual code
+
+return vine\`\` as any as __VINE_VLS_VueVineComponent;
+
+} as CustomElementConstructor);
+
+
+// eslint-disable-next-line antfu/top-level-function
+export const AnotherCustomElement = ((
+  props: __VINE_VLS_VineComponentCommonProps & { foo: string },context: {},
+) => {
+  
+type AnotherCustomElement_Props = Parameters<typeof AnotherCustomElement>[0];
+
+vineCustomElement()
+
+  
+// --- Start: Template virtual code
+
+const __VINE_VLS_ctx = __VINE_VLS_CreateVineVLSCtx({
+  /* __LINKED_CODE_LEFT__#19 */SampleCustomElement: /* __LINKED_CODE_RIGHT__#19 */SampleCustomElement,
+  /* __LINKED_CODE_LEFT__#20 */AnotherCustomElement: /* __LINKED_CODE_RIGHT__#20 */AnotherCustomElement,
+  /* __LINKED_CODE_LEFT__#17 */TestCustomElement: /* __LINKED_CODE_RIGHT__#17 */TestCustomElement,
+  ...props,
+});
+const __VINE_VLS_localComponents = __VINE_VLS_ctx;
+type __VINE_VLS_LocalComponents = __VINE_VLS_OmitAny<typeof __VINE_VLS_localComponents>;
+type __VINE_VLS_LocalDirectives = __VINE_VLS_OmitAny<typeof __VINE_VLS_ctx>;
+let __VINE_VLS_directives!: __VINE_VLS_LocalDirectives & __VINE_VLS_GlobalDirectives;
+const __VINE_VLS_components = {
+  ...{} as __VINE_VLS_GlobalComponents,
+  ...__VINE_VLS_localComponents as unknown as __VINE_VLS_LocalComponents,
+};
+
+type __VINE_VLS_StyleScopedClasses = {};
+__VINE_VLS_asFunctionalElement(__VINE_VLS_elements.div, __VINE_VLS_elements.div)({
+});
+type __VINE_VLS_Slots = {};
+type __VINE_VLS_InheritedAttrs = {};
+type __VINE_VLS_TemplateRefs = {};
+type __VINE_VLS_RootEl = 
+| __VINE_VLS_NativeElements['div'];
+var __VINE_VLS_dollars!: {
+$slots: __VINE_VLS_Slots;
+$attrs: import('vue').ComponentPublicInstance['$attrs'] & Partial<__VINE_VLS_InheritedAttrs>;
+$refs: __VINE_VLS_TemplateRefs;
+$el: __VINE_VLS_RootEl;
+} & { [K in keyof import('vue').ComponentPublicInstance]: unknown };
+
+// --- End: Template virtual code
+
+return vine\`\` as any as __VINE_VLS_VueVineComponent;
+
+} as CustomElementConstructor);
+
+type __VINE_VLS_TestCustomElement_props__ = {}
+
+
+export function TestCustomElement(
+  props: __VINE_VLS_VineComponentCommonProps & __VINE_VLS_TestCustomElement_props__,
+context: {}) {
+  
+type TestCustomElement_Props = Parameters<typeof TestCustomElement>[0];
+
+customElements.define('vi-sample-custom-element', SampleCustomElement)
+  customElements.define('vi-another-custom-element', AnotherCustomElement)
+
+  
+// --- Start: Template virtual code
+
+const __VINE_VLS_ctx = __VINE_VLS_CreateVineVLSCtx({
+  /* __LINKED_CODE_LEFT__#21 */ViSampleCustomElement: /* __LINKED_CODE_RIGHT__#21 */ViSampleCustomElement,
+  /* __LINKED_CODE_LEFT__#22 */ViAnotherCustomElement: /* __LINKED_CODE_RIGHT__#22 */ViAnotherCustomElement,
+  /* __LINKED_CODE_LEFT__#19 */SampleCustomElement: /* __LINKED_CODE_RIGHT__#19 */SampleCustomElement,
+  /* __LINKED_CODE_LEFT__#20 */AnotherCustomElement: /* __LINKED_CODE_RIGHT__#20 */AnotherCustomElement,
+  /* __LINKED_CODE_LEFT__#17 */TestCustomElement: /* __LINKED_CODE_RIGHT__#17 */TestCustomElement,
+  /* No props formal params */
+});
+const __VINE_VLS_localComponents = __VINE_VLS_ctx;
+type __VINE_VLS_LocalComponents = __VINE_VLS_OmitAny<typeof __VINE_VLS_localComponents>;
+type __VINE_VLS_LocalDirectives = __VINE_VLS_OmitAny<typeof __VINE_VLS_ctx>;
+let __VINE_VLS_directives!: __VINE_VLS_LocalDirectives & __VINE_VLS_GlobalDirectives;
+const __VINE_VLS_components = {
+  ...{} as __VINE_VLS_GlobalComponents,
+  ...__VINE_VLS_localComponents as unknown as __VINE_VLS_LocalComponents,
+};
+
+type __VINE_VLS_StyleScopedClasses = {};
+__VINE_VLS_asFunctionalElement(__VINE_VLS_elements.div, __VINE_VLS_elements.div)({
+...{ class: "flex flex-col gap-4" },
+});
+__VINE_VLS_asFunctionalElement(__VINE_VLS_elements.h3, __VINE_VLS_elements.h3)({
+});
+const __VINE_VLS_0 = ({} as __VINE_VLS_WithComponent<'ViSampleCustomElement', __VINE_VLS_LocalComponents, void, 'ViSampleCustomElement', 'viSampleCustomElement', 'vi-sample-custom-element'>).ViSampleCustomElement;
+/** @type {[typeof __VINE_VLS_components.ViSampleCustomElement, typeof __VINE_VLS_components.viSampleCustomElement, ]} */;
+// @ts-ignore
+ViSampleCustomElement;
+// @ts-ignore
+const __VINE_VLS_1 = __VINE_VLS_asFunctionalComponent(__VINE_VLS_0, new __VINE_VLS_0({
+}));
+const __VINE_VLS_2 = __VINE_VLS_1({
+}, ...__VINE_VLS_functionalComponentArgsRest(__VINE_VLS_1));
+const __VINE_VLS_5 = ({} as __VINE_VLS_WithComponent<'ViAnotherCustomElement', __VINE_VLS_LocalComponents, void, 'ViAnotherCustomElement', 'viAnotherCustomElement', 'vi-another-custom-element'>).ViAnotherCustomElement;
+/** @type {[typeof __VINE_VLS_components.ViAnotherCustomElement, typeof __VINE_VLS_components.viAnotherCustomElement, ]} */;
+// @ts-ignore
+ViAnotherCustomElement;
+// @ts-ignore
+const __VINE_VLS_6 = __VINE_VLS_asFunctionalComponent(__VINE_VLS_5, new __VINE_VLS_5({
+}));
+const __VINE_VLS_7 = __VINE_VLS_6({
+}, ...__VINE_VLS_functionalComponentArgsRest(__VINE_VLS_6));
+/** @type {__VINE_VLS_StyleScopedClasses['flex']} */;
+/** @type {__VINE_VLS_StyleScopedClasses['flex-col']} */;
+/** @type {__VINE_VLS_StyleScopedClasses['gap-4']} */;
+type __VINE_VLS_Slots = {};
+type __VINE_VLS_InheritedAttrs = {};
+type __VINE_VLS_TemplateRefs = {};
+type __VINE_VLS_RootEl = 
+| __VINE_VLS_NativeElements['div'];
+var __VINE_VLS_dollars!: {
+$slots: __VINE_VLS_Slots;
+$attrs: import('vue').ComponentPublicInstance['$attrs'] & Partial<__VINE_VLS_InheritedAttrs>;
+$refs: __VINE_VLS_TemplateRefs;
+$el: __VINE_VLS_RootEl;
+} & { [K in keyof import('vue').ComponentPublicInstance]: unknown };
+
+// --- End: Template virtual code
+
+return vine\`\` as any as __VINE_VLS_VueVineComponent;
+
+}
+
+const __VINE_VLS_ComponentsReferenceMap = {
+  'SampleCustomElement': SampleCustomElement,
+  'AnotherCustomElement': AnotherCustomElement,
+  'TestCustomElement': TestCustomElement,
+  'vi-sample-custom-element': vi-sample-custom-element,
+  'vi-another-custom-element': vi-another-custom-element
+};
+
+const __VINE_VLS_IntrinsicElements = {} as __VINE_VLS_IntrinsicElements;"
+`;
+
 exports[`verify Volar virtual code snapshots > key-cases.vine.ts 1`] = `
 "/// <reference types=".vue-global-types/vine_vue_99_true" />
 import type { Directive } from 'vue'

--- a/packages/language-service/tests/virtual-code.spec.ts
+++ b/packages/language-service/tests/virtual-code.spec.ts
@@ -34,4 +34,7 @@ describe('verify Volar virtual code snapshots', () => {
   it('use-template-ref-virtual-code.vine.ts', () => {
     testSnapshotForFile('../../e2e-test/src/fixtures/use-template-ref-virtual-code.vine.ts')
   })
+  it('custom-elements.vine.ts', () => {
+    testSnapshotForFile('../../e2e-test/src/fixtures/custom-elements.vine.ts')
+  })
 })

--- a/packages/vue-vine/types/macros.d.ts
+++ b/packages/vue-vine/types/macros.d.ts
@@ -70,6 +70,8 @@ declare global {
     }
   ): Ref<T>
 
+  function vineCustomElement(): void
+
   const vineStyle: VineStyleMacro
 
   const vine: (template: TemplateStringsArray) => VueVineComponent


### PR DESCRIPTION
Fix #290 

- [x] Supplement the missing feature of custom elements
- [x] Add new section to introduce the usage of `vineCustomElements()`
- [x] Add E2E Test case