### PR TITLE
fix(lang-service): gurantee VLS types available in generated dts

### DIFF
--- a/packages/language-service/src/codegen.ts
+++ b/packages/language-service/src/codegen.ts
@@ -173,7 +173,7 @@ export function generateEmitProps(
         ? createLinkedCodeTag('left', onEmit.length)
         : ''
     }${quotedPropName}${isOptional ? '?' : ''
-    }: __VLS_VINE_${vineCompFn.fnName}_emits__['${emit}']`
+    }: __VLS_VINE.${vineCompFn.fnName}_emits__['${emit}']`
   }).filter(Boolean).join(', ')
   }\n}`
 
@@ -263,7 +263,7 @@ export function generateContextFormalParam(
   // Generate `expose: (exposed: ExposedType) => void`
   if (vineCompFn.expose) {
     contextProperties.push(
-      `expose: __VLS_VINE_PickComponentExpose<typeof ${vineCompFn.fnName}>,`,
+      `expose: __VLS_VINE.PickComponentExpose<typeof ${vineCompFn.fnName}>,`,
     )
   }
 
@@ -284,7 +284,7 @@ export function generatePropsType(
   const { tsCodeSegments } = ctx
   let propTypeBase = ''
   if (type === 'macro') {
-    propTypeBase = `__VLS_VINE_VineComponentCommonProps & __VLS_VINE_${vineCompFn.fnName}_props__`
+    propTypeBase = `__VLS_VINE.VineComponentCommonProps & __VLS_VINE_${vineCompFn.fnName}_props__`
   }
   else {
     // User provide a `props` formal parameter in the component function,
@@ -293,7 +293,7 @@ export function generatePropsType(
     if (formalParamTypeNode) {
       generateScriptUntil(ctx, formalParamTypeNode.start!)
       // Insert common props before the user provided props type
-      tsCodeSegments.push('__VLS_VINE_VineComponentCommonProps & ')
+      tsCodeSegments.push(`__VLS_VINE.VineComponentCommonProps & `)
       generateScriptUntil(ctx, formalParamTypeNode.end!)
     }
   }
@@ -322,7 +322,7 @@ export function generateComponentPropsAndContext(
     })}\n`)
   }
   if (vineCompFn.emits.length > 0) {
-    tsCodeSegments.push(`\ntype __VLS_VINE_${vineCompFn.fnName}_emits__ = __VLS_NormalizeEmits<__VLS_VINE_VueDefineEmits<${
+    tsCodeSegments.push(`\ntype __VLS_VINE_${vineCompFn.fnName}_emits__ = __VLS_NormalizeEmits<__VLS_VINE.VueDefineEmits<${
       vineCompFn.emitsTypeParam
         ? vineFileCtx.getAstNodeContent(vineCompFn.emitsTypeParam)
         : `{${vineCompFn.emits.map(emit => `'${emit}': any`).join(', ')}}`

--- a/packages/language-service/src/injectTypes.ts
+++ b/packages/language-service/src/injectTypes.ts
@@ -63,46 +63,20 @@ export function setupGlobalTypes(
 export function generateGlobalTypes(vueOptions: VueCompilerOptions): string {
   let globalTypes = _generateGlobalTypes(vueOptions)
 
-  // Replace __VLS_Element
+  // Replace __VLS_Element to include VUE_VINE_COMPONENT marker
   globalTypes = globalTypes
     .replace(
       'type __VLS_Element = import(\'vue/jsx-runtime\').JSX.Element;',
       'type __VLS_Element = import(\'vue/jsx-runtime\').JSX.Element & { [VUE_VINE_COMPONENT]: true };',
     )
 
-  // Insert Vine specific definition after 'declare global'
+  // Insert Vine-specific global declarations
+  // Note: The actual type definitions are injected directly into virtual code
+  // to ensure they are included in generated .d.ts files
   globalTypes = globalTypes.replace(
     /declare global\s*\{/,
     `declare global {
   const VUE_VINE_COMPONENT: unique symbol;
-  type __VLS_VINE_StrictIsAny<T> = [unknown] extends [T]
-    ? ([T] extends [unknown] ? true : false)
-    : false;
-  type __VLS_VINE_OmitAny<T> = {
-    [K in keyof T as __VLS_VINE_StrictIsAny<T[K]> extends true ? never : K]: T[K]
-  }
-  type __VLS_VINE_MakeVLSCtx<T extends object> =
-    & T
-    & import('vue').ComponentPublicInstance
-  const __VLS_VINE_CreateVineVLSCtx: <T>(ctx: T) => __VLS_VINE_MakeVLSCtx<import('vue').ShallowUnwrapRef<T>>;
-  type __VLS_VINE_VueVineComponent = __VLS_Element;
-  const __VLS_elements: import('vue/jsx-runtime').JSX.IntrinsicElements;
-
-  // From vuejs 'runtime-core.d.ts':
-  type __VLS_VINE_UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never;
-  type __VLS_VINE_RecordToUnion<T extends Record<string, any>> = T[keyof T];
-  type __VLS_VINE_VueDefineEmits<T extends Record<string, any>> = __VLS_VINE_UnionToIntersection<Exclude<__VLS_VINE_RecordToUnion<{
-      [K in keyof T]: (evt: K, ...args: Exclude<T[K], undefined>) => void;
-  }>, undefined>>;
-
-  type __VLS_VINE_PickComponentExpose<F extends (...args: any[]) => any> = ReturnType<F> extends __VLS_VINE_VueVineComponent & {
-    exposed: infer E
-  } ? (exposed: E) => void : never;
-
-  type __VLS_VINE_VineComponentCommonProps = import('vue').HTMLAttributes & {
-    key?: PropertyKey
-    ref?: string | import('vue').Ref | ((ref: Element | import('vue').ComponentPublicInstance | null, refs: Record<string, any>) => void);
-  }
     `,
   )
 
@@ -165,7 +139,7 @@ export function generateVLSContext(
   )
 
   const __VINE_CONTEXT_TYPES = `
-const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
+const __VLS_ctx = __VLS_VINE.CreateVineVLSCtx({
 ${notPropsBindings.map(([name]) => {
   // `name` maybe 'router-view' format,
   // so we need to convert it to PascalCase: `RouterView`
@@ -186,8 +160,8 @@ ${notPropsBindings.map(([name]) => {
   }
 });
 const __VLS_localComponents = __VLS_ctx;
-type __VLS_LocalComponents = __VLS_VINE_OmitAny<typeof __VLS_localComponents>;
-type __VLS_LocalDirectives = __VLS_VINE_OmitAny<typeof __VLS_ctx>;
+type __VLS_LocalComponents = __VLS_VINE.OmitAny<typeof __VLS_localComponents>;
+type __VLS_LocalDirectives = __VLS_VINE.OmitAny<typeof __VLS_ctx>;
 let __VLS_directives!: __VLS_LocalDirectives & __VLS_GlobalDirectives;
 const __VLS_components = {
   ...{} as __VLS_GlobalComponents,

--- a/packages/language-service/src/virtual-code.ts
+++ b/packages/language-service/src/virtual-code.ts
@@ -147,6 +147,9 @@ export function createVueVineVirtualCode(
     console.error('[Vue Vine] Failed to setup global types')
   }
 
+  // Import Vine internal types for virtual code type definitions
+  tsCodeSegments.push(`import * as __VLS_VINE from 'vue-vine/internals';\n\n`)
+
   const firstVineCompFnDeclNode = vineFileCtx.vineCompFns[0]?.fnDeclNode
   if (firstVineCompFnDeclNode) {
     generateScriptUntil(codegenCtx, firstVineCompFnDeclNode.start!)
@@ -272,7 +275,7 @@ export function createVueVineVirtualCode(
       generateScriptUntil(codegenCtx, vineCompFn.templateStringNode.quasi.start!)
 
       // clear the template string
-      tsCodeSegments.push(`\`\` as any as __VLS_VINE_VueVineComponent${vineCompFn.expose
+      tsCodeSegments.push(`\`\` as any as __VLS_VINE.VueVineComponent${vineCompFn.expose
         ? ` & { exposed: (import('vue').ShallowUnwrapRef<typeof __VLS_VINE_ComponentExpose__>) }`
         : ''
       };\n`)

--- a/packages/language-service/tests/__snapshots__/global-types.spec.ts.snap
+++ b/packages/language-service/tests/__snapshots__/global-types.spec.ts.snap
@@ -6,34 +6,6 @@ export {};
 
 ; declare global {
   const VUE_VINE_COMPONENT: unique symbol;
-  type __VLS_VINE_StrictIsAny<T> = [unknown] extends [T]
-    ? ([T] extends [unknown] ? true : false)
-    : false;
-  type __VLS_VINE_OmitAny<T> = {
-    [K in keyof T as __VLS_VINE_StrictIsAny<T[K]> extends true ? never : K]: T[K]
-  }
-  type __VLS_VINE_MakeVLSCtx<T extends object> =
-    & T
-    & import('vue').ComponentPublicInstance
-  const __VLS_VINE_CreateVineVLSCtx: <T>(ctx: T) => __VLS_VINE_MakeVLSCtx<import('vue').ShallowUnwrapRef<T>>;
-  type __VLS_VINE_VueVineComponent = __VLS_Element;
-  const __VLS_elements: import('vue/jsx-runtime').JSX.IntrinsicElements;
-
-  // From vuejs 'runtime-core.d.ts':
-  type __VLS_VINE_UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never;
-  type __VLS_VINE_RecordToUnion<T extends Record<string, any>> = T[keyof T];
-  type __VLS_VINE_VueDefineEmits<T extends Record<string, any>> = __VLS_VINE_UnionToIntersection<Exclude<__VLS_VINE_RecordToUnion<{
-      [K in keyof T]: (evt: K, ...args: Exclude<T[K], undefined>) => void;
-  }>, undefined>>;
-
-  type __VLS_VINE_PickComponentExpose<F extends (...args: any[]) => any> = ReturnType<F> extends __VLS_VINE_VueVineComponent & {
-    exposed: infer E
-  } ? (exposed: E) => void : never;
-
-  type __VLS_VINE_VineComponentCommonProps = import('vue').HTMLAttributes & {
-    key?: PropertyKey
-    ref?: string | import('vue').Ref | ((ref: Element | import('vue').ComponentPublicInstance | null, refs: Record<string, any>) => void);
-  }
     
 	const __VLS_directiveBindingRestFields: { instance: null, oldValue: null, modifiers: any, dir: any };
 	const __VLS_unref: typeof import('vue').unref;

--- a/packages/language-service/tests/__snapshots__/virtual-code.spec.ts.snap
+++ b/packages/language-service/tests/__snapshots__/virtual-code.spec.ts.snap
@@ -2,10 +2,12 @@
 
 exports[`verify Volar virtual code snapshots > custom-elements.vine.ts 1`] = `
 "/// <reference types="../../../../node_modules/.vue-global-types/vine_vue_99_true.d.ts" />
+import * as __VLS_VINE from 'vue-vine/internals';
+
 
 type __VLS_VINE_SampleCustomElement_props__ = {}
 export const SampleCustomElement = (function (
-  props: __VLS_VINE_VineComponentCommonProps & __VLS_VINE_SampleCustomElement_props__,
+  props: __VLS_VINE.VineComponentCommonProps & __VLS_VINE_SampleCustomElement_props__,
 context: {}) {
   
 type SampleCustomElement_Props = Parameters<typeof SampleCustomElement>[0];
@@ -18,7 +20,7 @@ vineCustomElement()
   
 // --- Start: Template virtual code
 
-const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
+const __VLS_ctx = __VLS_VINE.CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#5 */count: /* __LINKED_CODE_RIGHT__#5 */count,
   /* __LINKED_CODE_LEFT__#8 */addCount: /* __LINKED_CODE_RIGHT__#8 */addCount,
   /* __LINKED_CODE_LEFT__#19 */SampleCustomElement: /* __LINKED_CODE_RIGHT__#19 */SampleCustomElement,
@@ -27,8 +29,8 @@ const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
   /* No props formal params */
 });
 const __VLS_localComponents = __VLS_ctx;
-type __VLS_LocalComponents = __VLS_VINE_OmitAny<typeof __VLS_localComponents>;
-type __VLS_LocalDirectives = __VLS_VINE_OmitAny<typeof __VLS_ctx>;
+type __VLS_LocalComponents = __VLS_VINE.OmitAny<typeof __VLS_localComponents>;
+type __VLS_LocalDirectives = __VLS_VINE.OmitAny<typeof __VLS_ctx>;
 let __VLS_directives!: __VLS_LocalDirectives & __VLS_GlobalDirectives;
 const __VLS_components = {
   ...{} as __VLS_GlobalComponents,
@@ -74,14 +76,14 @@ $el: __VLS_RootEl;
 
 // --- End: Template virtual code
 
-return vine\`\` as any as __VLS_VINE_VueVineComponent;
+return vine\`\` as any as __VLS_VINE.VueVineComponent;
 
 } as CustomElementConstructor);
 
 
 // eslint-disable-next-line antfu/top-level-function
 export const AnotherCustomElement = ((
-  props: __VLS_VINE_VineComponentCommonProps & { foo: string },context: {},
+  props: __VLS_VINE.VineComponentCommonProps & { foo: string },context: {},
 ) => {
   
 type AnotherCustomElement_Props = Parameters<typeof AnotherCustomElement>[0];
@@ -91,15 +93,15 @@ vineCustomElement()
   
 // --- Start: Template virtual code
 
-const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
+const __VLS_ctx = __VLS_VINE.CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#19 */SampleCustomElement: /* __LINKED_CODE_RIGHT__#19 */SampleCustomElement,
   /* __LINKED_CODE_LEFT__#20 */AnotherCustomElement: /* __LINKED_CODE_RIGHT__#20 */AnotherCustomElement,
   /* __LINKED_CODE_LEFT__#17 */TestCustomElement: /* __LINKED_CODE_RIGHT__#17 */TestCustomElement,
   ...props,
 });
 const __VLS_localComponents = __VLS_ctx;
-type __VLS_LocalComponents = __VLS_VINE_OmitAny<typeof __VLS_localComponents>;
-type __VLS_LocalDirectives = __VLS_VINE_OmitAny<typeof __VLS_ctx>;
+type __VLS_LocalComponents = __VLS_VINE.OmitAny<typeof __VLS_localComponents>;
+type __VLS_LocalDirectives = __VLS_VINE.OmitAny<typeof __VLS_ctx>;
 let __VLS_directives!: __VLS_LocalDirectives & __VLS_GlobalDirectives;
 const __VLS_components = {
   ...{} as __VLS_GlobalComponents,
@@ -123,7 +125,7 @@ $el: __VLS_RootEl;
 
 // --- End: Template virtual code
 
-return vine\`\` as any as __VLS_VINE_VueVineComponent;
+return vine\`\` as any as __VLS_VINE.VueVineComponent;
 
 } as CustomElementConstructor);
 
@@ -131,7 +133,7 @@ type __VLS_VINE_TestCustomElement_props__ = {}
 
 
 export function TestCustomElement(
-  props: __VLS_VINE_VineComponentCommonProps & __VLS_VINE_TestCustomElement_props__,
+  props: __VLS_VINE.VineComponentCommonProps & __VLS_VINE_TestCustomElement_props__,
 context: {}) {
   
 type TestCustomElement_Props = Parameters<typeof TestCustomElement>[0];
@@ -142,7 +144,7 @@ customElements.define('vi-sample-custom-element', SampleCustomElement)
   
 // --- Start: Template virtual code
 
-const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
+const __VLS_ctx = __VLS_VINE.CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#21 */ViSampleCustomElement: /* __LINKED_CODE_RIGHT__#21 */ViSampleCustomElement,
   /* __LINKED_CODE_LEFT__#22 */ViAnotherCustomElement: /* __LINKED_CODE_RIGHT__#22 */ViAnotherCustomElement,
   /* __LINKED_CODE_LEFT__#19 */SampleCustomElement: /* __LINKED_CODE_RIGHT__#19 */SampleCustomElement,
@@ -151,8 +153,8 @@ const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
   /* No props formal params */
 });
 const __VLS_localComponents = __VLS_ctx;
-type __VLS_LocalComponents = __VLS_VINE_OmitAny<typeof __VLS_localComponents>;
-type __VLS_LocalDirectives = __VLS_VINE_OmitAny<typeof __VLS_ctx>;
+type __VLS_LocalComponents = __VLS_VINE.OmitAny<typeof __VLS_localComponents>;
+type __VLS_LocalDirectives = __VLS_VINE.OmitAny<typeof __VLS_ctx>;
 let __VLS_directives!: __VLS_LocalDirectives & __VLS_GlobalDirectives;
 const __VLS_components = {
   ...{} as __VLS_GlobalComponents,
@@ -200,7 +202,7 @@ $el: __VLS_RootEl;
 
 // --- End: Template virtual code
 
-return vine\`\` as any as __VLS_VINE_VueVineComponent;
+return vine\`\` as any as __VLS_VINE.VueVineComponent;
 
 }
 
@@ -217,6 +219,8 @@ const __VLS_IntrinsicElements = {} as __VLS_IntrinsicElements;"
 
 exports[`verify Volar virtual code snapshots > key-cases.vine.ts 1`] = `
 "/// <reference types="../../../../node_modules/.vue-global-types/vine_vue_99_true.d.ts" />
+import * as __VLS_VINE from 'vue-vine/internals';
+
 import type { Directive } from 'vue'
 import { onMounted, ref, useTemplateRef, watchEffect } from 'vue'
 
@@ -229,7 +233,7 @@ type __VLS_VINE_Comp_props__ = {
 /* __LINKED_CODE_LEFT__#3 */foo: string
 }
 function Comp(
-  props: __VLS_VINE_VineComponentCommonProps & __VLS_VINE_Comp_props__,
+  props: __VLS_VINE.VineComponentCommonProps & __VLS_VINE_Comp_props__,
 context: {}) {
   
 type Comp_Props = Parameters<typeof Comp>[0];
@@ -239,7 +243,7 @@ const /* __LINKED_CODE_RIGHT__#3 */foo = vineProp<string>()
   
 // --- Start: Template virtual code
 
-const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
+const __VLS_ctx = __VLS_VINE.CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#3 */foo: /* __LINKED_CODE_RIGHT__#3 */foo,
   /* __LINKED_CODE_LEFT__#9 */onMounted: /* __LINKED_CODE_RIGHT__#9 */onMounted,
   /* __LINKED_CODE_LEFT__#3 */ref: /* __LINKED_CODE_RIGHT__#3 */ref,
@@ -262,8 +266,8 @@ const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
   /* No props formal params */
 });
 const __VLS_localComponents = __VLS_ctx;
-type __VLS_LocalComponents = __VLS_VINE_OmitAny<typeof __VLS_localComponents>;
-type __VLS_LocalDirectives = __VLS_VINE_OmitAny<typeof __VLS_ctx>;
+type __VLS_LocalComponents = __VLS_VINE.OmitAny<typeof __VLS_localComponents>;
+type __VLS_LocalDirectives = __VLS_VINE.OmitAny<typeof __VLS_ctx>;
 let __VLS_directives!: __VLS_LocalDirectives & __VLS_GlobalDirectives;
 const __VLS_components = {
   ...{} as __VLS_GlobalComponents,
@@ -290,7 +294,7 @@ $el: __VLS_RootEl;
 
 // --- End: Template virtual code
 
-return vine\`\` as any as __VLS_VINE_VueVineComponent;
+return vine\`\` as any as __VLS_VINE.VueVineComponent;
 
 }
 type __VLS_VINE_SampleOne_props__ = {
@@ -302,7 +306,7 @@ type __VLS_VINE_SampleOne_props__ = {
 // - Case 1: 'vue-vine/format-vine-macros-leading'
 // - Case 2: 'vue-vine/essentials-no-child-content'
 export function SampleOne(
-  props: __VLS_VINE_VineComponentCommonProps & __VLS_VINE_SampleOne_props__,
+  props: __VLS_VINE.VineComponentCommonProps & __VLS_VINE_SampleOne_props__,
 context: {}) {
   
 type SampleOne_Props = Parameters<typeof SampleOne>[0];
@@ -318,7 +322,7 @@ const count = ref(0)
   
 // --- Start: Template virtual code
 
-const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
+const __VLS_ctx = __VLS_VINE.CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#4 */Comp: /* __LINKED_CODE_RIGHT__#4 */Comp,
   /* __LINKED_CODE_LEFT__#2 */p1: /* __LINKED_CODE_RIGHT__#2 */p1,
   /* __LINKED_CODE_LEFT__#5 */count: /* __LINKED_CODE_RIGHT__#5 */count,
@@ -343,8 +347,8 @@ const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
   /* No props formal params */
 });
 const __VLS_localComponents = __VLS_ctx;
-type __VLS_LocalComponents = __VLS_VINE_OmitAny<typeof __VLS_localComponents>;
-type __VLS_LocalDirectives = __VLS_VINE_OmitAny<typeof __VLS_ctx>;
+type __VLS_LocalComponents = __VLS_VINE.OmitAny<typeof __VLS_localComponents>;
+type __VLS_LocalDirectives = __VLS_VINE.OmitAny<typeof __VLS_ctx>;
 let __VLS_directives!: __VLS_LocalDirectives & __VLS_GlobalDirectives;
 const __VLS_components = {
   ...{} as __VLS_GlobalComponents,
@@ -392,7 +396,7 @@ $el: __VLS_RootEl;
 
 // --- End: Template virtual code
 
-return vine\`\` as any as __VLS_VINE_VueVineComponent;
+return vine\`\` as any as __VLS_VINE.VueVineComponent;
 
 }
 type __VLS_VINE_SampleTwo_props__ = {}
@@ -401,7 +405,7 @@ type __VLS_VINE_SampleTwo_props__ = {}
 // - Case 1: 'vue-vine/format-prefer-template' with autofix in setup
 // - Case 2: 'vue-vine/format-prefer-template' not autofix in template
 export function SampleTwo(
-  props: __VLS_VINE_VineComponentCommonProps & __VLS_VINE_SampleTwo_props__,
+  props: __VLS_VINE.VineComponentCommonProps & __VLS_VINE_SampleTwo_props__,
 context: {}) {
   
 type SampleTwo_Props = Parameters<typeof SampleTwo>[0];
@@ -412,7 +416,7 @@ let count = ref('0x' + Foo + 'CAFE')
   
 // --- Start: Template virtual code
 
-const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
+const __VLS_ctx = __VLS_VINE.CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#5 */count: /* __LINKED_CODE_RIGHT__#5 */count,
   /* __LINKED_CODE_LEFT__#4 */type: /* __LINKED_CODE_RIGHT__#4 */type,
   /* __LINKED_CODE_LEFT__#9 */onMounted: /* __LINKED_CODE_RIGHT__#9 */onMounted,
@@ -436,8 +440,8 @@ const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
   /* No props formal params */
 });
 const __VLS_localComponents = __VLS_ctx;
-type __VLS_LocalComponents = __VLS_VINE_OmitAny<typeof __VLS_localComponents>;
-type __VLS_LocalDirectives = __VLS_VINE_OmitAny<typeof __VLS_ctx>;
+type __VLS_LocalComponents = __VLS_VINE.OmitAny<typeof __VLS_localComponents>;
+type __VLS_LocalDirectives = __VLS_VINE.OmitAny<typeof __VLS_ctx>;
 let __VLS_directives!: __VLS_LocalDirectives & __VLS_GlobalDirectives;
 const __VLS_components = {
   ...{} as __VLS_GlobalComponents,
@@ -470,14 +474,14 @@ $el: __VLS_RootEl;
 
 // --- End: Template virtual code
 
-return vine\`\` as any as __VLS_VINE_VueVineComponent;
+return vine\`\` as any as __VLS_VINE.VueVineComponent;
 
 }
 type __VLS_VINE_TestPlainTextTemplate_props__ = {}
 
 
 export function TestPlainTextTemplate(
-  props: __VLS_VINE_VineComponentCommonProps & __VLS_VINE_TestPlainTextTemplate_props__,
+  props: __VLS_VINE.VineComponentCommonProps & __VLS_VINE_TestPlainTextTemplate_props__,
 context: {}) {
   
 type TestPlainTextTemplate_Props = Parameters<typeof TestPlainTextTemplate>[0];
@@ -486,7 +490,7 @@ type TestPlainTextTemplate_Props = Parameters<typeof TestPlainTextTemplate>[0];
   
 // --- Start: Template virtual code
 
-const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
+const __VLS_ctx = __VLS_VINE.CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#9 */onMounted: /* __LINKED_CODE_RIGHT__#9 */onMounted,
   /* __LINKED_CODE_LEFT__#3 */ref: /* __LINKED_CODE_RIGHT__#3 */ref,
   /* __LINKED_CODE_LEFT__#14 */useTemplateRef: /* __LINKED_CODE_RIGHT__#14 */useTemplateRef,
@@ -508,8 +512,8 @@ const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
   /* No props formal params */
 });
 const __VLS_localComponents = __VLS_ctx;
-type __VLS_LocalComponents = __VLS_VINE_OmitAny<typeof __VLS_localComponents>;
-type __VLS_LocalDirectives = __VLS_VINE_OmitAny<typeof __VLS_ctx>;
+type __VLS_LocalComponents = __VLS_VINE.OmitAny<typeof __VLS_localComponents>;
+type __VLS_LocalDirectives = __VLS_VINE.OmitAny<typeof __VLS_ctx>;
 let __VLS_directives!: __VLS_LocalDirectives & __VLS_GlobalDirectives;
 const __VLS_components = {
   ...{} as __VLS_GlobalComponents,
@@ -530,7 +534,7 @@ $el: __VLS_RootEl;
 
 // --- End: Template virtual code
 
-return vine\`\` as any as __VLS_VINE_VueVineComponent;
+return vine\`\` as any as __VLS_VINE.VueVineComponent;
 
 }
 type __VLS_VINE_TestUnoCssAttributeMode_props__ = {}
@@ -545,7 +549,7 @@ type __VLS_VINE_TestUnoCssAttributeMode_props__ = {}
   }
  */
 export function TestUnoCssAttributeMode(
-  props: __VLS_VINE_VineComponentCommonProps & __VLS_VINE_TestUnoCssAttributeMode_props__,
+  props: __VLS_VINE.VineComponentCommonProps & __VLS_VINE_TestUnoCssAttributeMode_props__,
 context: {}) {
   
 type TestUnoCssAttributeMode_Props = Parameters<typeof TestUnoCssAttributeMode>[0];
@@ -559,7 +563,7 @@ const vBounce: Directive<HTMLElement> = {
   
 // --- Start: Template virtual code
 
-const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
+const __VLS_ctx = __VLS_VINE.CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#7 */vBounce: /* __LINKED_CODE_RIGHT__#7 */vBounce,
   /* __LINKED_CODE_LEFT__#9 */onMounted: /* __LINKED_CODE_RIGHT__#9 */onMounted,
   /* __LINKED_CODE_LEFT__#3 */ref: /* __LINKED_CODE_RIGHT__#3 */ref,
@@ -582,8 +586,8 @@ const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
   /* No props formal params */
 });
 const __VLS_localComponents = __VLS_ctx;
-type __VLS_LocalComponents = __VLS_VINE_OmitAny<typeof __VLS_localComponents>;
-type __VLS_LocalDirectives = __VLS_VINE_OmitAny<typeof __VLS_ctx>;
+type __VLS_LocalComponents = __VLS_VINE.OmitAny<typeof __VLS_localComponents>;
+type __VLS_LocalDirectives = __VLS_VINE.OmitAny<typeof __VLS_ctx>;
 let __VLS_directives!: __VLS_LocalDirectives & __VLS_GlobalDirectives;
 const __VLS_components = {
   ...{} as __VLS_GlobalComponents,
@@ -613,7 +617,7 @@ $el: __VLS_RootEl;
 
 // --- End: Template virtual code
 
-return vine\`\` as any as __VLS_VINE_VueVineComponent;
+return vine\`\` as any as __VLS_VINE.VueVineComponent;
 
 }
 type __VLS_VINE_TestCompOne_props__ = {
@@ -623,7 +627,7 @@ type __VLS_VINE_TestCompOne_props__ = {
 /* __LINKED_CODE_LEFT__#3 */foo?: number
 }
 
-type __VLS_VINE_TestCompOne_emits__ = __VLS_NormalizeEmits<__VLS_VINE_VueDefineEmits<{
+type __VLS_VINE_TestCompOne_emits__ = __VLS_NormalizeEmits<__VLS_VINE.VueDefineEmits<{
     'click:comp-one': [boolean]
   }>>;
 
@@ -632,8 +636,8 @@ type __VLS_VINE_TestCompOne_emits__ = __VLS_NormalizeEmits<__VLS_VINE_VueDefineE
 
 // #region Fixtures for testing component reference & props check in VSCode
 export function TestCompOne(
-  props: __VLS_VINE_VineComponentCommonProps & __VLS_VINE_TestCompOne_props__  & {
-    /* __LINKED_CODE_LEFT__#16 */'onClick:comp-one': __VLS_VINE_TestCompOne_emits__['click:comp-one']
+  props: __VLS_VINE.VineComponentCommonProps & __VLS_VINE_TestCompOne_props__  & {
+    /* __LINKED_CODE_LEFT__#16 */'onClick:comp-one': __VLS_VINE.TestCompOne_emits__['click:comp-one']
 },
 context: {}) {
   
@@ -650,7 +654,7 @@ type TestCompOne_Props = Parameters<typeof TestCompOne>[0];
   
 // --- Start: Template virtual code
 
-const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
+const __VLS_ctx = __VLS_VINE.CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#3 */zee: /* __LINKED_CODE_RIGHT__#3 */zee,
   /* __LINKED_CODE_LEFT__#3 */foo: /* __LINKED_CODE_RIGHT__#3 */foo,
   /* __LINKED_CODE_LEFT__#5 */emits: /* __LINKED_CODE_RIGHT__#5 */emits,
@@ -675,8 +679,8 @@ const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
   /* No props formal params */
 });
 const __VLS_localComponents = __VLS_ctx;
-type __VLS_LocalComponents = __VLS_VINE_OmitAny<typeof __VLS_localComponents>;
-type __VLS_LocalDirectives = __VLS_VINE_OmitAny<typeof __VLS_ctx>;
+type __VLS_LocalComponents = __VLS_VINE.OmitAny<typeof __VLS_localComponents>;
+type __VLS_LocalDirectives = __VLS_VINE.OmitAny<typeof __VLS_ctx>;
 let __VLS_directives!: __VLS_LocalDirectives & __VLS_GlobalDirectives;
 const __VLS_components = {
   ...{} as __VLS_GlobalComponents,
@@ -709,14 +713,14 @@ $el: __VLS_RootEl;
 
 // --- End: Template virtual code
 
-return vine\`\` as any as __VLS_VINE_VueVineComponent;
+return vine\`\` as any as __VLS_VINE.VueVineComponent;
 
 }
 type __VLS_VINE_TestCompTwo_props__ = {}
 
 
 function TestCompTwo(
-  props: __VLS_VINE_VineComponentCommonProps & __VLS_VINE_TestCompTwo_props__,
+  props: __VLS_VINE.VineComponentCommonProps & __VLS_VINE_TestCompTwo_props__,
 context: {}) {
   
 type TestCompTwo_Props = Parameters<typeof TestCompTwo>[0];
@@ -726,7 +730,7 @@ const bar = ref('123')
   
 // --- Start: Template virtual code
 
-const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
+const __VLS_ctx = __VLS_VINE.CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#11 */UnknownComp: /* __LINKED_CODE_RIGHT__#11 */UnknownComp,
   /* __LINKED_CODE_LEFT__#11 */TestCompOne: /* __LINKED_CODE_RIGHT__#11 */TestCompOne,
   /* __LINKED_CODE_LEFT__#3 */bar: /* __LINKED_CODE_RIGHT__#3 */bar,
@@ -750,8 +754,8 @@ const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
   /* No props formal params */
 });
 const __VLS_localComponents = __VLS_ctx;
-type __VLS_LocalComponents = __VLS_VINE_OmitAny<typeof __VLS_localComponents>;
-type __VLS_LocalDirectives = __VLS_VINE_OmitAny<typeof __VLS_ctx>;
+type __VLS_LocalComponents = __VLS_VINE.OmitAny<typeof __VLS_localComponents>;
+type __VLS_LocalDirectives = __VLS_VINE.OmitAny<typeof __VLS_ctx>;
 let __VLS_directives!: __VLS_LocalDirectives & __VLS_GlobalDirectives;
 const __VLS_components = {
   ...{} as __VLS_GlobalComponents,
@@ -795,16 +799,16 @@ $el: __VLS_RootEl;
 
 // --- End: Template virtual code
 
-return vine\`\` as any as __VLS_VINE_VueVineComponent;
+return vine\`\` as any as __VLS_VINE.VueVineComponent;
 
 }
 // #endregion
 
 // #region Test vineExpose and component ref
-function TargetComp(props: __VLS_VINE_VineComponentCommonProps & {
+function TargetComp(props: __VLS_VINE.VineComponentCommonProps & {
   foo: boolean
 },context: {
-  expose: __VLS_VINE_PickComponentExpose<typeof TargetComp>,
+  expose: __VLS_VINE.PickComponentExpose<typeof TargetComp>,
 }) {
   
 type TargetComp_Props = Parameters<typeof TargetComp>[0];
@@ -826,7 +830,7 @@ vineExpose(__VLS_VINE_ComponentExpose__)
   
 // --- Start: Template virtual code
 
-const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
+const __VLS_ctx = __VLS_VINE.CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#11 */TestCompOne: /* __LINKED_CODE_RIGHT__#11 */TestCompOne,
   /* __LINKED_CODE_LEFT__#5 */count: /* __LINKED_CODE_RIGHT__#5 */count,
   /* __LINKED_CODE_LEFT__#14 */onClickCompOne: /* __LINKED_CODE_RIGHT__#14 */onClickCompOne,
@@ -850,8 +854,8 @@ const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
   ...props,
 });
 const __VLS_localComponents = __VLS_ctx;
-type __VLS_LocalComponents = __VLS_VINE_OmitAny<typeof __VLS_localComponents>;
-type __VLS_LocalDirectives = __VLS_VINE_OmitAny<typeof __VLS_ctx>;
+type __VLS_LocalComponents = __VLS_VINE.OmitAny<typeof __VLS_localComponents>;
+type __VLS_LocalDirectives = __VLS_VINE.OmitAny<typeof __VLS_ctx>;
 let __VLS_directives!: __VLS_LocalDirectives & __VLS_GlobalDirectives;
 const __VLS_components = {
   ...{} as __VLS_GlobalComponents,
@@ -907,14 +911,14 @@ $el: __VLS_RootEl;
 
 // --- End: Template virtual code
 
-return vine\`\` as any as __VLS_VINE_VueVineComponent & { exposed: (import('vue').ShallowUnwrapRef<typeof __VLS_VINE_ComponentExpose__>) };
+return vine\`\` as any as __VLS_VINE.VueVineComponent & { exposed: (import('vue').ShallowUnwrapRef<typeof __VLS_VINE_ComponentExpose__>) };
 
 }
 type __VLS_VINE_TestCompRef_props__ = {}
 
 
 export function TestCompRef(
-  props: __VLS_VINE_VineComponentCommonProps & __VLS_VINE_TestCompRef_props__,
+  props: __VLS_VINE.VineComponentCommonProps & __VLS_VINE_TestCompRef_props__,
 context: {}) {
   
 type TestCompRef_Props = Parameters<typeof TestCompRef>[0];
@@ -926,7 +930,7 @@ const target = useTemplateRef<__VLS_TemplateRefs['target'], keyof __VLS_Template
   
 // --- Start: Template virtual code
 
-const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
+const __VLS_ctx = __VLS_VINE.CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#10 */TargetComp: /* __LINKED_CODE_RIGHT__#10 */TargetComp,
   /* __LINKED_CODE_LEFT__#9 */onMounted: /* __LINKED_CODE_RIGHT__#9 */onMounted,
   /* __LINKED_CODE_LEFT__#3 */ref: /* __LINKED_CODE_RIGHT__#3 */ref,
@@ -948,8 +952,8 @@ const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
   /* No props formal params */
 });
 const __VLS_localComponents = __VLS_ctx;
-type __VLS_LocalComponents = __VLS_VINE_OmitAny<typeof __VLS_localComponents>;
-type __VLS_LocalDirectives = __VLS_VINE_OmitAny<typeof __VLS_ctx>;
+type __VLS_LocalComponents = __VLS_VINE.OmitAny<typeof __VLS_localComponents>;
+type __VLS_LocalDirectives = __VLS_VINE.OmitAny<typeof __VLS_ctx>;
 let __VLS_directives!: __VLS_LocalDirectives & __VLS_GlobalDirectives;
 const __VLS_components = {
   ...{} as __VLS_GlobalComponents,
@@ -992,7 +996,7 @@ $el: __VLS_RootEl;
 
 // --- End: Template virtual code
 
-return vine\`\` as any as __VLS_VINE_VueVineComponent;
+return vine\`\` as any as __VLS_VINE.VueVineComponent;
 
 }
 type __VLS_VINE_TestNoVforKeyOnChild_props__ = {}
@@ -1001,7 +1005,7 @@ type __VLS_VINE_TestNoVforKeyOnChild_props__ = {}
 
 // #region Test ESLint rule: no-v-for-key-on-child
 export function TestNoVforKeyOnChild(
-  props: __VLS_VINE_VineComponentCommonProps & __VLS_VINE_TestNoVforKeyOnChild_props__,
+  props: __VLS_VINE.VineComponentCommonProps & __VLS_VINE_TestNoVforKeyOnChild_props__,
 context: {}) {
   
 type TestNoVforKeyOnChild_Props = Parameters<typeof TestNoVforKeyOnChild>[0];
@@ -1011,7 +1015,7 @@ interface User { id: string, name: string }
   
 // --- Start: Template virtual code
 
-const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
+const __VLS_ctx = __VLS_VINE.CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#5 */users: /* __LINKED_CODE_RIGHT__#5 */users,
   /* __LINKED_CODE_LEFT__#9 */onMounted: /* __LINKED_CODE_RIGHT__#9 */onMounted,
   /* __LINKED_CODE_LEFT__#3 */ref: /* __LINKED_CODE_RIGHT__#3 */ref,
@@ -1034,8 +1038,8 @@ const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
   /* No props formal params */
 });
 const __VLS_localComponents = __VLS_ctx;
-type __VLS_LocalComponents = __VLS_VINE_OmitAny<typeof __VLS_localComponents>;
-type __VLS_LocalDirectives = __VLS_VINE_OmitAny<typeof __VLS_ctx>;
+type __VLS_LocalComponents = __VLS_VINE.OmitAny<typeof __VLS_localComponents>;
+type __VLS_LocalDirectives = __VLS_VINE.OmitAny<typeof __VLS_ctx>;
 let __VLS_directives!: __VLS_LocalDirectives & __VLS_GlobalDirectives;
 const __VLS_components = {
   ...{} as __VLS_GlobalComponents,
@@ -1069,7 +1073,7 @@ $el: __VLS_RootEl;
 
 // --- End: Template virtual code
 
-return vine\`\` as any as __VLS_VINE_VueVineComponent;
+return vine\`\` as any as __VLS_VINE.VueVineComponent;
 
 }
 type __VLS_VINE_TestNoLifecycleHookAfterAwait_props__ = {}
@@ -1079,7 +1083,7 @@ type __VLS_VINE_TestNoLifecycleHookAfterAwait_props__ = {}
 // #region Test ESLint rule: no-lifecycle-hook-after-await
 declare const doSomethingAsync: () => Promise<void>
 export async function TestNoLifecycleHookAfterAwait(
-  props: __VLS_VINE_VineComponentCommonProps & __VLS_VINE_TestNoLifecycleHookAfterAwait_props__,
+  props: __VLS_VINE.VineComponentCommonProps & __VLS_VINE_TestNoLifecycleHookAfterAwait_props__,
 context: {}) {
   
 type TestNoLifecycleHookAfterAwait_Props = Parameters<typeof TestNoLifecycleHookAfterAwait>[0];
@@ -1093,7 +1097,7 @@ await doSomethingAsync()
   
 // --- Start: Template virtual code
 
-const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
+const __VLS_ctx = __VLS_VINE.CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#9 */onMounted: /* __LINKED_CODE_RIGHT__#9 */onMounted,
   /* __LINKED_CODE_LEFT__#3 */ref: /* __LINKED_CODE_RIGHT__#3 */ref,
   /* __LINKED_CODE_LEFT__#14 */useTemplateRef: /* __LINKED_CODE_RIGHT__#14 */useTemplateRef,
@@ -1115,8 +1119,8 @@ const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
   /* No props formal params */
 });
 const __VLS_localComponents = __VLS_ctx;
-type __VLS_LocalComponents = __VLS_VINE_OmitAny<typeof __VLS_localComponents>;
-type __VLS_LocalDirectives = __VLS_VINE_OmitAny<typeof __VLS_ctx>;
+type __VLS_LocalComponents = __VLS_VINE.OmitAny<typeof __VLS_localComponents>;
+type __VLS_LocalDirectives = __VLS_VINE.OmitAny<typeof __VLS_ctx>;
 let __VLS_directives!: __VLS_LocalDirectives & __VLS_GlobalDirectives;
 const __VLS_components = {
   ...{} as __VLS_GlobalComponents,
@@ -1140,7 +1144,7 @@ $el: __VLS_RootEl;
 
 // --- End: Template virtual code
 
-return vine\`\` as any as __VLS_VINE_VueVineComponent;
+return vine\`\` as any as __VLS_VINE.VueVineComponent;
 
 }
 // #endregion
@@ -1148,7 +1152,7 @@ return vine\`\` as any as __VLS_VINE_VueVineComponent;
 // #region Test generics on Vine component function
 
 export function TestGenericComp1<T extends keyof HTMLElementTagNameMap = 'h1'>(
-  props: __VLS_VINE_VineComponentCommonProps & Partial<HTMLElementTagNameMap[T]> & { as: T },context: {},
+  props: __VLS_VINE.VineComponentCommonProps & Partial<HTMLElementTagNameMap[T]> & { as: T },context: {},
 ) {
   
 type TestGenericComp1_Props = Parameters<typeof TestGenericComp1>[0];
@@ -1156,7 +1160,7 @@ type TestGenericComp1_Props = Parameters<typeof TestGenericComp1>[0];
 
 // --- Start: Template virtual code
 
-const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
+const __VLS_ctx = __VLS_VINE.CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#9 */component: /* __LINKED_CODE_RIGHT__#9 */component,
   /* __LINKED_CODE_LEFT__#9 */onMounted: /* __LINKED_CODE_RIGHT__#9 */onMounted,
   /* __LINKED_CODE_LEFT__#3 */ref: /* __LINKED_CODE_RIGHT__#3 */ref,
@@ -1179,8 +1183,8 @@ const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
   ...props,
 });
 const __VLS_localComponents = __VLS_ctx;
-type __VLS_LocalComponents = __VLS_VINE_OmitAny<typeof __VLS_localComponents>;
-type __VLS_LocalDirectives = __VLS_VINE_OmitAny<typeof __VLS_ctx>;
+type __VLS_LocalComponents = __VLS_VINE.OmitAny<typeof __VLS_localComponents>;
+type __VLS_LocalDirectives = __VLS_VINE.OmitAny<typeof __VLS_ctx>;
 let __VLS_directives!: __VLS_LocalDirectives & __VLS_GlobalDirectives;
 const __VLS_components = {
   ...{} as __VLS_GlobalComponents,
@@ -1212,7 +1216,7 @@ $el: __VLS_RootEl;
 
 // --- End: Template virtual code
 
-return vine\`\` as any as __VLS_VINE_VueVineComponent;
+return vine\`\` as any as __VLS_VINE.VueVineComponent;
 
 }
 
@@ -1240,12 +1244,14 @@ const __VLS_IntrinsicElements = {} as __VLS_IntrinsicElements;"
 
 exports[`verify Volar virtual code snapshots > use-template-ref-virtual-code.vine.ts 1`] = `
 "/// <reference types="../../../../node_modules/.vue-global-types/vine_vue_99_true.d.ts" />
+import * as __VLS_VINE from 'vue-vine/internals';
+
 import { useTemplateRef } from 'vue'
 
 
 type __VLS_VINE_TestUseTemplateRefVirtualCode_props__ = {}
 export function TestUseTemplateRefVirtualCode(
-  props: __VLS_VINE_VineComponentCommonProps & __VLS_VINE_TestUseTemplateRefVirtualCode_props__,
+  props: __VLS_VINE.VineComponentCommonProps & __VLS_VINE_TestUseTemplateRefVirtualCode_props__,
 context: {}) {
   
 type TestUseTemplateRefVirtualCode_Props = Parameters<typeof TestUseTemplateRefVirtualCode>[0];
@@ -1261,14 +1267,14 @@ const container1Ref = useTemplateRef<__VLS_TemplateRefs['container1Ref'], keyof 
   
 // --- Start: Template virtual code
 
-const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
+const __VLS_ctx = __VLS_VINE.CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#14 */useTemplateRef: /* __LINKED_CODE_RIGHT__#14 */useTemplateRef,
   /* __LINKED_CODE_LEFT__#29 */TestUseTemplateRefVirtualCode: /* __LINKED_CODE_RIGHT__#29 */TestUseTemplateRefVirtualCode,
   /* No props formal params */
 });
 const __VLS_localComponents = __VLS_ctx;
-type __VLS_LocalComponents = __VLS_VINE_OmitAny<typeof __VLS_localComponents>;
-type __VLS_LocalDirectives = __VLS_VINE_OmitAny<typeof __VLS_ctx>;
+type __VLS_LocalComponents = __VLS_VINE.OmitAny<typeof __VLS_localComponents>;
+type __VLS_LocalDirectives = __VLS_VINE.OmitAny<typeof __VLS_ctx>;
 let __VLS_directives!: __VLS_LocalDirectives & __VLS_GlobalDirectives;
 const __VLS_components = {
   ...{} as __VLS_GlobalComponents,
@@ -1299,7 +1305,7 @@ $el: __VLS_RootEl;
 
 // --- End: Template virtual code
 
-return vine\`\` as any as __VLS_VINE_VueVineComponent;
+return vine\`\` as any as __VLS_VINE.VueVineComponent;
 
 }
 
@@ -1312,13 +1318,15 @@ const __VLS_IntrinsicElements = {} as __VLS_IntrinsicElements;"
 
 exports[`verify Volar virtual code snapshots > vine-model.vine.ts 1`] = `
 "/// <reference types="../../../../node_modules/.vue-global-types/vine_vue_99_true.d.ts" />
+import * as __VLS_VINE from 'vue-vine/internals';
+
 import { ref } from 'vue'
 import '../styles/atom.css'
 
 
 type __VLS_VINE_SimpleInput_props__ = {}
 export function SimpleInput(
-  props: __VLS_VINE_VineComponentCommonProps & __VLS_VINE_SimpleInput_props__  & {
+  props: __VLS_VINE.VineComponentCommonProps & __VLS_VINE_SimpleInput_props__  & {
     modelValue: unknown
 },
 context: {}) {
@@ -1330,7 +1338,7 @@ const value = vineModel()
   
 // --- Start: Template virtual code
 
-const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
+const __VLS_ctx = __VLS_VINE.CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#5 */value: /* __LINKED_CODE_RIGHT__#5 */value,
   /* __LINKED_CODE_LEFT__#3 */ref: /* __LINKED_CODE_RIGHT__#3 */ref,
   /* __LINKED_CODE_LEFT__#11 */SimpleInput: /* __LINKED_CODE_RIGHT__#11 */SimpleInput,
@@ -1339,8 +1347,8 @@ const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
   /* No props formal params */
 });
 const __VLS_localComponents = __VLS_ctx;
-type __VLS_LocalComponents = __VLS_VINE_OmitAny<typeof __VLS_localComponents>;
-type __VLS_LocalDirectives = __VLS_VINE_OmitAny<typeof __VLS_ctx>;
+type __VLS_LocalComponents = __VLS_VINE.OmitAny<typeof __VLS_localComponents>;
+type __VLS_LocalDirectives = __VLS_VINE.OmitAny<typeof __VLS_ctx>;
 let __VLS_directives!: __VLS_LocalDirectives & __VLS_GlobalDirectives;
 const __VLS_components = {
   ...{} as __VLS_GlobalComponents,
@@ -1373,13 +1381,13 @@ $el: __VLS_RootEl;
 
 // --- End: Template virtual code
 
-return vine\`\` as any as __VLS_VINE_VueVineComponent;
+return vine\`\` as any as __VLS_VINE.VueVineComponent;
 
 }
 type __VLS_VINE_NamedModelInput_props__ = {}
 
 export function NamedModelInput(
-  props: __VLS_VINE_VineComponentCommonProps & __VLS_VINE_NamedModelInput_props__  & {
+  props: __VLS_VINE.VineComponentCommonProps & __VLS_VINE_NamedModelInput_props__  & {
     special: unknown
 },
 context: {}) {
@@ -1391,7 +1399,7 @@ const value = vineModel('special')
   
 // --- Start: Template virtual code
 
-const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
+const __VLS_ctx = __VLS_VINE.CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#5 */value: /* __LINKED_CODE_RIGHT__#5 */value,
   /* __LINKED_CODE_LEFT__#3 */ref: /* __LINKED_CODE_RIGHT__#3 */ref,
   /* __LINKED_CODE_LEFT__#11 */SimpleInput: /* __LINKED_CODE_RIGHT__#11 */SimpleInput,
@@ -1400,8 +1408,8 @@ const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
   /* No props formal params */
 });
 const __VLS_localComponents = __VLS_ctx;
-type __VLS_LocalComponents = __VLS_VINE_OmitAny<typeof __VLS_localComponents>;
-type __VLS_LocalDirectives = __VLS_VINE_OmitAny<typeof __VLS_ctx>;
+type __VLS_LocalComponents = __VLS_VINE.OmitAny<typeof __VLS_localComponents>;
+type __VLS_LocalDirectives = __VLS_VINE.OmitAny<typeof __VLS_ctx>;
 let __VLS_directives!: __VLS_LocalDirectives & __VLS_GlobalDirectives;
 const __VLS_components = {
   ...{} as __VLS_GlobalComponents,
@@ -1434,14 +1442,14 @@ $el: __VLS_RootEl;
 
 // --- End: Template virtual code
 
-return vine\`\` as any as __VLS_VINE_VueVineComponent;
+return vine\`\` as any as __VLS_VINE.VueVineComponent;
 
 }
 type __VLS_VINE_TestVineModel_props__ = {}
 
 
 export function TestVineModel(
-  props: __VLS_VINE_VineComponentCommonProps & __VLS_VINE_TestVineModel_props__,
+  props: __VLS_VINE.VineComponentCommonProps & __VLS_VINE_TestVineModel_props__,
 context: {}) {
   
 type TestVineModel_Props = Parameters<typeof TestVineModel>[0];
@@ -1454,7 +1462,7 @@ const simpleMsg = ref('')
   
 // --- Start: Template virtual code
 
-const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
+const __VLS_ctx = __VLS_VINE.CreateVineVLSCtx({
   /* __LINKED_CODE_LEFT__#11 */SimpleInput: /* __LINKED_CODE_RIGHT__#11 */SimpleInput,
   /* __LINKED_CODE_LEFT__#15 */NamedModelInput: /* __LINKED_CODE_RIGHT__#15 */NamedModelInput,
   /* __LINKED_CODE_LEFT__#9 */simpleMsg: /* __LINKED_CODE_RIGHT__#9 */simpleMsg,
@@ -1464,8 +1472,8 @@ const __VLS_ctx = __VLS_VINE_CreateVineVLSCtx({
   /* No props formal params */
 });
 const __VLS_localComponents = __VLS_ctx;
-type __VLS_LocalComponents = __VLS_VINE_OmitAny<typeof __VLS_localComponents>;
-type __VLS_LocalDirectives = __VLS_VINE_OmitAny<typeof __VLS_ctx>;
+type __VLS_LocalComponents = __VLS_VINE.OmitAny<typeof __VLS_localComponents>;
+type __VLS_LocalDirectives = __VLS_VINE.OmitAny<typeof __VLS_ctx>;
 let __VLS_directives!: __VLS_LocalDirectives & __VLS_GlobalDirectives;
 const __VLS_components = {
   ...{} as __VLS_GlobalComponents,
@@ -1560,7 +1568,7 @@ $el: __VLS_RootEl;
 
 // --- End: Template virtual code
 
-return vine\`\` as any as __VLS_VINE_VueVineComponent;
+return vine\`\` as any as __VLS_VINE.VueVineComponent;
 
 }
 

--- a/packages/language-service/typescript-plugin/proxy-ts-lang-service.ts
+++ b/packages/language-service/typescript-plugin/proxy-ts-lang-service.ts
@@ -34,18 +34,22 @@ export function proxyLanguageServiceForVine(
 const hiddenCompletions = [
   'VUE_VINE_COMPONENT',
 ]
+const hiddenModules = [
+  'vue-vine/internals',
+]
 function vineGetCompletionsAtPosition(
   originalGetCompletionsAtPosition: ts.LanguageService['getCompletionsAtPosition'],
 ): ts.LanguageService['getCompletionsAtPosition'] {
   return (fileName, position, options, formattingSettings) => {
     const result = originalGetCompletionsAtPosition(fileName, position, options, formattingSettings)
     if (result) {
-      // Filter all `__VLS_` items
+      // Filter all `__VLS_` items and internal modules
       result.entries = result.entries.filter(
-        entry => (
-          !entry.name.includes('__VLS_')
-          && !entry.labelDetails?.description?.includes('__VLS_')
-          && !hiddenCompletions.includes(entry.name)
+        entry => !(
+          entry.name.includes('__VLS_')
+          || entry.labelDetails?.description?.includes('__VLS_')
+          || hiddenCompletions.includes(entry.name)
+          || hiddenModules.some(mod => entry.source?.includes(mod))
         ),
       )
     }

--- a/packages/vue-vine/package.json
+++ b/packages/vue-vine/package.json
@@ -24,6 +24,9 @@
     "./macros": {
       "types": "./types/macros.d.ts"
     },
+    "./internals": {
+      "types": "./types/internals.d.ts"
+    },
     "./rspack": {
       "vine": "./src/rspack/index.ts",
       "types": "./dist/rspack.d.ts",

--- a/packages/vue-vine/types/internals.d.ts
+++ b/packages/vue-vine/types/internals.d.ts
@@ -1,0 +1,56 @@
+/**
+ * Internal types for Vue Vine virtual code generation
+ * These types are used by the language service to generate correct TypeScript definitions
+ */
+
+declare const VUE_VINE_COMPONENT: unique symbol
+
+type StrictIsAny<T> = [unknown] extends [T]
+  ? ([T] extends [unknown] ? true : false)
+  : false
+
+type OmitAny<T> = {
+  [K in keyof T as StrictIsAny<T[K]> extends true ? never : K]: T[K]
+}
+
+type MakeVLSCtx<T extends object>
+  = & T
+    & import('vue').ComponentPublicInstance
+
+declare const CreateVineVLSCtx: <T>(ctx: T) => MakeVLSCtx<import('vue').ShallowUnwrapRef<T>>
+
+type VueVineComponent = import('vue/jsx-runtime').JSX.Element & { [VUE_VINE_COMPONENT]: true }
+
+type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never
+
+type RecordToUnion<T extends Record<string, any>> = T[keyof T]
+
+type VueDefineEmits<T extends Record<string, any>> = UnionToIntersection<Exclude<RecordToUnion<{
+  [K in keyof T]: (evt: K, ...args: Exclude<T[K], undefined>) => void;
+}>, undefined>>
+
+type PickComponentExpose<F extends (...args: any[]) => any> = ReturnType<F> extends VueVineComponent & {
+  exposed: infer E
+} ? (exposed: E) => void : never
+
+type VineComponentCommonProps = import('vue').HTMLAttributes & {
+  key?: PropertyKey
+  ref?: string | import('vue').Ref | ((ref: Element | import('vue').ComponentPublicInstance | null, refs: Record<string, any>) => void)
+}
+
+export type {
+  MakeVLSCtx,
+  OmitAny,
+  PickComponentExpose,
+  RecordToUnion,
+  StrictIsAny,
+  UnionToIntersection,
+  VineComponentCommonProps,
+  VueDefineEmits,
+  VueVineComponent,
+}
+
+export {
+  CreateVineVLSCtx,
+  VUE_VINE_COMPONENT,
+}


### PR DESCRIPTION
Close #325 

For generated type declaration in dts files, we should put every referencing type in need into Volar virtual code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added internal type utilities and exports for Vue Vine components to improve language service support.

* **Bug Fixes**
  * Enhanced IDE autocompletion filtering to exclude internal modules from suggestions.

* **Chores**
  * Reorganized internal type system namespace references for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->