### PR TITLE
feat(compiler): support vineModel destructure as array pattern

### DIFF
--- a/packages/compiler/src/analyze.ts
+++ b/packages/compiler/src/analyze.ts
@@ -1044,12 +1044,38 @@ const analyzeVineModel: AnalyzeRunner = (
 
   // Traverse all `vineModel` macro calls
   for (const { macroCall, parentVarDecl } of vineModelMacroCalls) {
-    if (!parentVarDecl || !isIdentifier(parentVarDecl.id)) {
+    if (!parentVarDecl) {
       continue
     }
 
-    const varName = parentVarDecl.id.name
+    // Extract varName and modifiersVarName from declaration
+    let varName: string | undefined
+    let modifiersVarName: string | undefined
+
+    // Support Identifier: `const value = vineModel()`
+    if (isIdentifier(parentVarDecl.id)) {
+      varName = parentVarDecl.id.name
+    }
+    // Support ArrayPattern: `const [value, modifiers] = vineModel()`
+    else if (isArrayPattern(parentVarDecl.id)) {
+      const elements = parentVarDecl.id.elements
+      const firstElement = elements[0]
+      const secondElement = elements[1]
+
+      if (firstElement && isIdentifier(firstElement)) {
+        varName = firstElement.name
+      }
+      if (secondElement && isIdentifier(secondElement)) {
+        modifiersVarName = secondElement.name
+      }
+    }
+
+    if (!varName) {
+      continue
+    }
+
     const typeParameter = macroCall.typeParameters?.params[0]
+    const modifiersTypeParameter = macroCall.typeParameters?.params[1]
 
     // If the macro call has no argument,
     // - its model name is 'modelValue' as default
@@ -1058,9 +1084,11 @@ const analyzeVineModel: AnalyzeRunner = (
     if (!macroCall.arguments.length) {
       vineCompFnCtx.vineModels.modelValue = {
         varName,
+        modifiersVarName,
         modelModifiersName: DEFAULT_MODEL_MODIFIERS_NAME,
         modelOptions: null,
         typeParameter,
+        modifiersTypeParameter,
       }
       continue
     }
@@ -1075,9 +1103,11 @@ const analyzeVineModel: AnalyzeRunner = (
         const modelName = macroCall.arguments[0].value
         vineCompFnCtx.vineModels[modelName] = {
           varName,
+          modifiersVarName,
           modelModifiersName: `${modelName}Modifiers`,
           modelOptions: null,
           typeParameter,
+          modifiersTypeParameter,
         }
       }
       // If this argument is a object literal,
@@ -1087,9 +1117,11 @@ const analyzeVineModel: AnalyzeRunner = (
       else {
         vineCompFnCtx.vineModels.modelValue = {
           varName,
+          modifiersVarName,
           modelModifiersName: DEFAULT_MODEL_MODIFIERS_NAME,
           modelOptions: macroCall.arguments[0],
           typeParameter,
+          modifiersTypeParameter,
         }
       }
     }
@@ -1101,8 +1133,11 @@ const analyzeVineModel: AnalyzeRunner = (
       const modelName = (macroCall.arguments[0] as StringLiteral).value
       vineCompFnCtx.vineModels[modelName] = {
         varName,
+        modifiersVarName,
         modelModifiersName: `${modelName}Modifiers`,
         modelOptions: macroCall.arguments[1],
+        typeParameter,
+        modifiersTypeParameter,
       }
     }
   }
@@ -1112,6 +1147,10 @@ const analyzeVineModel: AnalyzeRunner = (
     vineCompFnCtx.bindings[modelName] = VineBindingTypes.PROPS
     // If `varName` is equal to `modelName`, it would be overrided to `setup-ref`
     vineCompFnCtx.bindings[modelDef.varName] = VineBindingTypes.SETUP_REF
+    // If modifiersVarName is defined, add it as a setup-ref binding
+    if (modelDef.modifiersVarName) {
+      vineCompFnCtx.bindings[modelDef.modifiersVarName] = VineBindingTypes.SETUP_REF
+    }
   }
 }
 

--- a/packages/compiler/src/transform/steps.ts
+++ b/packages/compiler/src/transform/steps.ts
@@ -250,7 +250,7 @@ export function generateVineModel(
     let modelCodeGen: string[] = []
 
     for (const [modelName, modelDef] of modelEntries) {
-      const { varName, modelOptions } = modelDef
+      const { varName, modifiersVarName, modelOptions } = modelDef
       let optionCode: string | undefined
       if (modelOptions) {
         if (modelOptions.type === 'ObjectExpression') {
@@ -279,11 +279,19 @@ export function generateVineModel(
         }
       }
 
-      modelCodeGen.push(
-        `const ${varName} = _${USE_MODEL_HELPER}(__props, '${modelName}'${
-          optionCode ? `, ${optionCode}` : ''
-        })`,
-      )
+      // Generate code based on whether modifiers are destructured
+      // - With modifiers: `const [varName, modifiersVarName] = _useModel(...)`
+      // - Without modifiers: `const varName = _useModel(...)`
+      const useModelCall = `_${USE_MODEL_HELPER}(__props, '${modelName}'${
+        optionCode ? `, ${optionCode}` : ''
+      })`
+
+      if (modifiersVarName) {
+        modelCodeGen.push(`const [${varName}, ${modifiersVarName}] = ${useModelCall}`)
+      }
+      else {
+        modelCodeGen.push(`const ${varName} = ${useModelCall}`)
+      }
     }
 
     const modelCodeGenStr = `\n${modelCodeGen.join('\n')}\n`

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -286,7 +286,12 @@ export interface VineCompFnCtx {
   /** Store `vineModel` defines */
   vineModels: Record<string, {
     varName: string
+    /** User destructured modifiers variable name, e.g. `const [value, modifiers] = vineModel()` */
+    modifiersVarName?: string
+    /** First type parameter: model value type */
     typeParameter?: TSType
+    /** Second type parameter: modifiers type, e.g. 'trim' | 'capitalize' */
+    modifiersTypeParameter?: TSType
     modelModifiersName: string
     modelOptions: Node | null
   }>

--- a/packages/compiler/tests/__snapshots__/transform.spec.ts.snap
+++ b/packages/compiler/tests/__snapshots__/transform.spec.ts.snap
@@ -2231,3 +2231,73 @@ typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
   __VUE_HMR_RUNTIME__.createRecord(MyComp.__hmrId, MyComp);
 "
 `;
+
+exports[`test transform > should transform vineModel with array destructuring for modifiers 1`] = `
+"import {
+  defineComponent as _defineComponent,
+  useCssVars as _useCssVars,
+  unref as _unref,
+  useModel as _useModel,
+  vModelText as _vModelText,
+  createElementVNode as _createElementVNode,
+  withDirectives as _withDirectives,
+  openBlock as _openBlock,
+  createElementBlock as _createElementBlock,
+  createCommentVNode as _createCommentVNode,
+} from "vue";
+
+export const MyComp = (() => {
+  const _hoisted_1 = { key: 0 };
+  const __vine = _defineComponent({
+    name: "MyComp",
+    props: {
+      modelValue: {},
+      modelModifiers: {},
+      title: { default: "" },
+      titleModifiers: {},
+    },
+    emits: ["update:modelValue", "update:title"],
+    setup(__props, { expose: __expose }) {
+      __expose();
+      const props = __props;
+
+      const [value, modifiers] = _useModel(__props, "modelValue");
+      const [title, titleMods] = _useModel(__props, "title");
+
+      return (_ctx, _cache) => {
+        return (
+          _openBlock(),
+          _createElementBlock("div", null, [
+            _withDirectives(
+              _createElementVNode(
+                "input",
+                {
+                  "onUpdate:modelValue":
+                    _cache[0] ||
+                    (_cache[0] = ($event) => (value.value = $event)),
+                },
+                null,
+                512 /* NEED_PATCH */,
+              ),
+              [[_vModelText, value.value]],
+            ),
+            modifiers.value.trim
+              ? (_openBlock(),
+                _createElementBlock("p", _hoisted_1, "Trim active"))
+              : _createCommentVNode("v-if", true),
+          ])
+        );
+      };
+    },
+  });
+
+  __vine.__vue_vine = true;
+  __vine.__hmrId = "684965d8";
+
+  return __vine;
+})();
+
+typeof __VUE_HMR_RUNTIME__ !== "undefined" &&
+  __VUE_HMR_RUNTIME__.createRecord(MyComp.__hmrId, MyComp);
+"
+`;

--- a/packages/compiler/tests/validate.spec.ts
+++ b/packages/compiler/tests/validate.spec.ts
@@ -158,7 +158,7 @@ function App(props: { foo: string }) {
           "Properties of \`vineSlots\` can only have function type annotation",
           "the declaration of \`vineModel\` macro call must be inside a variable declaration",
           "The given vineModel name must be a string literal",
-          "the declaration of macro \`vineModel\` call must be an identifier",
+          "the declaration of \`vineModel\` macro call must be an identifier or array destructuring pattern",
           "Vue Vine component function can only have one default model",
           "\`vineStyle\` can only have one string argument'",
           "\`vineEmits\` macro must have a type parameter or an array of string for event names",

--- a/packages/e2e-vite/src/app.vine.ts
+++ b/packages/e2e-vite/src/app.vine.ts
@@ -11,6 +11,7 @@ const routes = [
   { path: '/vibe', label: 'Vibe' },
   { path: '/use-defaults', label: 'Use Defaults' },
   { path: '/vine-model', label: 'Vine Model' },
+  { path: '/vine-model-modifiers', label: 'Vine Model Modifiers' },
   { path: '/vine-emits', label: 'Vine Emits' },
   { path: '/vine-validators', label: 'Vine Validators' },
   { path: '/todo-list', label: 'Todo List' },

--- a/packages/e2e-vite/src/fixtures/vine-model-modifiers.vine.ts
+++ b/packages/e2e-vite/src/fixtures/vine-model-modifiers.vine.ts
@@ -1,0 +1,142 @@
+import { ref } from 'vue'
+import '../styles/atom.css'
+
+/**
+ * Child component that uses vineModel with array destructuring
+ * to access both model ref and modifiers
+ */
+export function ModifierInput() {
+  const [value, modifiers] = vineModel<string, 'trim' | 'uppercase'>()
+
+  vineStyle.scoped(`
+    .modifier-input {
+      width: 200px;
+      background-color: #f0f0f0;
+      border: none;
+      outline: none;
+      padding: 0.5rem;
+      box-shadow: 0 0 0 1px #00000011;
+    }
+    .modifier-status {
+      font-size: 0.75rem;
+      color: #666;
+      margin-top: 0.25rem;
+    }
+  `)
+
+  function handleInput(e: Event) {
+    const target = e.target as HTMLInputElement
+    let newValue = target.value
+
+    // Apply modifiers
+    if (modifiers.trim) {
+      newValue = newValue.trim()
+    }
+    if (modifiers.uppercase) {
+      newValue = newValue.toUpperCase()
+    }
+
+    value.value = newValue
+  }
+
+  return vine`
+    <div>
+      <input class="modifier-input" type="text" :value="value" @input="handleInput" />
+      <div class="modifier-status flex flex-col">
+        <span v-if="modifiers.trim" class="has-trim">.trim</span>
+        <span v-if="modifiers.uppercase" class="has-uppercase">.uppercase</span>
+      </div>
+    </div>
+  `
+}
+
+/**
+ * Child component with named model and modifiers
+ */
+export function NamedModifierInput() {
+  const [value, modifiers] = vineModel<string, 'capitalize'>('content')
+
+  function handleInput(e: Event) {
+    const target = e.target as HTMLInputElement
+    let newValue = target.value
+
+    // Apply capitalize modifier
+    if (modifiers.capitalize && newValue.length > 0) {
+      newValue = newValue.charAt(0).toUpperCase() + newValue.slice(1)
+    }
+
+    value.value = newValue
+  }
+
+  return vine`
+    <div>
+      <input class="named-modifier-input" type="text" :value="value" @input="handleInput" />
+      <div class="modifier-status">
+        <span v-if="modifiers.capitalize" class="has-capitalize">.capitalize</span>
+      </div>
+    </div>
+  `
+}
+
+/**
+ * Test page for vineModel modifiers
+ */
+export function TestVineModelModifiers() {
+  const trimValue = ref('')
+  const uppercaseValue = ref('')
+  const trimUppercaseValue = ref('')
+  const capitalizeValue = ref('')
+
+  vineStyle.scoped(`
+    .container {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      padding: 1rem;
+    }
+    .test-case {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+    .label {
+      font-weight: 500;
+    }
+    .show-msg {
+      border-bottom: 1px solid #00000011;
+      min-width: 200px;
+      padding: 0.25rem 0;
+      color: #333;
+    }
+  `)
+
+  return vine`
+    <div class="container">
+      <h2>Test Vine Model Modifiers</h2>
+
+      <div class="test-case">
+        <div class="label">With .trim modifier:</div>
+        <ModifierInput v-model.trim="trimValue" />
+        <div class="show-msg trim-result">Value: "{{ trimValue }}"</div>
+      </div>
+
+      <div class="test-case">
+        <div class="label">With .uppercase modifier:</div>
+        <ModifierInput v-model.uppercase="uppercaseValue" />
+        <div class="show-msg uppercase-result">Value: "{{ uppercaseValue }}"</div>
+      </div>
+
+      <div class="test-case">
+        <div class="label">With .trim.uppercase modifiers:</div>
+        <ModifierInput v-model.trim.uppercase="trimUppercaseValue" />
+        <div class="show-msg trim-uppercase-result">Value: "{{ trimUppercaseValue }}"</div>
+      </div>
+
+      <div class="test-case">
+        <div class="label">Named model with .capitalize:</div>
+        <NamedModifierInput v-model:content.capitalize="capitalizeValue" />
+        <div class="show-msg capitalize-result">Value: "{{ capitalizeValue }}"</div>
+      </div>
+    </div>
+  `
+}

--- a/packages/e2e-vite/src/router.ts
+++ b/packages/e2e-vite/src/router.ts
@@ -13,6 +13,7 @@ import { TestTransformAssetUrl } from './fixtures/transform-asset-url.vine'
 import { TestUseDefaults } from './fixtures/use-defaults.vine'
 import { TestVibe } from './fixtures/vibe.vine'
 import { TestVineEmitsPage } from './fixtures/vine-emits.vine'
+import { TestVineModelModifiers } from './fixtures/vine-model-modifiers.vine'
 import { TestVineModel } from './fixtures/vine-model.vine'
 import { TestVinePropPage } from './fixtures/vine-prop.vine'
 import { TestVineSlots } from './fixtures/vine-slots.vine'
@@ -31,6 +32,7 @@ const routes = [
   { path: '/vibe', component: TestVibe },
   { path: '/use-defaults', component: TestUseDefaults },
   { path: '/vine-model', component: TestVineModel },
+  { path: '/vine-model-modifiers', component: TestVineModelModifiers },
   { path: '/vine-emits', component: TestVineEmitsPage },
   { path: '/vine-validators', component: TestVineValidatorsPage },
   { path: '/todo-list', component: TodoList },

--- a/packages/e2e-vite/tests/e2e.spec.ts
+++ b/packages/e2e-vite/tests/e2e.spec.ts
@@ -121,6 +121,31 @@ describe('basic functionality', async () => {
     },
   ))
 
+  it('should work with vine model modifiers', runTestAtPage(
+    '/vine-model-modifiers',
+    browserCtx,
+    async () => {
+      // Test trim modifier
+      await browserCtx.page?.fill('.test-case:nth-child(2) .modifier-input', '  hello  ')
+      expect(await evaluator.getTextContent('.trim-result')).toBe('Value: "hello"')
+      expect(await evaluator.getTextContent('.test-case:nth-child(2) .has-trim')).toBe('.trim')
+
+      // Test uppercase modifier
+      await browserCtx.page?.fill('.test-case:nth-child(3) .modifier-input', 'hello')
+      expect(await evaluator.getTextContent('.uppercase-result')).toBe('Value: "HELLO"')
+      expect(await evaluator.getTextContent('.test-case:nth-child(3) .has-uppercase')).toBe('.uppercase')
+
+      // Test trim + uppercase modifiers
+      await browserCtx.page?.fill('.test-case:nth-child(4) .modifier-input', '  hello  ')
+      expect(await evaluator.getTextContent('.trim-uppercase-result')).toBe('Value: "HELLO"')
+
+      // Test named model with capitalize modifier
+      await browserCtx.page?.fill('.named-modifier-input', 'hello')
+      expect(await evaluator.getTextContent('.capitalize-result')).toBe('Value: "Hello"')
+      expect(await evaluator.getTextContent('.test-case:nth-child(5) .has-capitalize')).toBe('.capitalize')
+    },
+  ))
+
   it('should report console warning by validators', async () => {
     // Collect console warnings
     const consoleWarnings: string[] = []

--- a/packages/language-service/src/codegen.ts
+++ b/packages/language-service/src/codegen.ts
@@ -186,9 +186,16 @@ export function generateModelProps(
   tabNum = 2,
 ): string {
   const { vineFileCtx } = ctx
+  const indent = ' '.repeat(tabNum + 2)
   const modelProps = `{${Object.entries(vineCompFn.vineModels).map(([modelName, model]) => {
-    const { typeParameter } = model
-    return `\n${' '.repeat(tabNum + 2)}${modelName}: ${typeParameter ? vineFileCtx.getAstNodeContent(typeParameter) : 'unknown'}`
+    const { typeParameter, modifiersTypeParameter, modelModifiersName } = model
+    const modelType = typeParameter ? vineFileCtx.getAstNodeContent(typeParameter) : 'unknown'
+    // Use specific modifier type if provided, otherwise fallback to generic string
+    const modifiersKeyType = modifiersTypeParameter
+      ? vineFileCtx.getAstNodeContent(modifiersTypeParameter)
+      : 'string'
+    // Generate both model value prop and modifiers prop
+    return `\n${indent}${modelName}?: ${modelType},\n${indent}${modelModifiersName}?: Partial<Record<${modifiersKeyType}, true | undefined>>`
   }).join(', ')
   }\n}`
   return modelProps

--- a/packages/language-service/tests/__snapshots__/virtual-code.spec.ts.snap
+++ b/packages/language-service/tests/__snapshots__/virtual-code.spec.ts.snap
@@ -1339,7 +1339,8 @@ import '../styles/atom.css'
 type __VLS_VINE_SimpleInput_props__ = {}
 export function SimpleInput(
   props: __VLS_VINE.VineComponentCommonProps & __VLS_VINE_SimpleInput_props__  & {
-    modelValue: unknown
+    modelValue?: unknown,
+    modelModifiers?: Partial<Record<string, true | undefined>>
 },
 context: {}) {
   
@@ -1403,7 +1404,8 @@ type __VLS_VINE_NamedModelInput_props__ = {}
 
 export function NamedModelInput(
   props: __VLS_VINE.VineComponentCommonProps & __VLS_VINE_NamedModelInput_props__  & {
-    special: unknown
+    special?: unknown,
+    specialModifiers?: Partial<Record<string, true | undefined>>
 },
 context: {}) {
   
@@ -1468,7 +1470,8 @@ type __VLS_VINE_AccessorModelInput_props__ = {}
 
 export function AccessorModelInput(
   props: __VLS_VINE.VineComponentCommonProps & __VLS_VINE_AccessorModelInput_props__  & {
-    modelValue: number
+    modelValue?: number,
+    modelModifiers?: Partial<Record<string, true | undefined>>
 },
 context: {}) {
   

--- a/packages/vue-vine/types/macros.d.ts
+++ b/packages/vue-vine/types/macros.d.ts
@@ -57,22 +57,25 @@ declare global {
     }>,
   ): void
 
-  function vineModel<T>(): Ref<T>
-  function vineModel<T>(modelOptions: {
+  // vineModel options type
+  interface VineModelOptions<T> {
     default?: T
     required?: boolean
     get?: (v: T) => any
     set?: (v: T) => any
-  }): Ref<T>
-  function vineModel<T>(
+  }
+
+  // vineModel return type that supports both direct usage and destructuring
+  type VineModelReturn<T, M extends string = string> = Ref<T> & [Ref<T>, Record<M, true | undefined>]
+
+  function vineModel<T, M extends string = string>(): VineModelReturn<T, M>
+  function vineModel<T, M extends string = string>(
+    modelOptions: VineModelOptions<T>
+  ): VineModelReturn<T, M>
+  function vineModel<T, M extends string = string>(
     modelName: string,
-    modelOptions?: {
-      default?: T
-      required?: boolean
-      get?: (v: T) => any
-      set?: (v: T) => any
-    }
-  ): Ref<T>
+    modelOptions?: VineModelOptions<T>
+  ): VineModelReturn<T, M>
 
   function vineCustomElement(): void
 


### PR DESCRIPTION
Link with #340 and continue the missing part of @rzzf 's changes

Fix issues that mentioned in https://github.com/vue-vine/vue-vine/pull/340#issuecomment-3568710565

- [x] Add compiler unit tests
- [x] Add E2E test fixtures 
- [x] Finish validation of language service in IDE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for destructuring `vineModel` to capture modifiers alongside the model value: `const [value, modifiers] = vineModel<T, M>()`. Enables reactive tracking of v-model modifiers like `.trim`, `.uppercase`, and custom modifier implementations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->