### PR TITLE
Analyze ts server error on virtual code generation

### DIFF
--- a/packages/language-service/src/virtual-code.ts
+++ b/packages/language-service/src/virtual-code.ts
@@ -211,6 +211,10 @@ export function createVueVineVirtualCode(
         // Insert `__VLS_StyleScopedClasses`
         generateStyleScopedClasses(codegenCtx)
 
+        // Insert `__VLS_elements` variable definition
+        // This variable is required by the template codegen to reference native HTML elements
+        tsCodeSegments.push(`let __VLS_elements!: __VLS_IntrinsicElements;\n`)
+
         const generatedTemplate = generateTemplate({
           ts,
           compilerOptions,

--- a/packages/language-service/tests/__snapshots__/virtual-code.spec.ts.snap
+++ b/packages/language-service/tests/__snapshots__/virtual-code.spec.ts.snap
@@ -38,6 +38,7 @@ const __VLS_components = {
 };
 
 type __VLS_VINE_StyleScopedClasses = {};
+let __VLS_elements!: __VLS_IntrinsicElements;
 __VLS_asFunctionalElement(__VLS_elements.div, __VLS_elements.div)({
 ...{ class: "border-1 border-amber-100 border-solid bg-amber-100/50 p-4" },
 });
@@ -109,6 +110,7 @@ const __VLS_components = {
 };
 
 type __VLS_VINE_StyleScopedClasses = {};
+let __VLS_elements!: __VLS_IntrinsicElements;
 __VLS_asFunctionalElement(__VLS_elements.div, __VLS_elements.div)({
 });
 type __VLS_Slots = {};
@@ -162,6 +164,7 @@ const __VLS_components = {
 };
 
 type __VLS_VINE_StyleScopedClasses = {};
+let __VLS_elements!: __VLS_IntrinsicElements;
 __VLS_asFunctionalElement(__VLS_elements.div, __VLS_elements.div)({
 ...{ class: "flex flex-col gap-4" },
 });
@@ -275,6 +278,7 @@ const __VLS_components = {
 };
 
 type __VLS_VINE_StyleScopedClasses = {};
+let __VLS_elements!: __VLS_IntrinsicElements;
 __VLS_asFunctionalElement(__VLS_elements.div, __VLS_elements.div)({
 });
 ( __VLS_ctx.foo );
@@ -356,6 +360,7 @@ const __VLS_components = {
 };
 
 type __VLS_VINE_StyleScopedClasses = {};
+let __VLS_elements!: __VLS_IntrinsicElements;
 __VLS_asFunctionalElement(__VLS_elements.div, __VLS_elements.div)({
 ...{ style: {} },
 ...{ style: ({
@@ -449,6 +454,7 @@ const __VLS_components = {
 };
 
 type __VLS_VINE_StyleScopedClasses = {};
+let __VLS_elements!: __VLS_IntrinsicElements;
 __VLS_asFunctionalElement(__VLS_elements.div, __VLS_elements.div)({
 ...{ class: (['btn', 'btn' + __VLS_ctx.type]) },
 });
@@ -521,6 +527,7 @@ const __VLS_components = {
 };
 
 type __VLS_VINE_StyleScopedClasses = {};
+let __VLS_elements!: __VLS_IntrinsicElements;
 type __VLS_Slots = {};
 type __VLS_InheritedAttrs = {};
 type __VLS_TemplateRefs = {};
@@ -595,6 +602,7 @@ const __VLS_components = {
 };
 
 type __VLS_VINE_StyleScopedClasses = {};
+let __VLS_elements!: __VLS_IntrinsicElements;
 __VLS_asFunctionalElement(__VLS_elements.div, __VLS_elements.div)({
 border: "1px solid red",
 });
@@ -688,6 +696,7 @@ const __VLS_components = {
 };
 
 type __VLS_VINE_StyleScopedClasses = {};
+let __VLS_elements!: __VLS_IntrinsicElements;
 __VLS_asFunctionalElement(__VLS_elements.div, __VLS_elements.div)({
 ...{ onClick: (...[$event]) => {
 __VLS_ctx.emits('click:comp-one', true);
@@ -763,6 +772,7 @@ const __VLS_components = {
 };
 
 type __VLS_VINE_StyleScopedClasses = {};
+let __VLS_elements!: __VLS_IntrinsicElements;
 __VLS_asFunctionalElement(__VLS_elements.div, __VLS_elements.div)({
 });
 ( __VLS_ctx.bar );
@@ -863,6 +873,7 @@ const __VLS_components = {
 };
 
 type __VLS_VINE_StyleScopedClasses = {};
+let __VLS_elements!: __VLS_IntrinsicElements;
 __VLS_asFunctionalElement(__VLS_elements.div, __VLS_elements.div)({
 ...{ onClick: (...[$event]) => {
 __VLS_ctx.count++;
@@ -961,6 +972,7 @@ const __VLS_components = {
 };
 
 type __VLS_VINE_StyleScopedClasses = {};
+let __VLS_elements!: __VLS_IntrinsicElements;
 __VLS_asFunctionalElement(__VLS_elements.div, __VLS_elements.div)({
 });
 const __VLS_0 = ({} as __VLS_WithComponent<'TargetComp', __VLS_LocalComponents, void, 'TargetComp', 'TargetComp', 'TargetComp'>).TargetComp;
@@ -1047,6 +1059,7 @@ const __VLS_components = {
 };
 
 type __VLS_VINE_StyleScopedClasses = {};
+let __VLS_elements!: __VLS_IntrinsicElements;
 __VLS_asFunctionalElement(__VLS_elements.div, __VLS_elements.div)({
 ...{ class: "user-list" },
 });
@@ -1128,6 +1141,7 @@ const __VLS_components = {
 };
 
 type __VLS_VINE_StyleScopedClasses = {};
+let __VLS_elements!: __VLS_IntrinsicElements;
 __VLS_asFunctionalElement(__VLS_elements.p, __VLS_elements.p)({
 });
 type __VLS_Slots = {};
@@ -1192,6 +1206,7 @@ const __VLS_components = {
 };
 
 type __VLS_VINE_StyleScopedClasses = {};
+let __VLS_elements!: __VLS_IntrinsicElements;
 const __VLS_0 = ((__VLS_ctx.as));
 // @ts-ignore
 const __VLS_1 = __VLS_asFunctionalComponent(__VLS_0, new __VLS_0({
@@ -1282,6 +1297,7 @@ const __VLS_components = {
 };
 
 type __VLS_VINE_StyleScopedClasses = {};
+let __VLS_elements!: __VLS_IntrinsicElements;
 __VLS_asFunctionalElement(__VLS_elements.div, __VLS_elements.div)({
 ref: "container1Ref",
 });
@@ -1359,6 +1375,7 @@ type __VLS_VINE_StyleScopedClasses = {}
  & { "container": true }
  & { "container": true }
  & { "show-msg": true };
+let __VLS_elements!: __VLS_IntrinsicElements;
 __VLS_asFunctionalElement(__VLS_elements.input)({
 ...{ class: "simple-input" },
 type: "text",
@@ -1420,6 +1437,7 @@ type __VLS_VINE_StyleScopedClasses = {}
  & { "container": true }
  & { "container": true }
  & { "show-msg": true };
+let __VLS_elements!: __VLS_IntrinsicElements;
 __VLS_asFunctionalElement(__VLS_elements.input)({
 ...{ class: "special-input" },
 type: "text",
@@ -1484,6 +1502,7 @@ type __VLS_VINE_StyleScopedClasses = {}
  & { "container": true }
  & { "container": true }
  & { "show-msg": true };
+let __VLS_elements!: __VLS_IntrinsicElements;
 __VLS_asFunctionalElement(__VLS_elements.div, __VLS_elements.div)({
 ...{ class: "container" },
 });


### PR DESCRIPTION
Add `__VLS_elements` variable definition to Vue Vine's virtual code generation to resolve TS Server errors for undefined `__VLS_elements`.

The `generateTemplate` function used by Vue Vine expects the `__VLS_elements` variable to be pre-defined by the caller. Previously, only the `__VLS_IntrinsicElements` type was available globally, but the `__VLS_elements` variable itself was missing in the component's virtual code scope, leading to "Cannot find name '__VLS_elements'" errors from TS Server during recompilation. This change explicitly defines the variable before its usage in the template's virtual code.

---
<a href="https://cursor.com/background-agent?bcId=bc-9284b4cf-b7f0-4dc0-848d-5b17ad4054f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9284b4cf-b7f0-4dc0-848d-5b17ad4054f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced template code generation to better support referencing native HTML elements in the language service, improving IDE code generation capabilities for template files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->