### PR TITLE
fix(vite-hmr): use `addSourceFileAtPath` instead of `createSourceFile`

### DIFF
--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -237,8 +237,7 @@ function createVinePlugin(options: VineCompilerOptions = {}): PluginOption {
 
           if (!sourceFile) {
             // Handle new files: add them to the ts-morph project
-            const updatedContent = await ctx.read()
-            sourceFile = project.createSourceFile(ctx.file, updatedContent, { overwrite: false })
+            sourceFile = project.addSourceFileAtPath(ctx.file)
 
             // Ensure the new file is also in Vite's module graph
             const moduleNode = ctx.server.moduleGraph.getModuleById(ctx.file)


### PR DESCRIPTION
### Problem

`ts-morph` would throw a error if you would like to do HMR in a new file

```
[vue vine] Error on ts-morph action: Did you mean to provide the overwrite option? 
A source file already exists at the provided file path: /Users/liangmi/code/vue-vine/packages/e2e-test/src/a.vine.ts
```

The current implementation uses `createSourceFile` with `overwrite: false` which throws an error when the file already exists in the filesystem. 

But for a new file, it must already exist in the filesystem - we just need to add it to the ts-morph project cache instead of re-creating it.

### Fixes

Replace `createSourceFile` with `addSourceFileAtPath`

### Impact

This change ensures HMR works for new `.vine.ts` files without errors

Hope it is helpful

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hot-module reloading reliability when new files are added, reducing missed updates and intermittent errors during development.

* **Refactor**
  * Streamlined how new files are registered by the plugin during HMR, avoiding unnecessary file reads.
  * Delivers faster recognition of newly added files and more consistent behavior across environments.
  * Minor performance and stability improvements during incremental development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->