### PR TITLE
fix(compiler): handle kebab-case props correctly

### DIFF
--- a/packages/compiler/src/analyze.ts
+++ b/packages/compiler/src/analyze.ts
@@ -429,6 +429,10 @@ const analyzeVineProps: AnalyzeRunner = (
           else if (isAssignmentPattern(property.value)) {
             data.default = property.value.right
             defaultsFromDestructuredProps[propItemName] = property.value.right
+            // Check if there's an alias in the assignment pattern's left side
+            if (isIdentifier(property.value.left) && property.value.left.name !== propItemName) {
+              data.alias = property.value.left.name
+            }
           }
 
           // Why we mark it as `SETUP_REF` instead of `PROPS_ALIASED`?

--- a/packages/compiler/src/transform/steps.ts
+++ b/packages/compiler/src/transform/steps.ts
@@ -307,7 +307,7 @@ export function generateVinePropToRefs(
     )
     const propsFromMacro = Object.entries(vineCompFnCtx.props)
       .filter(([_, meta]) => Boolean(meta.isFromMacroDefine))
-      .map(([propName, _]) => propName)
+      .map(([propName, _]) => identRE.test(propName) ? propName : `'${propName}'`)
     ms.prependLeft(
       firstStmt.start!,
       `const { ${propsFromMacro.join(', ')} } = _toRefs(${vineCompFnCtx.propsAlias});\n`,
@@ -380,10 +380,10 @@ export function generatePropsDestructure(
           acc.push(`...${name}`)
         }
         else if (data.alias) {
-          acc.push(`'${name}': ${data.alias}`)
+          acc.push(`${identRE.test(name) ? name : `'${name}'`}: ${data.alias}`)
         }
         else {
-          acc.push(name)
+          acc.push(identRE.test(name) ? name : `'${name}'`)
         }
         return acc
       }, [] as string[])
@@ -666,7 +666,9 @@ export function generatePropsDeclaration(
     propsDeclarationStmt = `const ${vineCompFnCtx.propsAlias} = _${USE_DEFAULTS_HELPER}(__props, {\n${
       Object.entries(vineCompFnCtx.props)
         .filter(([_, propMeta]) => Boolean(propMeta.default))
-        .map(([propName, propMeta]) => `  ${propName}: () => (${
+        .map(([propName, propMeta]) => `  ${
+          identRE.test(propName) ? propName : `'${propName}'`
+        }: () => (${
           ms.original.slice(
             propMeta.default!.start!,
             propMeta.default!.end!,

--- a/packages/compiler/src/ts-morph/resolve-type.ts
+++ b/packages/compiler/src/ts-morph/resolve-type.ts
@@ -4,6 +4,9 @@ import type { TsMorphCache, VineCompFnCtx, VineCompilerHooks, VinePropMeta } fro
 import { Node } from 'ts-morph'
 import { vineErr } from '../diagnostics'
 
+// Regular expression to test if a string is a valid JavaScript identifier
+const identRE = /^[_$a-z\xA0-\uFFFF][\w$\xA0-\uFFFF]*$/i
+
 function isBooleanType(
   typeChecker: TypeChecker,
   type: Type,
@@ -136,10 +139,14 @@ export function resolveVineCompFnProps(params: {
     const propType = typeChecker.getTypeOfSymbolAtLocation(prop, propsIdentifier)
 
     const propName = prop.getName()
+    // Check if prop name is not a valid identifier (e.g., kebab-case like 'aria-atomic')
+    const nameNeedQuoted = !identRE.test(propName)
+
     propsInfo[propName] = {
       isFromMacroDefine: false,
       isRequired: !prop.isOptional(),
       isMaybeBool: isBooleanType(typeChecker, propType),
+      nameNeedQuoted,
     }
     if (defaultsFromDestructuredProps[propName]) {
       propsInfo[propName].default = defaultsFromDestructuredProps[propName]

--- a/packages/compiler/tests/__snapshots__/transform.spec.ts.snap
+++ b/packages/compiler/tests/__snapshots__/transform.spec.ts.snap
@@ -1653,6 +1653,130 @@ typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
 "
 `;
 
+exports[`test transform > should handle kebab-case props correctly 1`] = `
+"import {
+  defineComponent as _defineComponent,
+  useCssVars as _useCssVars,
+  unref as _unref,
+  createElementVNode as _createElementVNode,
+  normalizeProps as _normalizeProps,
+  guardReactiveProps as _guardReactiveProps,
+  openBlock as _openBlock,
+  createElementBlock as _createElementBlock,
+} from "vue";
+
+export const TestComponent = (() => {
+  const __vine = _defineComponent({
+    name: "TestComponent",
+    props: {
+      "aria-atomic": { required: true, type: Boolean },
+      "aria-busy": { required: true, type: Boolean },
+      "data-test-id": { required: true },
+    },
+    /* No emits */
+    setup(__props, { expose: __expose }) {
+      __expose();
+      const props = __props;
+
+      return (_ctx, _cache) => {
+        return (
+          _openBlock(),
+          _createElementBlock(
+            "div",
+            _normalizeProps(_guardReactiveProps(_ctx.$props)),
+            [
+              ...(_cache[0] ||
+                (_cache[0] = [
+                  _createElementVNode(
+                    "h1",
+                    null,
+                    "Test Component",
+                    -1 /* CACHED */,
+                  ),
+                ])),
+            ],
+            16 /* FULL_PROPS */,
+          )
+        );
+      };
+    },
+  });
+
+  __vine.__vue_vine = true;
+  __vine.__hmrId = "dabfd4e0";
+
+  return __vine;
+})();
+
+typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
+  __VUE_HMR_RUNTIME__.createRecord(TestComponent.__hmrId, TestComponent);
+"
+`;
+
+exports[`test transform > should handle kebab-case props with defaults correctly 1`] = `
+"import { useDefaults as _useDefaults } from "vue-vine";
+import {
+  defineComponent as _defineComponent,
+  useCssVars as _useCssVars,
+  unref as _unref,
+  toRefs as _toRefs,
+  toDisplayString as _toDisplayString,
+  createElementVNode as _createElementVNode,
+  openBlock as _openBlock,
+  createElementBlock as _createElementBlock,
+} from "vue";
+
+export const TestComponent = (() => {
+  const __vine = _defineComponent({
+    name: "TestComponent",
+    props: {
+      "aria-label": {
+        /* Simple prop */
+      },
+      "data-test-id": { required: true },
+    },
+    /* No emits */
+    setup(__props, { expose: __expose }) {
+      __expose();
+      const props = _useDefaults(__props, {
+        "aria-label": () => "default label",
+      });
+      const { "aria-label": ariaLabel, "data-test-id": dataTestId } =
+        _toRefs(props);
+
+      return (_ctx, _cache) => {
+        return (
+          _openBlock(),
+          _createElementBlock("div", null, [
+            _createElementVNode(
+              "span",
+              null,
+              _toDisplayString(_ctx.ariaLabel),
+              1 /* TEXT */,
+            ),
+            _createElementVNode(
+              "span",
+              null,
+              _toDisplayString(_ctx.dataTestId),
+              1 /* TEXT */,
+            ),
+          ])
+        );
+      };
+    },
+  });
+
+  __vine.__vue_vine = true;
+  __vine.__hmrId = "00294b30";
+
+  return __vine;
+})();
+
+typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
+  __VUE_HMR_RUNTIME__.createRecord(TestComponent.__hmrId, TestComponent);
+"
+`;
+
 exports[`test transform > should not export on function delcaration when already exported in somewhere 2`] = `
 "import {
   defineComponent as _defineComponent,

--- a/packages/compiler/tests/transform.spec.ts
+++ b/packages/compiler/tests/transform.spec.ts
@@ -519,4 +519,80 @@ function MyComp() {
     expect(inlineModeResult).toMatchSnapshot()
     expect(separatedModeResult).toMatchSnapshot()
   })
+
+  // issue#327
+  it('should handle kebab-case props correctly', async () => {
+    const { mockCompilerCtx, mockCompilerHooks } = createMockTransformCtx({
+      envMode: 'development',
+    })
+    const specContent = `
+export function TestComponent(props: {
+  'aria-atomic': boolean;
+  'aria-busy': boolean;
+  'data-test-id': string;
+}) {
+  return vine\`
+    <div v-bind="$props">
+      <h1>Test Component</h1>
+    </div>
+  \`
+}
+    `
+
+    compileVineTypeScriptFile(specContent, 'testKebabCaseProps', { compilerHooks: mockCompilerHooks })
+    expect(mockCompilerCtx.vineCompileErrors.length).toBe(0)
+    const fileCtx = mockCompilerCtx.fileCtxMap.get('testKebabCaseProps')
+    const transformed = fileCtx?.fileMagicCode.toString() ?? ''
+    const formated = await format(
+      transformed,
+      { parser: 'babel-ts' },
+    )
+
+    // Check that kebab-case props are quoted in props option
+    expect(formated).toMatch(/"aria-atomic":/)
+    expect(formated).toMatch(/"aria-busy":/)
+    expect(formated).toMatch(/"data-test-id":/)
+    expect(formated).toMatchSnapshot()
+  })
+
+  it('should handle kebab-case props with defaults correctly', async () => {
+    const { mockCompilerCtx, mockCompilerHooks } = createMockTransformCtx({
+      envMode: 'development',
+    })
+    const specContent = `
+export function TestComponent({
+  'aria-label': ariaLabel = 'default label',
+  'data-test-id': dataTestId,
+}: {
+  'aria-label'?: string,
+  'data-test-id': string,
+}) {
+  return vine\`
+    <div>
+      <span>{{ ariaLabel }}</span>
+      <span>{{ dataTestId }}</span>
+    </div>
+  \`
+}
+    `
+
+    compileVineTypeScriptFile(specContent, 'testKebabCasePropsWithDefaults', { compilerHooks: mockCompilerHooks })
+    expect(mockCompilerCtx.vineCompileErrors.length).toBe(0)
+    const fileCtx = mockCompilerCtx.fileCtxMap.get('testKebabCasePropsWithDefaults')
+    const transformed = fileCtx?.fileMagicCode.toString() ?? ''
+    const formated = await format(
+      transformed,
+      { parser: 'babel-ts' },
+    )
+
+    // Check that kebab-case props are quoted in props option
+    expect(formated).toMatch(/"aria-label":/)
+    expect(formated).toMatch(/"data-test-id":/)
+    // Check that useDefaults handles kebab-case props correctly
+    expect(formated).toMatch(/"aria-label":\s*\(\)\s*=>/)
+    // Check that destructuring handles kebab-case props correctly
+    expect(formated).toMatch(/"aria-label":\s*ariaLabel/)
+    expect(formated).toMatch(/"data-test-id":\s*dataTestId/)
+    expect(formated).toMatchSnapshot()
+  })
 })

--- a/scripts/pre-commit.js
+++ b/scripts/pre-commit.js
@@ -3,7 +3,7 @@ import { join } from 'node:path'
 import process from 'node:process'
 import { log } from '@baiwusanyu/utils-log'
 
-const commitRE = /^(?:revert: )?(?:feat|fix|docs|refactor|perf|test|workflow|build|ci|chore|types|wip|release)(?:\(.+\))?!?: .{1,50}/
+const commitRE = /^[a-z]+:\s*.{1,100}$/i
 
 const msgPath = join(import.meta.dirname, '..', '.git', 'COMMIT_EDITMSG')
 
@@ -19,9 +19,15 @@ async function runCommitMsgHook() {
     log('error', `
 Error: Commit message format does not meet the requirements.
 
-Please follow the commitlint format, for example:
-  feat(module): message less than 50 characters
-  fix: message less than 50 characters
+Please follow the format: <word>: <message>
+  - <word>: one English word (letters only)
+  - colon followed by optional space
+  - <message>: any characters, up to 100 characters
+
+Examples:
+  feat: add new feature
+  fix: resolve issue
+  docs: update documentation
 `)
     process.exit(1)
   }


### PR DESCRIPTION
Close #327 

- [x] Add related unit test for compiler
- [x] Also fix kebab-case handling for other scenario

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced compiler support for non-identifier prop names (kebab-case, aria-*, data-* attributes) with proper quoting in generated code.
  * Improved alias detection in destructured props.

* **Tests**
  * Added tests for kebab-case prop handling with and without defaults.

* **Chores**
  * Updated commit message validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->