### PR TITLE
fix: complicated event names need quotes

### DIFF
--- a/packages/e2e-test/src/fixtures/key-cases.vine.ts
+++ b/packages/e2e-test/src/fixtures/key-cases.vine.ts
@@ -20,7 +20,7 @@ export function SampleOne() {
 
   const p1 = vineProp<string>()
   vineOptions({
-    name: 'ESLintErrsSample'
+    name: 'ESLintErrsSample',
   })
 
   return vine`
@@ -72,7 +72,7 @@ export function TestUnoCssAttributeMode() {
   const vBounce: Directive<HTMLElement> = {
     mounted(el) {
       el.classList.add('bounce')
-    }
+    },
   }
 
   return vine`
@@ -84,15 +84,18 @@ export function TestUnoCssAttributeMode() {
 
 // #endregion
 
-
 // #region Fixtures for testing component reference & props check in VSCode
 export function TestCompOne() {
   /** @description zee is a string! */
   const zee = vineProp<string>()
   const foo = vineProp.withDefault(0)
 
+  const emits = vineEmits<{
+    'click:comp-one': [boolean]
+  }>()
+
   return vine`
-    <div>This is Comp1</div>
+    <div @click="emits('click:comp-one', true)">This is Comp1</div>
     <p>foo: {{ foo }}</p>
   `
 }
@@ -106,12 +109,11 @@ function TestCompTwo() {
     <!-- ^^^ It should reports error here -->
     <!-- due to unknown component 'UnknownComp' -->
     <TestCompOne />
-    <!--     ^^^ It should reports error here -->
+
     <!-- due to missing required prop 'zee' but not for 'foo' -->
   `
 }
 // #endregion
-
 
 // #region Test vineExpose and component ref
 function TargetComp(props: {
@@ -119,17 +121,21 @@ function TargetComp(props: {
 }) {
   const count = ref(0)
 
+  const onClickCompOne = (foo: boolean) => {
+    console.log('onClickCompOne: ', foo)
+  }
+
   watchEffect(() => {
     console.log('count: ', count.value)
   })
   vineExpose({
-    count
+    count,
   })
 
   return vine`
     <div @click="count++">Hello I'm target</div>
     <p>count: {{ count }}</p>
-    <TestCompOne zee="123" :foo="456" />
+    <TestCompOne zee="123" :foo="456" @click:comp-one="onClickCompOne" />
   `
 }
 
@@ -148,7 +154,7 @@ export function TestCompRef() {
 
 // #region Test ESLint rule: no-v-for-key-on-child
 export function TestNoVforKeyOnChild() {
-  interface User { id: string; name: string }
+  interface User { id: string, name: string }
   const users = ref<User[]>([])
   return vine`
     <div class="user-list">
@@ -180,7 +186,7 @@ export async function TestNoLifecycleHookAfterAwait() {
 // #region Test generics on Vine component function
 
 export function TestGenericComp1<T extends keyof HTMLElementTagNameMap = 'h1'>(
-  props: Partial<HTMLElementTagNameMap[T]> & { as: T }
+  props: Partial<HTMLElementTagNameMap[T]> & { as: T },
 ) {
   return vine`
     <component :is="as" />

--- a/packages/language-service/src/virtual-code.ts
+++ b/packages/language-service/src/virtual-code.ts
@@ -34,6 +34,9 @@ function getLinkedCodeMappings(tsCode: string): Mapping[] {
   for (let i = 0; i < linkedCodeLeftFounds.length; i++) {
     const foundLeft = linkedCodeLeftFounds[i]
     const foundRight = linkedCodeRightFounds[i]
+    if (!foundLeft || !foundRight) {
+      continue
+    }
 
     const start = foundLeft.index + foundLeft.tagLength
     const end = foundRight.index + foundRight.tagLength

--- a/packages/language-service/tests/__snapshots__/virtual-code.spec.ts.snap
+++ b/packages/language-service/tests/__snapshots__/virtual-code.spec.ts.snap
@@ -312,7 +312,7 @@ const count = ref(0)
 
   const /* __LINKED_CODE_RIGHT__#2 */p1 = vineProp<string>()
   vineOptions({
-    name: 'ESLintErrsSample'
+    name: 'ESLintErrsSample',
   })
 
   
@@ -553,7 +553,7 @@ type TestUnoCssAttributeMode_Props = Parameters<typeof TestUnoCssAttributeMode>[
 const vBounce: Directive<HTMLElement> = {
     mounted(el) {
       el.classList.add('bounce')
-    }
+    },
   }
 
   
@@ -623,13 +623,18 @@ type __VLS_VINE_TestCompOne_props__ = {
 /* __LINKED_CODE_LEFT__#3 */foo?: number
 }
 
+type __VLS_VINE_TestCompOne_emits__ = __VLS_NormalizeEmits<__VLS_VINE_VueDefineEmits<{
+    'click:comp-one': [boolean]
+  }>>;
+
 
 // #endregion
 
-
 // #region Fixtures for testing component reference & props check in VSCode
 export function TestCompOne(
-  props: __VLS_VINE_VineComponentCommonProps & __VLS_VINE_TestCompOne_props__,
+  props: __VLS_VINE_VineComponentCommonProps & __VLS_VINE_TestCompOne_props__  & {
+    /* __LINKED_CODE_LEFT__#16 */'onClick:comp-one': __VLS_VINE_TestCompOne_emits__['click:comp-one']
+},
 context: {}) {
   
 type TestCompOne_Props = Parameters<typeof TestCompOne>[0];
@@ -638,12 +643,17 @@ type TestCompOne_Props = Parameters<typeof TestCompOne>[0];
   const /* __LINKED_CODE_RIGHT__#3 */zee = vineProp<string>()
   const /* __LINKED_CODE_RIGHT__#3 */foo = vineProp.withDefault(0)
 
+  const emits = vineEmits<{
+    'click:comp-one': [boolean]
+  }>()
+
   
 // --- Start: Template virtual code
 
 const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#3 */zee: /* __LINKED_CODE_RIGHT__#3 */zee,
   /* __LINKED_CODE_LEFT__#3 */foo: /* __LINKED_CODE_RIGHT__#3 */foo,
+  /* __LINKED_CODE_LEFT__#5 */emits: /* __LINKED_CODE_RIGHT__#5 */emits,
   /* __LINKED_CODE_LEFT__#9 */onMounted: /* __LINKED_CODE_RIGHT__#9 */onMounted,
   /* __LINKED_CODE_LEFT__#3 */ref: /* __LINKED_CODE_RIGHT__#3 */ref,
   /* __LINKED_CODE_LEFT__#14 */useTemplateRef: /* __LINKED_CODE_RIGHT__#14 */useTemplateRef,
@@ -675,6 +685,11 @@ const __VLS_components = {
 
 type __VLS_VINE_StyleScopedClasses = {};
 __VLS_asFunctionalElement(__VLS_elements.div, __VLS_elements.div)({
+...{ onClick: (...[$event]) => {
+__VLS_ctx.emits('click:comp-one', true);
+// @ts-ignore
+[emits,];
+}},
 });
 __VLS_asFunctionalElement(__VLS_elements.p, __VLS_elements.p)({
 });
@@ -785,7 +800,6 @@ return vine\`\` as any as __VLS_VINE_VueVineComponent;
 }
 // #endregion
 
-
 // #region Test vineExpose and component ref
 function TargetComp(props: __VLS_VINE_VineComponentCommonProps & {
   foo: boolean
@@ -797,11 +811,15 @@ type TargetComp_Props = Parameters<typeof TargetComp>[0];
 
 const count = ref(0)
 
+  const onClickCompOne = (foo: boolean) => {
+    console.log('onClickCompOne: ', foo)
+  }
+
   watchEffect(() => {
     console.log('count: ', count.value)
   })
   const __VLS_VINE_ComponentExpose__ = {
-    count
+    count,
   };
 vineExpose(__VLS_VINE_ComponentExpose__)
 
@@ -811,6 +829,7 @@ vineExpose(__VLS_VINE_ComponentExpose__)
 const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#11 */TestCompOne: /* __LINKED_CODE_RIGHT__#11 */TestCompOne,
   /* __LINKED_CODE_LEFT__#5 */count: /* __LINKED_CODE_RIGHT__#5 */count,
+  /* __LINKED_CODE_LEFT__#14 */onClickCompOne: /* __LINKED_CODE_RIGHT__#14 */onClickCompOne,
   /* __LINKED_CODE_LEFT__#9 */onMounted: /* __LINKED_CODE_RIGHT__#9 */onMounted,
   /* __LINKED_CODE_LEFT__#3 */ref: /* __LINKED_CODE_RIGHT__#3 */ref,
   /* __LINKED_CODE_LEFT__#14 */useTemplateRef: /* __LINKED_CODE_RIGHT__#14 */useTemplateRef,
@@ -858,13 +877,23 @@ const __VLS_0 = ({} as __VLS_WithComponent<'TestCompOne', __VLS_LocalComponents,
 TestCompOne;
 // @ts-ignore
 const __VLS_1 = __VLS_asFunctionalComponent(__VLS_0, new __VLS_0({
+...{ 'onClick:compOne': {} as any },
 zee: "123",
 foo: (456),
 }));
 const __VLS_2 = __VLS_1({
+...{ 'onClick:compOne': {} as any },
 zee: "123",
 foo: (456),
 }, ...__VLS_functionalComponentArgsRest(__VLS_1));
+let __VLS_4!: __VLS_ResolveEmits<typeof __VLS_0, typeof __VLS_3.emit>;
+let __VLS_5!: __VLS_FunctionalComponentProps<typeof __VLS_1, typeof __VLS_2>;
+const __VLS_6: __VLS_NormalizeComponentEvent<typeof __VLS_5, typeof __VLS_4, 'onClick:compOne', 'click:comp-one', 'click:compOne'> = (
+{ 'click:compOne': {} as any } as typeof __VLS_4,
+{ 'onClick:compOne': (__VLS_ctx.onClickCompOne)});
+// @ts-ignore
+[onClickCompOne,];
+var __VLS_3!: __VLS_FunctionalComponentCtx<typeof __VLS_0, typeof __VLS_2>;
 type __VLS_Slots = {};
 type __VLS_InheritedAttrs = {};
 type __VLS_TemplateRefs = {};
@@ -977,7 +1006,7 @@ context: {}) {
   
 type TestNoVforKeyOnChild_Props = Parameters<typeof TestNoVforKeyOnChild>[0];
 
-interface User { id: string; name: string }
+interface User { id: string, name: string }
   const users = ref<User[]>([])
   
 // --- Start: Template virtual code
@@ -1119,7 +1148,7 @@ return vine\`\` as any as __VLS_VINE_VueVineComponent;
 // #region Test generics on Vine component function
 
 export function TestGenericComp1<T extends keyof HTMLElementTagNameMap = 'h1'>(
-  props: __VLS_VINE_VineComponentCommonProps & Partial<HTMLElementTagNameMap[T]> & { as: T },context: {}
+  props: __VLS_VINE_VineComponentCommonProps & Partial<HTMLElementTagNameMap[T]> & { as: T },context: {},
 ) {
   
 type TestGenericComp1_Props = Parameters<typeof TestGenericComp1>[0];

--- a/packages/language-service/tests/utils.spec.ts
+++ b/packages/language-service/tests/utils.spec.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest'
+import { convertEmitToOnHandler, needsQuotes } from '../src/codegen'
+
+describe('convertEmitToOnHandler', () => {
+  describe('complex property names (containing special characters)', () => {
+    it('should handle emit names containing colons', () => {
+      expect(convertEmitToOnHandler('update:modelValue')).toBe('onUpdate:modelValue')
+      expect(convertEmitToOnHandler('update:something')).toBe('onUpdate:something')
+      expect(convertEmitToOnHandler('change:value')).toBe('onChange:value')
+    })
+
+    it('should handle emit names containing underscores', () => {
+      expect(convertEmitToOnHandler('custom_event')).toBe('onCustom_event')
+      expect(convertEmitToOnHandler('user_login')).toBe('onUser_login')
+      expect(convertEmitToOnHandler('data_change')).toBe('onData_change')
+    })
+
+    it('should handle emit names containing dots', () => {
+      expect(convertEmitToOnHandler('namespace.event')).toBe('onNamespace.event')
+      expect(convertEmitToOnHandler('module.action')).toBe('onModule.action')
+    })
+
+    it('should handle emit names containing double colons', () => {
+      expect(convertEmitToOnHandler('event::name')).toBe('onEvent::name')
+      expect(convertEmitToOnHandler('module::action')).toBe('onModule::action')
+    })
+
+    it('should handle emit names containing mixed special characters', () => {
+      expect(convertEmitToOnHandler('update:model_value')).toBe('onUpdate:model_value')
+      expect(convertEmitToOnHandler('change:data.value')).toBe('onChange:data.value')
+      expect(convertEmitToOnHandler('ns::event_name')).toBe('onNs::event_name')
+    })
+
+    it('should handle emit names starting with special characters', () => {
+      expect(convertEmitToOnHandler(':special')).toBe('on:special')
+      expect(convertEmitToOnHandler('_private')).toBe('on_private')
+      expect(convertEmitToOnHandler('.dotted')).toBe('on.dotted')
+    })
+  })
+
+  describe('simple property names (only containing letters and numbers)', () => {
+    it('should handle simple emit names', () => {
+      expect(convertEmitToOnHandler('click')).toBe('onClick')
+      expect(convertEmitToOnHandler('change')).toBe('onChange')
+      expect(convertEmitToOnHandler('input')).toBe('onInput')
+    })
+
+    it('should handle emit names containing hyphens (camel case conversion)', () => {
+      expect(convertEmitToOnHandler('my-event')).toBe('onMyEvent')
+      expect(convertEmitToOnHandler('user-click')).toBe('onUserClick')
+      expect(convertEmitToOnHandler('data-change')).toBe('onDataChange')
+    })
+
+    it('should handle multiple hyphens in emit names', () => {
+      expect(convertEmitToOnHandler('very-long-event-name')).toBe('onVeryLongEventName')
+      expect(convertEmitToOnHandler('a-b-c-d')).toBe('onABCD')
+    })
+
+    it('should handle emit names containing numbers', () => {
+      expect(convertEmitToOnHandler('event1')).toBe('onEvent1')
+      expect(convertEmitToOnHandler('data2change')).toBe('onData2change')
+      expect(convertEmitToOnHandler('test123')).toBe('onTest123')
+    })
+
+    it('should handle mixed case emit names', () => {
+      expect(convertEmitToOnHandler('myEvent')).toBe('onMyEvent')
+      expect(convertEmitToOnHandler('DataChange')).toBe('onDataChange')
+      expect(convertEmitToOnHandler('userAction')).toBe('onUserAction')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle empty strings', () => {
+      expect(convertEmitToOnHandler('')).toBe('on')
+    })
+
+    it('should handle single character emit names', () => {
+      expect(convertEmitToOnHandler('a')).toBe('onA')
+      expect(convertEmitToOnHandler('1')).toBe('on1')
+      expect(convertEmitToOnHandler(':')).toBe('on:')
+      expect(convertEmitToOnHandler('_')).toBe('on_')
+    })
+
+    it('should handle emit names containing only special characters', () => {
+      expect(convertEmitToOnHandler(':::')).toBe('on:::')
+      expect(convertEmitToOnHandler('___')).toBe('on___')
+      expect(convertEmitToOnHandler('...')).toBe('on...')
+    })
+
+    it('should handle long strings', () => {
+      const longEmit = 'very-very-very-long-event-name-with-many-words'
+      const expected = 'onVeryVeryVeryLongEventNameWithManyWords'
+      expect(convertEmitToOnHandler(longEmit)).toBe(expected)
+    })
+  })
+})
+
+describe('needsQuotes', () => {
+  describe('should return true for invalid JavaScript identifiers', () => {
+    it('should handle property names containing special characters', () => {
+      expect(needsQuotes('onUpdate:modelValue')).toBe(true)
+      expect(needsQuotes('onChange:value')).toBe(true)
+      expect(needsQuotes('onNamespace.event')).toBe(true)
+      expect(needsQuotes('onEvent::name')).toBe(true)
+    })
+
+    it('should handle property names starting with numbers', () => {
+      expect(needsQuotes('123invalid')).toBe(true)
+      expect(needsQuotes('1event')).toBe(true)
+    })
+
+    it('should handle property names with spaces', () => {
+      expect(needsQuotes('on event')).toBe(true)
+      expect(needsQuotes('my prop')).toBe(true)
+    })
+
+    it('should handle property names with other special characters', () => {
+      expect(needsQuotes('on-event')).toBe(true) // hyphen is not valid in identifier
+      expect(needsQuotes('on@event')).toBe(true)
+      expect(needsQuotes('on#event')).toBe(true)
+      expect(needsQuotes('on%event')).toBe(true)
+    })
+
+    it('should handle empty string', () => {
+      expect(needsQuotes('')).toBe(true)
+    })
+  })
+
+  describe('should return false for valid JavaScript identifiers', () => {
+    it('should handle simple camelCase property names', () => {
+      expect(needsQuotes('onClick')).toBe(false)
+      expect(needsQuotes('onChange')).toBe(false)
+      expect(needsQuotes('onInput')).toBe(false)
+      expect(needsQuotes('onMyEvent')).toBe(false)
+    })
+
+    it('should handle property names starting with valid characters', () => {
+      expect(needsQuotes('onEvent')).toBe(false)
+      expect(needsQuotes('_private')).toBe(false)
+      expect(needsQuotes('$special')).toBe(false)
+      expect(needsQuotes('a')).toBe(false)
+    })
+
+    it('should handle property names with numbers (but not starting with)', () => {
+      expect(needsQuotes('onEvent1')).toBe(false)
+      expect(needsQuotes('data2change')).toBe(false)
+      expect(needsQuotes('test123')).toBe(false)
+    })
+
+    it('should handle property names with underscores and dollar signs', () => {
+      expect(needsQuotes('on_event')).toBe(false)
+      expect(needsQuotes('onCustom_event')).toBe(false)
+      expect(needsQuotes('$onEvent')).toBe(false)
+      expect(needsQuotes('_on_event_')).toBe(false)
+      expect(needsQuotes('$$private$$')).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
- Doesn't panic when linked code mappings not found (nullish value safety)

- Complicated event names should be wrapped in quotes to avoid syntax error in virtual code.