### PR TITLE
fix(lang-service): missing & in concating internal virtual code types

### DIFF
--- a/packages/e2e-vite/src/fixtures/props-with-emits.vine.ts
+++ b/packages/e2e-vite/src/fixtures/props-with-emits.vine.ts
@@ -1,0 +1,30 @@
+// Test case for props formal parameter with type annotation and emits
+export function TestPropsWithEmits(props: {
+  name: string
+  age?: number
+}) {
+  const emits = vineEmits(['submit', 'cancel'])
+
+  return vine`
+    <div>
+      <p>Name: {{ name }}</p>
+      <p v-if="age">Age: {{ age }}</p>
+      <button @click="emits('submit', name)">Submit</button>
+      <button @click="emits('cancel')">Cancel</button>
+    </div>
+  `
+}
+
+export function TestParent() {
+  const handleSubmit = (evt: SubmitEvent) => {
+    console.log('Submitted:', evt)
+  }
+
+  const handleCancel = () => {
+    console.log('Cancelled')
+  }
+
+  return vine`
+    <TestPropsWithEmits name="John" :age="30" @submit="handleSubmit" @cancel="handleCancel" />
+  `
+}

--- a/packages/language-service/src/codegen.ts
+++ b/packages/language-service/src/codegen.ts
@@ -315,6 +315,13 @@ export class CodeGenerator {
         yield* this.scriptUntil(formalParamTypeNode.start!)
         yield `__VLS_VINE.VineComponentCommonProps & `
         yield* this.scriptUntil(formalParamTypeNode.end!)
+        // For param type, we don't add props to typeParts here because
+        // the props type is already yielded above for linked code tags.
+        // We only need to collect emits and models for the return string.
+      }
+      else {
+        // No user props, but we still need base props in the return string
+        typeParts.push('__VLS_VINE.VineComponentCommonProps')
       }
     }
 
@@ -336,6 +343,11 @@ export class CodeGenerator {
     if (Object.keys(vineCompFn.vineModels).length > 0) {
       const modelPropsStr = `__VLS_VINE_${vineCompFn.fnName}_models__`
       typeParts.push(modelPropsStr)
+    }
+
+    // For param type with user props, we need to prepend ' & ' to connect with the yielded props type
+    if (type === 'param' && vineCompFn.propsFormalParamType && typeParts.length > 0) {
+      return ` & ${typeParts.filter(Boolean).join(' & ')},`
     }
 
     return `${typeParts.filter(Boolean).join(' & ')},`

--- a/packages/language-service/tests/__snapshots__/virtual-code.spec.ts.snap
+++ b/packages/language-service/tests/__snapshots__/virtual-code.spec.ts.snap
@@ -1254,6 +1254,182 @@ const __VLS_VINE_ComponentsReferenceMap = {
 const __VLS_IntrinsicElements = {} as __VLS_IntrinsicElements;"
 `;
 
+exports[`verify Volar virtual code snapshots > props-with-emits.vine.ts - props formal parameter with type annotation and emits 1`] = `
+"/// <reference types="../../../../node_modules/.vue-global-types/vine_vue_99_true.d.ts" />
+import * as __VLS_VINE from 'vue-vine/internals';
+// Test case for props formal parameter with type annotation and emits
+
+type __VLS_VINE_TestPropsWithEmits_emits__ = __VLS_NormalizeEmits<__VLS_VINE.VueDefineEmits<{'submit': any, 'cancel': any}>>;
+export function TestPropsWithEmits(props: __VLS_VINE.VineComponentCommonProps & {
+  name: string
+  age?: number
+} & {    onSubmit?: __VLS_VINE_TestPropsWithEmits_emits__['submit'],     onCancel?: __VLS_VINE_TestPropsWithEmits_emits__['cancel']
+},context: {}) {
+  
+type TestPropsWithEmits_Props = Parameters<typeof TestPropsWithEmits>[0];
+
+const emits = vineEmits(['submit', 'cancel'])
+
+  
+// --- Start: Template virtual code
+
+const __VLS_ctx = __VLS_VINE.CreateVineVLSCtx({
+  /* __LINKED_CODE_LEFT__#5 */emits: /* __LINKED_CODE_RIGHT__#5 */emits,
+  /* __LINKED_CODE_LEFT__#18 */TestPropsWithEmits: /* __LINKED_CODE_RIGHT__#18 */TestPropsWithEmits,
+  /* __LINKED_CODE_LEFT__#10 */TestParent: /* __LINKED_CODE_RIGHT__#10 */TestParent,
+  ...props,
+});
+const __VLS_localComponents = __VLS_ctx;
+type __VLS_LocalComponents = __VLS_VINE.OmitAny<typeof __VLS_localComponents>;
+type __VLS_LocalDirectives = __VLS_VINE.OmitAny<typeof __VLS_ctx>;
+let __VLS_directives!: __VLS_LocalDirectives & __VLS_GlobalDirectives;
+const __VLS_components = {
+  ...{} as __VLS_GlobalComponents,
+  ...__VLS_localComponents as unknown as __VLS_LocalComponents,
+};
+
+type __VLS_VINE_StyleScopedClasses = {};
+let __VLS_elements!: __VLS_IntrinsicElements;
+__VLS_asFunctionalElement(__VLS_elements.div, __VLS_elements.div)({
+});
+__VLS_asFunctionalElement(__VLS_elements.p, __VLS_elements.p)({
+});
+( __VLS_ctx.name );
+// @ts-ignore
+[name,];
+if (__VLS_ctx.age) {
+// @ts-ignore
+[age,];
+__VLS_asFunctionalElement(__VLS_elements.p, __VLS_elements.p)({
+});
+( __VLS_ctx.age );
+// @ts-ignore
+[age,];
+}
+__VLS_asFunctionalElement(__VLS_elements.button, __VLS_elements.button)({
+...{ onClick: (...[$event]) => {
+__VLS_ctx.emits('submit', __VLS_ctx.name);
+// @ts-ignore
+[name,emits,];
+}},
+});
+__VLS_asFunctionalElement(__VLS_elements.button, __VLS_elements.button)({
+...{ onClick: (...[$event]) => {
+__VLS_ctx.emits('cancel');
+// @ts-ignore
+[emits,];
+}},
+});
+type __VLS_Slots = {};
+type __VLS_InheritedAttrs = {};
+type __VLS_TemplateRefs = {};
+type __VLS_RootEl = 
+| __VLS_NativeElements['div'];
+var __VLS_dollars!: {
+$slots: __VLS_Slots;
+$attrs: import('vue').ComponentPublicInstance['$attrs'] & Partial<__VLS_InheritedAttrs>;
+$refs: __VLS_TemplateRefs;
+$el: __VLS_RootEl;
+} & { [K in keyof import('vue').ComponentPublicInstance]: unknown };
+
+// --- End: Template virtual code
+
+return vine\`\` as any as __VLS_VINE.VueVineComponent;
+
+}
+type __VLS_VINE_TestParent_props__ = {}
+
+
+export function TestParent(
+  props: __VLS_VINE.VineComponentCommonProps & __VLS_VINE_TestParent_props__,
+context: {}) {
+  
+type TestParent_Props = Parameters<typeof TestParent>[0];
+
+const handleSubmit = (evt: SubmitEvent) => {
+    console.log('Submitted:', evt)
+  }
+
+  const handleCancel = () => {
+    console.log('Cancelled')
+  }
+
+  
+// --- Start: Template virtual code
+
+const __VLS_ctx = __VLS_VINE.CreateVineVLSCtx({
+  /* __LINKED_CODE_LEFT__#18 */TestPropsWithEmits: /* __LINKED_CODE_RIGHT__#18 */TestPropsWithEmits,
+  /* __LINKED_CODE_LEFT__#12 */handleSubmit: /* __LINKED_CODE_RIGHT__#12 */handleSubmit,
+  /* __LINKED_CODE_LEFT__#12 */handleCancel: /* __LINKED_CODE_RIGHT__#12 */handleCancel,
+  /* __LINKED_CODE_LEFT__#10 */TestParent: /* __LINKED_CODE_RIGHT__#10 */TestParent,
+  /* No props formal params */
+});
+const __VLS_localComponents = __VLS_ctx;
+type __VLS_LocalComponents = __VLS_VINE.OmitAny<typeof __VLS_localComponents>;
+type __VLS_LocalDirectives = __VLS_VINE.OmitAny<typeof __VLS_ctx>;
+let __VLS_directives!: __VLS_LocalDirectives & __VLS_GlobalDirectives;
+const __VLS_components = {
+  ...{} as __VLS_GlobalComponents,
+  ...__VLS_localComponents as unknown as __VLS_LocalComponents,
+};
+
+type __VLS_VINE_StyleScopedClasses = {};
+let __VLS_elements!: __VLS_IntrinsicElements;
+const __VLS_0 = ({} as __VLS_WithComponent<'TestPropsWithEmits', __VLS_LocalComponents, void, 'TestPropsWithEmits', 'TestPropsWithEmits', 'TestPropsWithEmits'>).TestPropsWithEmits;
+/** @type {[typeof __VLS_components.TestPropsWithEmits, ]} */;
+// @ts-ignore
+TestPropsWithEmits;
+// @ts-ignore
+const __VLS_1 = __VLS_asFunctionalComponent(__VLS_0, new __VLS_0({
+...{ 'onSubmit': {} as any },
+...{ 'onCancel': {} as any },
+name: "John",
+age: (30),
+}));
+const __VLS_2 = __VLS_1({
+...{ 'onSubmit': {} as any },
+...{ 'onCancel': {} as any },
+name: "John",
+age: (30),
+}, ...__VLS_functionalComponentArgsRest(__VLS_1));
+let __VLS_4!: __VLS_ResolveEmits<typeof __VLS_0, typeof __VLS_3.emit>;
+let __VLS_5!: __VLS_FunctionalComponentProps<typeof __VLS_1, typeof __VLS_2>;
+const __VLS_6: __VLS_NormalizeComponentEvent<typeof __VLS_5, typeof __VLS_4, 'onSubmit', 'submit', 'submit'> = (
+{ submit: {} as any } as typeof __VLS_4,
+{ onSubmit: (__VLS_ctx.handleSubmit)});
+const __VLS_7: __VLS_NormalizeComponentEvent<typeof __VLS_5, typeof __VLS_4, 'onCancel', 'cancel', 'cancel'> = (
+{ cancel: {} as any } as typeof __VLS_4,
+{ onCancel: (__VLS_ctx.handleCancel)});
+var __VLS_8 = {} as (Parameters<NonNullable<typeof __VLS_3['expose']>>[0] | null);
+// @ts-ignore
+[handleSubmit,handleCancel,];
+var __VLS_3!: __VLS_FunctionalComponentCtx<typeof __VLS_0, typeof __VLS_2>;
+type __VLS_Slots = {};
+type __VLS_InheritedAttrs = {};
+type __VLS_TemplateRefs = {};
+type __VLS_RootEl = 
+| NonNullable<typeof __VLS_8>['$el'];
+var __VLS_dollars!: {
+$slots: __VLS_Slots;
+$attrs: import('vue').ComponentPublicInstance['$attrs'] & Partial<__VLS_InheritedAttrs>;
+$refs: __VLS_TemplateRefs;
+$el: __VLS_RootEl;
+} & { [K in keyof import('vue').ComponentPublicInstance]: unknown };
+
+// --- End: Template virtual code
+
+return vine\`\` as any as __VLS_VINE.VueVineComponent;
+
+}
+
+const __VLS_VINE_ComponentsReferenceMap = {
+  'TestPropsWithEmits': TestPropsWithEmits,
+  'TestParent': TestParent
+};
+
+const __VLS_IntrinsicElements = {} as __VLS_IntrinsicElements;"
+`;
+
 exports[`verify Volar virtual code snapshots > use-template-ref-virtual-code.vine.ts 1`] = `
 "/// <reference types="../../../../node_modules/.vue-global-types/vine_vue_99_true.d.ts" />
 import * as __VLS_VINE from 'vue-vine/internals';

--- a/packages/language-service/tests/virtual-code.spec.ts
+++ b/packages/language-service/tests/virtual-code.spec.ts
@@ -37,4 +37,7 @@ describe('verify Volar virtual code snapshots', () => {
   it('custom-elements.vine.ts', () => {
     testSnapshotForFile('../../e2e-vite/src/fixtures/custom-elements.vine.ts')
   })
+  it('props-with-emits.vine.ts - props formal parameter with type annotation and emits', () => {
+    testSnapshotForFile('../../e2e-vite/src/fixtures/props-with-emits.vine.ts')
+  })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for component props and event handling scenarios.

* **Chores**
  * Enhanced code generation logic for component props type handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->