### PR TITLE
Remove vineLynxMainThread macro and logic

### DIFF
--- a/packages/compiler/src/babel-helpers/ast.ts
+++ b/packages/compiler/src/babel-helpers/ast.ts
@@ -219,7 +219,6 @@ export const isVineStyle: IsVineMacroOf = isVineMacroOf([
 ])
 export const isVineCustomElement: IsVineMacroOf = isVineMacroOf('vineCustomElement')
 export const isVineValidators: IsVineMacroOf = isVineMacroOf('vineValidators')
-export const isVineLynxRunOnMainThread: IsVineMacroOf = isVineMacroOf('vineLynxRunOnMainThread')
 export function isUseTemplateRefCall(node: Node): node is CallExpression {
   return isCallOf(node, 'useTemplateRef')
 }

--- a/packages/compiler/src/constants.ts
+++ b/packages/compiler/src/constants.ts
@@ -12,8 +12,6 @@ export const DEFAULT_MODEL_NAME = 'modelValue'
 export const DEFAULT_MODEL_MODIFIERS_NAME = 'modelModifiers'
 export const WITH_ASYNC_CONTEXT_HELPER = 'withAsyncContext'
 
-// Lynx platform helpers
-export const CREATE_LYNX_MAIN_THREAD_FN_HELPER = 'createLynxMainThreadFn'
 export const CREATE_PROPS_REST_PROXY_HELPER = 'createPropsRestProxy'
 
 /**
@@ -37,7 +35,6 @@ export const DECLARATION_MACROS = [
   'vineEmits',
   'vineSlots',
   'vineModel',
-  'vineLynxRunOnMainThread',
 ] as const
 export const VINE_MACROS: Array<(typeof DECLARATION_MACROS)[number] | (typeof BARE_CALL_MACROS)[number]> = [
   ...DECLARATION_MACROS,

--- a/packages/compiler/src/transform.ts
+++ b/packages/compiler/src/transform.ts
@@ -15,7 +15,6 @@ import {
   generateBasicComponentOptions,
   generateDefineComponentWrapper,
   generateEmitsOptions,
-  generateLynxRunOnMainThread,
   generatePropsDeclaration,
   generatePropsDestructure,
   generatePropsOptions,
@@ -180,7 +179,6 @@ export function transformFile(
     }
 
     onlyRemainFunctionBody(transformCtx, fnTransformCtx)
-    generateLynxRunOnMainThread(transformCtx, fnTransformCtx)
     removeStatementsContainsMacro(transformCtx, fnTransformCtx)
     generateVineSlots(transformCtx, fnTransformCtx)
     generateVineModel(transformCtx, fnTransformCtx)

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -301,12 +301,6 @@ export interface VineCompFnCtx {
   cssBindings: Record<string, string | null>
   externalStyleFilePaths: string[]
 
-  /**
-   * Lynx main thread code blocks within this component
-   * @see VineLynxRunOnMainThreadMeta
-   */
-  lynxMainThreadBlocks: VineLynxRunOnMainThreadMeta[]
-
   getPropsTypeRecordStr: (options?: {
     joinStr?: string
     isNeedLinkedCodeTag?: boolean
@@ -320,23 +314,6 @@ export interface VineDiagnostic {
   location: SourceLocation | null | undefined
   vineCompFnCtx?: VineCompFnCtx
   rawVueTemplateLocation?: VueSourceLocation | null
-}
-
-// ===================== Lynx Platform Support =====================
-
-/**
- * Metadata for vineLynxRunOnMainThread macro call
- *
- * This macro allows users to define code blocks that should be executed
- * on Lynx's main thread (UI thread) rather than the background thread.
- */
-export interface VineLynxRunOnMainThreadMeta {
-  /** The macro call AST node */
-  macroCall: CallExpression
-  /** The function body (arrow function or function expression) */
-  fnBody: ArrowFunctionExpression | FunctionExpression
-  /** Source code range [start, end] */
-  range: [number, number]
 }
 
 export interface VineFnPickedInfo {

--- a/packages/vue-vine/types/macros.d.ts
+++ b/packages/vue-vine/types/macros.d.ts
@@ -79,40 +79,6 @@ declare global {
 
   function vineCustomElement(): void
 
-  /**
-   * Define a code block that should be executed on Lynx's main thread (UI thread).
-   *
-   * This macro is used for Lynx platform support, allowing developers to write
-   * code that needs to run on the main thread for performance-critical UI operations.
-   *
-   * Note: The function passed to this macro should be **synchronous** (not async),
-   * as PrimJS main thread requires fast execution for UI responsiveness.
-   * If you need to get a return value, the call will be async (returns Promise).
-   *
-   * @param fn - A synchronous function containing the main thread code
-   *
-   * @example
-   * ```ts
-   * function App() {
-   *   // Simple usage without return value
-   *   vineLynxRunOnMainThread(() => {
-   *     // This code will be extracted and run on Lynx main thread
-   *     // You can use Lynx Element PAPI here
-   *     __SetClasses(el, 'active')
-   *   })
-   *
-   *   // With return value (async call)
-   *   const getValue = vineLynxRunOnMainThread(() => {
-   *     return someMainThreadValue
-   *   })
-   *   // Call: const result = await getValue()
-   *
-   *   return vine`<view>...</view>`
-   * }
-   * ```
-   */
-  function vineLynxRunOnMainThread<R = void>(fn: () => R): () => Promise<R>
-
   const vineStyle: VineStyleMacro
 
   const vine: (template: TemplateStringsArray) => VueVineComponent

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,10 +91,6 @@ catalogs:
     ts-morph:
       specifier: ^26.0.0
       version: 26.0.0
-  default:
-    '@lynx-js/runtime-wrapper-webpack-plugin':
-      specifier: ^0.1.3
-      version: 0.1.3
   docs:
     oxc-minify:
       specifier: ^0.82.2
@@ -168,6 +164,9 @@ catalogs:
     '@lynx-js/rspeedy':
       specifier: ^0.12.0
       version: 0.12.0
+    '@lynx-js/runtime-wrapper-webpack-plugin':
+      specifier: ^0.1.3
+      version: 0.1.3
     '@lynx-js/template-webpack-plugin':
       specifier: ^0.9.1
       version: 0.9.1
@@ -1052,7 +1051,7 @@ importers:
   packages/rspeedy-plugin-vue-vine:
     dependencies:
       '@lynx-js/runtime-wrapper-webpack-plugin':
-        specifier: 'catalog:'
+        specifier: catalog:lynx
         version: 0.1.3
       '@lynx-js/template-webpack-plugin':
         specifier: catalog:lynx
@@ -1066,10 +1065,13 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: catalog:lynx
-        version: 0.12.0(@rspack/core@1.6.4(@swc/helpers@0.5.17))(esbuild@0.25.11)(typescript@5.8.3)(webpack@5.103.0(esbuild@0.25.11))
+        version: 0.12.0(@rspack/core@1.5.8(@swc/helpers@0.5.17))(esbuild@0.25.11)(typescript@5.8.3)(webpack@5.103.0(esbuild@0.25.11))
       '@rsbuild/core':
         specifier: catalog:rsstack
         version: 1.5.17
+      '@rspack/core':
+        specifier: catalog:rsstack
+        version: 1.5.8(@swc/helpers@0.5.17)
 
   packages/runtime-lynx:
     dependencies:
@@ -11290,6 +11292,32 @@ snapshots:
 
   '@lynx-js/qrcode-rsbuild-plugin@0.4.3': {}
 
+  '@lynx-js/rspeedy@0.12.0(@rspack/core@1.5.8(@swc/helpers@0.5.17))(esbuild@0.25.11)(typescript@5.8.3)(webpack@5.103.0(esbuild@0.25.11))':
+    dependencies:
+      '@lynx-js/cache-events-webpack-plugin': 0.0.2
+      '@lynx-js/chunk-loading-webpack-plugin': 0.3.3
+      '@lynx-js/web-rsbuild-server-middleware': 0.18.4
+      '@lynx-js/webpack-dev-transport': 0.2.0
+      '@lynx-js/websocket': 0.0.4
+      '@rsbuild/core': 1.6.7
+      '@rsbuild/plugin-css-minimizer': 1.0.3(@rsbuild/core@1.6.7)(esbuild@0.25.11)(webpack@5.103.0(esbuild@0.25.11))
+      '@rsdoctor/rspack-plugin': 1.2.3(@rsbuild/core@1.6.7)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/css'
+      - bufferutil
+      - clean-css
+      - csso
+      - debug
+      - esbuild
+      - lightningcss
+      - supports-color
+      - utf-8-validate
+      - webpack
+
   '@lynx-js/rspeedy@0.12.0(@rspack/core@1.6.4(@swc/helpers@0.5.17))(esbuild@0.25.11)(typescript@5.8.3)(webpack@5.103.0(esbuild@0.25.11))':
     dependencies:
       '@lynx-js/cache-events-webpack-plugin': 0.0.2
@@ -12504,6 +12532,31 @@ snapshots:
 
   '@rsdoctor/client@1.2.3': {}
 
+  '@rsdoctor/core@1.2.3(@rsbuild/core@1.6.7)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))':
+    dependencies:
+      '@rsbuild/plugin-check-syntax': 1.3.0(@rsbuild/core@1.6.7)
+      '@rsdoctor/graph': 1.2.3(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))
+      '@rsdoctor/sdk': 1.2.3(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))
+      '@rsdoctor/types': 1.2.3(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))
+      '@rsdoctor/utils': 1.2.3(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))
+      axios: 1.13.2
+      browserslist-load-config: 1.0.1
+      enhanced-resolve: 5.12.0
+      filesize: 10.1.6
+      fs-extra: 11.3.2
+      lodash: 4.17.21
+      path-browserify: 1.0.1
+      semver: 7.7.2
+      source-map: 0.7.6
+    transitivePeerDependencies:
+      - '@rsbuild/core'
+      - '@rspack/core'
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+      - webpack
+
   '@rsdoctor/core@1.2.3(@rsbuild/core@1.6.7)(@rspack/core@1.6.4(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))':
     dependencies:
       '@rsbuild/plugin-check-syntax': 1.3.0(@rsbuild/core@1.6.7)
@@ -12529,6 +12582,17 @@ snapshots:
       - utf-8-validate
       - webpack
 
+  '@rsdoctor/graph@1.2.3(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))':
+    dependencies:
+      '@rsdoctor/types': 1.2.3(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))
+      '@rsdoctor/utils': 1.2.3(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))
+      lodash.unionby: 4.8.0
+      source-map: 0.7.6
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - supports-color
+      - webpack
+
   '@rsdoctor/graph@1.2.3(@rspack/core@1.6.4(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))':
     dependencies:
       '@rsdoctor/types': 1.2.3(@rspack/core@1.6.4(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))
@@ -12538,6 +12602,24 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
+      - webpack
+
+  '@rsdoctor/rspack-plugin@1.2.3(@rsbuild/core@1.6.7)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))':
+    dependencies:
+      '@rsdoctor/core': 1.2.3(@rsbuild/core@1.6.7)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))
+      '@rsdoctor/graph': 1.2.3(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))
+      '@rsdoctor/sdk': 1.2.3(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))
+      '@rsdoctor/types': 1.2.3(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))
+      '@rsdoctor/utils': 1.2.3(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))
+      lodash: 4.17.21
+    optionalDependencies:
+      '@rspack/core': 1.5.8(@swc/helpers@0.5.17)
+    transitivePeerDependencies:
+      - '@rsbuild/core'
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
       - webpack
 
   '@rsdoctor/rspack-plugin@1.2.3(@rsbuild/core@1.6.7)(@rspack/core@1.6.4(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))':
@@ -12554,6 +12636,30 @@ snapshots:
       - '@rsbuild/core'
       - bufferutil
       - debug
+      - supports-color
+      - utf-8-validate
+      - webpack
+
+  '@rsdoctor/sdk@1.2.3(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))':
+    dependencies:
+      '@rsdoctor/client': 1.2.3
+      '@rsdoctor/graph': 1.2.3(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))
+      '@rsdoctor/types': 1.2.3(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))
+      '@rsdoctor/utils': 1.2.3(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))
+      '@types/fs-extra': 11.0.4
+      body-parser: 1.20.3
+      cors: 2.8.5
+      dayjs: 1.11.13
+      fs-extra: 11.3.2
+      json-cycle: 1.5.0
+      open: 8.4.2
+      sirv: 2.0.4
+      socket.io: 4.8.1
+      source-map: 0.7.6
+      tapable: 2.2.2
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - bufferutil
       - supports-color
       - utf-8-validate
       - webpack
@@ -12582,6 +12688,16 @@ snapshots:
       - utf-8-validate
       - webpack
 
+  '@rsdoctor/types@1.2.3(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/estree': 1.0.5
+      '@types/tapable': 2.2.7
+      source-map: 0.7.6
+    optionalDependencies:
+      '@rspack/core': 1.5.8(@swc/helpers@0.5.17)
+      webpack: 5.103.0(esbuild@0.25.11)
+
   '@rsdoctor/types@1.2.3(@rspack/core@1.6.4(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))':
     dependencies:
       '@types/connect': 3.4.38
@@ -12591,6 +12707,30 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 1.6.4(@swc/helpers@0.5.17)
       webpack: 5.103.0(esbuild@0.25.11)
+
+  '@rsdoctor/utils@1.2.3(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@rsdoctor/types': 1.2.3(@rspack/core@1.5.8(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))
+      '@types/estree': 1.0.5
+      acorn: 8.15.0
+      acorn-import-attributes: 1.9.5(acorn@8.15.0)
+      acorn-walk: 8.3.4
+      connect: 3.7.0
+      deep-eql: 4.1.4
+      envinfo: 7.14.0
+      filesize: 10.1.6
+      fs-extra: 11.3.2
+      get-port: 5.1.1
+      json-stream-stringify: 3.0.1
+      lines-and-columns: 2.0.4
+      picocolors: 1.1.1
+      rslog: 1.3.2
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - supports-color
+      - webpack
 
   '@rsdoctor/utils@1.2.3(@rspack/core@1.6.4(@swc/helpers@0.5.17))(webpack@5.103.0(esbuild@0.25.11))':
     dependencies:


### PR DESCRIPTION
Remove `vineLynxMainThread` macro and all associated compiler logic because a new function directive approach will be adopted in the future.

---
<a href="https://cursor.com/background-agent?bcId=bc-95bd953c-2c5f-405d-a6b0-e9d50b2c11fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-95bd953c-2c5f-405d-a6b0-e9d50b2c11fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

