### PR TITLE
fix(compiler): should allow slot props use type name

### DIFF
--- a/packages/compiler/src/validate.ts
+++ b/packages/compiler/src/validate.ts
@@ -458,14 +458,14 @@ function assertSlotFunctionSignature(
   params: Array<Identifier | RestElement | ArrayPattern | ObjectPattern>,
   errorLocation: SourceLocation | null | undefined,
 ) {
-  const { vineCompilerHooks, vineFileCtx } = validatorCtx
-  const errMsg = 'Function signature of `vineSlots` can only have one parameter named `props`'
-
+  // Empty parameter in vineSlots declaration is allowed
   if (params.length === 0) {
-    // Empty parameter in vineSlots declaration is allowed
     return
   }
-  else if (params.length > 1) {
+
+  const { vineCompilerHooks, vineFileCtx } = validatorCtx
+  const errMsg = 'Function signature of `vineSlots` can only have one parameter named `props`'
+  if (params.length > 1) {
     vineCompilerHooks.onError(
       vineErr(
         { vineFileCtx },
@@ -504,12 +504,12 @@ function assertSlotFunctionSignature(
   }
 
   const paramTypeAnnotation = (firstParam.typeAnnotation as TSTypeAnnotation)?.typeAnnotation
-  if (!paramTypeAnnotation || !isTSTypeLiteral(paramTypeAnnotation)) {
+  if (!paramTypeAnnotation) {
     vineCompilerHooks.onError(
       vineErr(
         { vineFileCtx },
         {
-          msg: `${errMsg}, and its type annotation must be object literal`,
+          msg: errMsg,
           location: firstParam.loc,
         },
       ),

--- a/packages/compiler/tests/validate.spec.ts
+++ b/packages/compiler/tests/validate.spec.ts
@@ -148,13 +148,12 @@ function App(props: { foo: string }) {
 `
     const { mockCompilerCtx, mockCompilerHooks } = createMockTransformCtx()
     compileVineTypeScriptFile(content, 'testVineMacrosUsage', { compilerHooks: mockCompilerHooks })
-    expect(mockCompilerCtx.vineCompileErrors.length).toMatchInlineSnapshot(`17`)
+    expect(mockCompilerCtx.vineCompileErrors.length).toMatchInlineSnapshot(`16`)
     expect(mockCompilerCtx.vineCompileErrors.map(err => err.msg))
       .toMatchInlineSnapshot(`
         [
           "vineStyle CSS language only supports: \`css\`, \`scss\`, \`sass\`, \`less\`, \`stylus\` and \`postcss\`",
           "Every property of Vue Vine component function's \`vineSlots\` type must be function signature",
-          "Function signature of \`vineSlots\` can only have one parameter named \`props\`, and its type annotation must be object literal",
           "Function signature of \`vineSlots\` can only have one parameter named \`props\`, and its parameter name must be \`props\`, but got \`yyy\`",
           "Properties of \`vineSlots\` can only have function type annotation",
           "the declaration of \`vineModel\` macro call must be inside a variable declaration",


### PR DESCRIPTION
Close #323 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `vineSlots` function signature validation to be more flexible and less restrictive.
  * Simplified type annotation requirements and updated corresponding error messaging for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->